### PR TITLE
Rename println to avoid conflicts with std

### DIFF
--- a/book/src/applet/prelude/button1.rs
+++ b/book/src/applet/prelude/button1.rs
@@ -33,7 +33,7 @@ fn main() {
     //} ANCHOR_END: loop
         //{ ANCHOR: handler
         // We define a button handler printing the new state.
-        let handler = move |state| println!("Button {index} has been {state:?}.");
+        let handler = move |state| debug!("Button {index} has been {state:?}.");
         //} ANCHOR_END: handler
 
         //{ ANCHOR: listener

--- a/crates/prelude/CHANGELOG.md
+++ b/crates/prelude/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+### Minor
+
+- Add `debug!` macro as a replacement for `println!`
+- Deprecate `println!` macro in favor of `debug!`
+
 ## 0.1.1
 
 ### Minor

--- a/crates/prelude/src/debug.rs
+++ b/crates/prelude/src/debug.rs
@@ -32,11 +32,21 @@ pub fn println(msg: &str) {
 // We use an environment variable to avoid asking applets to forward features.
 pub const ENABLED: bool = option_env!("FIRWASM_DEBUG").is_some();
 
+#[deprecated(since = "0.1.2", note = "use debug! instead")]
+#[macro_export]
+macro_rules! println {
+    ($($args:tt)*) => {
+        if $crate::debug::ENABLED {
+            $crate::debug::println(&alloc::format!($($args)*));
+        }
+    };
+}
+
 /// Prints a line to the debug output.
 ///
 /// This is similar to the standard `std::println!()` macro and supports the same formatting.
 #[macro_export]
-macro_rules! println {
+macro_rules! debug {
     ($($args:tt)*) => {
         if $crate::debug::ENABLED {
             $crate::debug::println(&alloc::format!($($args)*));

--- a/crates/prelude/src/lib.rs
+++ b/crates/prelude/src/lib.rs
@@ -46,8 +46,6 @@ pub mod scheduling;
 pub mod store;
 pub mod usb;
 
-pub use debug::println;
-
 /// Defines the entry point of an applet.
 ///
 /// This macro brings all items of this crate into scope and makes sure `main()` is the entry point
@@ -92,6 +90,6 @@ macro_rules! applet {
 #[cfg(not(feature = "test"))]
 #[panic_handler]
 fn handle_panic(info: &core::panic::PanicInfo) -> ! {
-    println!("{}", info);
+    debug!("{}", info);
     core::arch::wasm32::unreachable()
 }

--- a/examples/rust/button/src/lib.rs
+++ b/examples/rust/button/src/lib.rs
@@ -27,7 +27,7 @@ fn main() {
     // For each button on the board.
     for index in 0 .. count {
         // We define a button handler printing the new state.
-        let handler = move |state| println!("Button {index} has been {state:?}.");
+        let handler = move |state| debug!("Button {index} has been {state:?}.");
 
         // We start listening for state changes with the handler.
         let listener = button::Listener::new(index, handler);

--- a/examples/rust/hello/src/lib.rs
+++ b/examples/rust/hello/src/lib.rs
@@ -16,5 +16,5 @@
 wasefire::applet!();
 
 fn main() {
-    println!("hello world");
+    debug!("hello world");
 }

--- a/examples/rust/timer_test/src/lib.rs
+++ b/examples/rust/timer_test/src/lib.rs
@@ -27,85 +27,85 @@ fn main() {
     test_oneshot_cancel();
     test_periodic_cancel();
     test_cancel_callback();
-    println!("End of tests.");
+    debug!("End of tests.");
 }
 
 fn test_periodic(explicit_stop: bool) {
-    println!("test_periodic({}): This should count seconds from 1 to 5.", explicit_stop);
+    debug!("test_periodic({}): This should count seconds from 1 to 5.", explicit_stop);
     let i = Rc::new(Cell::new(0));
     let timer = clock::Timer::new({
         let i = i.clone();
         move || {
             let j = i.get();
-            println!("- {}", j + 1);
+            debug!("- {}", j + 1);
             i.set(j + 1);
         }
     });
-    println!("+ start timer");
+    debug!("+ start timer");
     timer.start_ms(clock::Periodic, 1000);
     while i.get() < 5 {
         scheduling::wait_for_callback();
     }
     if explicit_stop {
-        println!("+ stop timer");
+        debug!("+ stop timer");
         timer.stop();
     }
     assert_eq!(i.get(), 5);
 }
 
 fn test_oneshot() {
-    println!("test_oneshot(): This should print a message after 1 second.");
+    debug!("test_oneshot(): This should print a message after 1 second.");
     let done = Rc::new(Cell::new(false));
     let timer = clock::Timer::new({
         let done = done.clone();
         move || {
-            println!("- done");
+            debug!("- done");
             done.set(true);
         }
     });
-    println!("+ start timer");
+    debug!("+ start timer");
     timer.start_ms(clock::Oneshot, 1000);
     scheduling::wait_until(|| done.get());
     assert!(done.get());
 }
 
 fn test_oneshot_cancel() {
-    println!("test_oneshot_cancel(): This should cancel a 5 seconds timer after 1 second.");
+    debug!("test_oneshot_cancel(): This should cancel a 5 seconds timer after 1 second.");
     let done = Rc::new(Cell::new(false));
     let timer = clock::Timer::new({
         let done = done.clone();
         move || done.set(true)
     });
-    println!("+ start timer");
+    debug!("+ start timer");
     timer.start_ms(clock::Oneshot, 5000);
-    println!("+ sleep");
+    debug!("+ sleep");
     clock::sleep_ms(1000);
-    println!("+ stop timer");
+    debug!("+ stop timer");
     timer.stop();
     assert!(!done.get());
 }
 
 fn test_periodic_cancel() {
-    println!("test_periodic_cancel(): This should cancel a periodic timer after 3.5 seconds.");
+    debug!("test_periodic_cancel(): This should cancel a periodic timer after 3.5 seconds.");
     let i = Rc::new(Cell::new(0));
     let timer = clock::Timer::new({
         let i = i.clone();
         move || {
             let j = i.get();
-            println!("- {}", j + 1);
+            debug!("- {}", j + 1);
             i.set(j + 1);
         }
     });
-    println!("+ start timer");
+    debug!("+ start timer");
     timer.start_ms(clock::Periodic, 1000);
     clock::sleep_ms(3500);
-    println!("+ stop timer");
+    debug!("+ stop timer");
     timer.stop();
     assert_eq!(i.get(), 3);
 }
 
 fn test_cancel_callback() {
-    println!("test_cancel_callback(): This should cancel a pending callback.");
+    debug!("test_cancel_callback(): This should cancel a pending callback.");
     let has_run = Rc::new(Cell::new(false));
     let first = clock::Timer::new({
         let has_run = has_run.clone();
@@ -113,7 +113,7 @@ fn test_cancel_callback() {
     });
     first.start_ms(clock::Oneshot, 1000);
     while scheduling::num_pending_callbacks() == 0 {}
-    println!("- callback scheduled");
+    debug!("- callback scheduled");
     drop(first);
     assert_eq!(scheduling::num_pending_callbacks(), 0);
     assert!(!has_run.get());


### PR DESCRIPTION
This is useful to avoid conflicts with std because tests may use std.