### PR TITLE
Disable cache for scheduled workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/cache@v3
-        if: ! github.event.schedule
+        if: github.event_name != 'schedule'
         with:
           path: |
             ~/.cargo/bin/


### PR DESCRIPTION
It apparently doesn't reuse the one from the main branch. It is also infrequent enough (weekly) that caching is more detrimental (it takes time to save the cache) than useful (it almost never restores a cache).