### PR TITLE
Use *const u8 for opaque data

### DIFF
--- a/crates/api-desc/CHANGELOG.md
+++ b/crates/api-desc/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.2.0-git
+
+### Major
+
+- Use `*const u8` instead of `*mut u8` for opaque data
+
 ## 0.1.3
 
 ### Minor

--- a/crates/api-desc/Cargo.lock
+++ b/crates/api-desc/Cargo.lock
@@ -146,7 +146,7 @@ checksum = "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0"
 
 [[package]]
 name = "wasefire-applet-api-desc"
-version = "0.1.3"
+version = "0.2.0-git"
 dependencies = [
  "anyhow",
  "clap",

--- a/crates/api-desc/Cargo.toml
+++ b/crates/api-desc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasefire-applet-api-desc"
-version = "0.1.3"
+version = "0.2.0-git"
 authors = ["Julien Cretin <cretin@google.com>"]
 license = "Apache-2.0"
 publish = true

--- a/crates/api-desc/src/button.rs
+++ b/crates/api-desc/src/button.rs
@@ -46,10 +46,10 @@ pub(crate) fn new() -> Item {
                 /// Function called on button events.
                 ///
                 /// The function takes its opaque `data` and the new button `state` as arguments.
-                handler_func: fn { data: *mut u8, state: usize },
+                handler_func: fn { data: *const u8, state: usize },
 
                 /// The opaque data to use when calling the handler function.
-                handler_data: *mut u8,
+                handler_data: *const u8,
             } -> {}
         },
         item! {

--- a/crates/api-desc/src/clock.rs
+++ b/crates/api-desc/src/clock.rs
@@ -34,10 +34,10 @@ pub(crate) fn new() -> Item {
             /// Allocates a timer (initially stopped).
             fn allocate "ta" {
                 /// Function called when the timer triggers.
-                handler_func: fn { data: *mut u8 },
+                handler_func: fn { data: *const u8 },
 
                 /// The opaque data to use when calling the handler function.
-                handler_data: *mut u8,
+                handler_data: *const u8,
             } -> {
                 /// Identifier for this timer.
                 id: usize,

--- a/crates/api-desc/src/usb/serial.rs
+++ b/crates/api-desc/src/usb/serial.rs
@@ -63,8 +63,8 @@ pub(crate) fn new() -> Item {
             /// It is possible that the callback is spuriously called.
             fn register "use" {
                 event: usize,
-                handler_func: fn { data: *mut u8 },
-                handler_data: *mut u8,
+                handler_func: fn { data: *const u8 },
+                handler_data: *const u8,
             } -> {}
         },
         item! {

--- a/crates/api-macro/CHANGELOG.md
+++ b/crates/api-macro/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.3.1-git
+
+### Patch
+
+- Update dependencies
+
 ## 0.3.0
 
 ### Major

--- a/crates/api-macro/Cargo.lock
+++ b/crates/api-macro/Cargo.lock
@@ -146,7 +146,7 @@ checksum = "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0"
 
 [[package]]
 name = "wasefire-applet-api-desc"
-version = "0.1.3"
+version = "0.2.0-git"
 dependencies = [
  "anyhow",
  "clap",
@@ -158,7 +158,7 @@ dependencies = [
 
 [[package]]
 name = "wasefire-applet-api-macro"
-version = "0.3.0"
+version = "0.3.1-git"
 dependencies = [
  "proc-macro2",
  "wasefire-applet-api-desc",

--- a/crates/api-macro/Cargo.toml
+++ b/crates/api-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasefire-applet-api-macro"
-version = "0.3.0"
+version = "0.3.1-git"
 authors = ["Julien Cretin <cretin@google.com>"]
 license = "Apache-2.0"
 publish = true
@@ -16,7 +16,7 @@ proc-macro = true
 
 [dependencies]
 proc-macro2 = { version = "1.0.60", default-features = false }
-wasefire-applet-api-desc = { version = "=0.1.3", path = "../api-desc" }
+wasefire-applet-api-desc = { version = "=0.2.0-git", path = "../api-desc" }
 
 [features]
 multivalue = ["wasefire-applet-api-desc/multivalue"]

--- a/crates/api/CHANGELOG.md
+++ b/crates/api/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.3.1-git
+
+### Patch
+
+- Update dependencies
+
 ## 0.3.0
 
 ### Major
@@ -37,4 +43,4 @@
 
 ## 0.1.0
 
-<!-- Increment to skip CHANGELOG.md test: 4 -->
+<!-- Increment to skip CHANGELOG.md test: 5 -->

--- a/crates/api/Cargo.lock
+++ b/crates/api/Cargo.lock
@@ -158,7 +158,7 @@ checksum = "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0"
 
 [[package]]
 name = "wasefire-applet-api"
-version = "0.3.0"
+version = "0.3.1-git"
 dependencies = [
  "sealed",
  "wasefire-applet-api-macro",
@@ -166,7 +166,7 @@ dependencies = [
 
 [[package]]
 name = "wasefire-applet-api-desc"
-version = "0.1.3"
+version = "0.2.0-git"
 dependencies = [
  "anyhow",
  "clap",
@@ -178,7 +178,7 @@ dependencies = [
 
 [[package]]
 name = "wasefire-applet-api-macro"
-version = "0.3.0"
+version = "0.3.1-git"
 dependencies = [
  "proc-macro2",
  "wasefire-applet-api-desc",

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasefire-applet-api"
-version = "0.3.0"
+version = "0.3.1-git"
 authors = ["Julien Cretin <cretin@google.com>"]
 license = "Apache-2.0"
 publish = true
@@ -17,7 +17,7 @@ targets = ["riscv32imc-unknown-none-elf", "thumbv7em-none-eabi"]
 
 [dependencies]
 sealed = { version = "0.5.0", default-features = false, optional = true }
-wasefire-applet-api-macro = { version = "0.3.0", path = "../api-macro" }
+wasefire-applet-api-macro = { version = "0.3.1-git", path = "../api-macro" }
 
 [features]
 # Compiles for host or wasm (choose exactly one).

--- a/crates/api/src/wasm.md
+++ b/crates/api/src/wasm.md
@@ -24,5 +24,5 @@ As such, they follow a precise convention:
   - `*const u8` and `*mut u8` for opaque/polymorphic pointers
   - `*const T` and `*mut T` for transparent pointers where `T` is recursively
     defined
-  - `extern "C" fn(data: *mut u8, ...)` for closures over some opaque data and
+  - `extern "C" fn(data: *const u8, ...)` for closures over some opaque data and
     possibly additional parameters

--- a/crates/prelude/CHANGELOG.md
+++ b/crates/prelude/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Add access to SEC1 encoding of ECDSA and ECDH private keys
 
+### Patch
+
+- Update dependencies
+
 ## 0.2.0
 
 ### Major

--- a/crates/prelude/Cargo.lock
+++ b/crates/prelude/Cargo.lock
@@ -294,14 +294,14 @@ dependencies = [
 
 [[package]]
 name = "wasefire-applet-api"
-version = "0.3.0"
+version = "0.3.1-git"
 dependencies = [
  "wasefire-applet-api-macro",
 ]
 
 [[package]]
 name = "wasefire-applet-api-desc"
-version = "0.1.3"
+version = "0.2.0-git"
 dependencies = [
  "anyhow",
  "clap",
@@ -313,7 +313,7 @@ dependencies = [
 
 [[package]]
 name = "wasefire-applet-api-macro"
-version = "0.3.0"
+version = "0.3.1-git"
 dependencies = [
  "proc-macro2",
  "wasefire-applet-api-desc",

--- a/crates/prelude/Cargo.toml
+++ b/crates/prelude/Cargo.toml
@@ -24,7 +24,7 @@ portable-atomic = { version = "1.3.3", default-features = false }
 rlsf = { version = "0.2.1", default-features = false }
 sealed = { version = "0.5.0", default-features = false }
 typenum = { version = "1.16.0", default-features = false }
-wasefire-applet-api = { version = "0.3.0", path = "../api", features = ["wasm"] }
+wasefire-applet-api = { version = "0.3.1-git", path = "../api", features = ["wasm"] }
 zeroize = { version = "1.6.0", default-features = false, features = ["derive"], optional = true }
 
 [features]

--- a/crates/prelude/src/callback.rs
+++ b/crates/prelude/src/callback.rs
@@ -16,8 +16,8 @@ macro_rules! define {
     ($n:ident $(, $x:ident)*) => {
         #[no_mangle]
         pub extern "C" fn $n(
-            ptr: extern "C" fn(*mut u8 $(, usize ${ignore(x)})*),
-            this: *mut u8 $(, $x: usize)*
+            ptr: extern "C" fn(*const u8 $(, usize ${ignore(x)})*),
+            this: *const u8 $(, $x: usize)*
         ) {
             ptr(this $(, $x)*);
         }

--- a/crates/prelude/src/usb/serial.rs
+++ b/crates/prelude/src/usb/serial.rs
@@ -160,7 +160,7 @@ impl<'a> Listener<'a> {
         if listener.is_registered() {
             let event = listener.kind.event() as usize;
             let handler_func = Self::call;
-            let handler_data = ready.as_ptr() as *mut u8;
+            let handler_data = ready.as_ptr() as *const u8;
             unsafe { api::register(api::register::Params { event, handler_func, handler_data }) };
         }
         let _ = listener.update();
@@ -204,8 +204,8 @@ impl<'a> Listener<'a> {
         unsafe { api::unregister(api::unregister::Params { event }) };
     }
 
-    extern "C" fn call(data: *mut u8) {
-        let ready = unsafe { &*(data as *mut Cell<bool>) };
+    extern "C" fn call(data: *const u8) {
+        let ready = unsafe { &*(data as *const Cell<bool>) };
         ready.set(true);
     }
 }

--- a/crates/runner-host/Cargo.lock
+++ b/crates/runner-host/Cargo.lock
@@ -991,7 +991,7 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "wasefire-applet-api"
-version = "0.3.0"
+version = "0.3.1-git"
 dependencies = [
  "sealed",
  "wasefire-applet-api-macro",
@@ -999,7 +999,7 @@ dependencies = [
 
 [[package]]
 name = "wasefire-applet-api-desc"
-version = "0.1.3"
+version = "0.2.0-git"
 dependencies = [
  "anyhow",
  "clap",
@@ -1011,7 +1011,7 @@ dependencies = [
 
 [[package]]
 name = "wasefire-applet-api-macro"
-version = "0.3.0"
+version = "0.3.1-git"
 dependencies = [
  "proc-macro2",
  "wasefire-applet-api-desc",

--- a/crates/runner-nordic/Cargo.lock
+++ b/crates/runner-nordic/Cargo.lock
@@ -978,7 +978,7 @@ dependencies = [
 
 [[package]]
 name = "wasefire-applet-api"
-version = "0.3.0"
+version = "0.3.1-git"
 dependencies = [
  "sealed",
  "wasefire-applet-api-macro",
@@ -986,7 +986,7 @@ dependencies = [
 
 [[package]]
 name = "wasefire-applet-api-desc"
-version = "0.1.3"
+version = "0.2.0-git"
 dependencies = [
  "anyhow",
  "clap",
@@ -998,7 +998,7 @@ dependencies = [
 
 [[package]]
 name = "wasefire-applet-api-macro"
-version = "0.3.0"
+version = "0.3.1-git"
 dependencies = [
  "proc-macro2",
  "wasefire-applet-api-desc",

--- a/crates/scheduler/CHANGELOG.md
+++ b/crates/scheduler/CHANGELOG.md
@@ -43,4 +43,4 @@
 
 ## 0.1.0
 
-<!-- Increment to skip CHANGELOG.md test: 11 -->
+<!-- Increment to skip CHANGELOG.md test: 12 -->

--- a/crates/scheduler/Cargo.lock
+++ b/crates/scheduler/Cargo.lock
@@ -385,7 +385,7 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "wasefire-applet-api"
-version = "0.3.0"
+version = "0.3.1-git"
 dependencies = [
  "sealed",
  "wasefire-applet-api-macro",
@@ -393,7 +393,7 @@ dependencies = [
 
 [[package]]
 name = "wasefire-applet-api-desc"
-version = "0.1.3"
+version = "0.2.0-git"
 dependencies = [
  "anyhow",
  "clap",
@@ -405,7 +405,7 @@ dependencies = [
 
 [[package]]
 name = "wasefire-applet-api-macro"
-version = "0.3.0"
+version = "0.3.1-git"
 dependencies = [
  "proc-macro2",
  "wasefire-applet-api-desc",

--- a/crates/scheduler/Cargo.toml
+++ b/crates/scheduler/Cargo.toml
@@ -17,7 +17,7 @@ derivative = { version = "2.2.0", default-features = false, features = ["use_cor
 digest = { version = "0.10.7", default-features = false, features = ["mac"] }
 generic-array = { version = "0.14.7", default-features = false }
 typenum = { version = "1.16.0", default-features = false }
-wasefire-applet-api = { version = "0.3.0", path = "../api", features = ["host"] }
+wasefire-applet-api = { version = "0.3.1-git", path = "../api", features = ["host"] }
 wasefire-board-api = { version = "0.4.0-git", path = "../board" }
 wasefire-interpreter = { version = "0.1.2", path = "../interpreter", features = ["toctou"] }
 wasefire-logger = { version = "0.1.3-git", path = "../logger" }

--- a/crates/stub/CHANGELOG.md
+++ b/crates/stub/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.1.1-git
+
+### Patch
+
+- Update dependencies
+
 ## 0.1.0
 
 <!-- Increment to skip CHANGELOG.md test: 3 -->

--- a/crates/stub/Cargo.lock
+++ b/crates/stub/Cargo.lock
@@ -455,14 +455,14 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasefire-applet-api"
-version = "0.3.0"
+version = "0.3.1-git"
 dependencies = [
  "wasefire-applet-api-macro",
 ]
 
 [[package]]
 name = "wasefire-applet-api-desc"
-version = "0.1.3"
+version = "0.2.0-git"
 dependencies = [
  "anyhow",
  "clap",
@@ -474,7 +474,7 @@ dependencies = [
 
 [[package]]
 name = "wasefire-applet-api-macro"
-version = "0.3.0"
+version = "0.3.1-git"
 dependencies = [
  "proc-macro2",
  "wasefire-applet-api-desc",
@@ -482,7 +482,7 @@ dependencies = [
 
 [[package]]
 name = "wasefire-stub"
-version = "0.1.0"
+version = "0.1.1-git"
 dependencies = [
  "crypto-common",
  "digest",

--- a/crates/stub/Cargo.toml
+++ b/crates/stub/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasefire-stub"
-version = "0.1.0"
+version = "0.1.1-git"
 authors = ["Julien Cretin <cretin@google.com>"]
 license = "Apache-2.0"
 publish = true
@@ -24,4 +24,4 @@ p384 = { version = "0.13.0", default-features = false, features = ["ecdsa"] }
 rand = { version = "0.8.5", default-features = false, features = ["std", "std_rng"] }
 sha2 = { version = "0.10.6", default-features = false }
 signature = { version = "2.1.0", default-features = false }
-wasefire-applet-api = { version = "0.3.0", path = "../api", features = ["native", "wasm"] }
+wasefire-applet-api = { version = "0.3.1-git", path = "../api", features = ["native", "wasm"] }

--- a/examples/rust/blink/Cargo.lock
+++ b/examples/rust/blink/Cargo.lock
@@ -261,14 +261,14 @@ dependencies = [
 
 [[package]]
 name = "wasefire-applet-api"
-version = "0.3.0"
+version = "0.3.1-git"
 dependencies = [
  "wasefire-applet-api-macro",
 ]
 
 [[package]]
 name = "wasefire-applet-api-desc"
-version = "0.1.3"
+version = "0.2.0-git"
 dependencies = [
  "anyhow",
  "clap",
@@ -280,7 +280,7 @@ dependencies = [
 
 [[package]]
 name = "wasefire-applet-api-macro"
-version = "0.3.0"
+version = "0.3.1-git"
 dependencies = [
  "proc-macro2",
  "wasefire-applet-api-desc",

--- a/examples/rust/blink_periodic/Cargo.lock
+++ b/examples/rust/blink_periodic/Cargo.lock
@@ -261,14 +261,14 @@ dependencies = [
 
 [[package]]
 name = "wasefire-applet-api"
-version = "0.3.0"
+version = "0.3.1-git"
 dependencies = [
  "wasefire-applet-api-macro",
 ]
 
 [[package]]
 name = "wasefire-applet-api-desc"
-version = "0.1.3"
+version = "0.2.0-git"
 dependencies = [
  "anyhow",
  "clap",
@@ -280,7 +280,7 @@ dependencies = [
 
 [[package]]
 name = "wasefire-applet-api-macro"
-version = "0.3.0"
+version = "0.3.1-git"
 dependencies = [
  "proc-macro2",
  "wasefire-applet-api-desc",

--- a/examples/rust/button/Cargo.lock
+++ b/examples/rust/button/Cargo.lock
@@ -261,14 +261,14 @@ dependencies = [
 
 [[package]]
 name = "wasefire-applet-api"
-version = "0.3.0"
+version = "0.3.1-git"
 dependencies = [
  "wasefire-applet-api-macro",
 ]
 
 [[package]]
 name = "wasefire-applet-api-desc"
-version = "0.1.3"
+version = "0.2.0-git"
 dependencies = [
  "anyhow",
  "clap",
@@ -280,7 +280,7 @@ dependencies = [
 
 [[package]]
 name = "wasefire-applet-api-macro"
-version = "0.3.0"
+version = "0.3.1-git"
 dependencies = [
  "proc-macro2",
  "wasefire-applet-api-desc",

--- a/examples/rust/button_abort/Cargo.lock
+++ b/examples/rust/button_abort/Cargo.lock
@@ -261,14 +261,14 @@ dependencies = [
 
 [[package]]
 name = "wasefire-applet-api"
-version = "0.3.0"
+version = "0.3.1-git"
 dependencies = [
  "wasefire-applet-api-macro",
 ]
 
 [[package]]
 name = "wasefire-applet-api-desc"
-version = "0.1.3"
+version = "0.2.0-git"
 dependencies = [
  "anyhow",
  "clap",
@@ -280,7 +280,7 @@ dependencies = [
 
 [[package]]
 name = "wasefire-applet-api-macro"
-version = "0.3.0"
+version = "0.3.1-git"
 dependencies = [
  "proc-macro2",
  "wasefire-applet-api-desc",

--- a/examples/rust/ccm/Cargo.lock
+++ b/examples/rust/ccm/Cargo.lock
@@ -261,14 +261,14 @@ dependencies = [
 
 [[package]]
 name = "wasefire-applet-api"
-version = "0.3.0"
+version = "0.3.1-git"
 dependencies = [
  "wasefire-applet-api-macro",
 ]
 
 [[package]]
 name = "wasefire-applet-api-desc"
-version = "0.1.3"
+version = "0.2.0-git"
 dependencies = [
  "anyhow",
  "clap",
@@ -280,7 +280,7 @@ dependencies = [
 
 [[package]]
 name = "wasefire-applet-api-macro"
-version = "0.3.0"
+version = "0.3.1-git"
 dependencies = [
  "proc-macro2",
  "wasefire-applet-api-desc",

--- a/examples/rust/ctap/Cargo.lock
+++ b/examples/rust/ctap/Cargo.lock
@@ -261,14 +261,14 @@ dependencies = [
 
 [[package]]
 name = "wasefire-applet-api"
-version = "0.3.0"
+version = "0.3.1-git"
 dependencies = [
  "wasefire-applet-api-macro",
 ]
 
 [[package]]
 name = "wasefire-applet-api-desc"
-version = "0.1.3"
+version = "0.2.0-git"
 dependencies = [
  "anyhow",
  "clap",
@@ -280,7 +280,7 @@ dependencies = [
 
 [[package]]
 name = "wasefire-applet-api-macro"
-version = "0.3.0"
+version = "0.3.1-git"
 dependencies = [
  "proc-macro2",
  "wasefire-applet-api-desc",

--- a/examples/rust/ec_test/Cargo.lock
+++ b/examples/rust/ec_test/Cargo.lock
@@ -537,14 +537,14 @@ dependencies = [
 
 [[package]]
 name = "wasefire-applet-api"
-version = "0.3.0"
+version = "0.3.1-git"
 dependencies = [
  "wasefire-applet-api-macro",
 ]
 
 [[package]]
 name = "wasefire-applet-api-desc"
-version = "0.1.3"
+version = "0.2.0-git"
 dependencies = [
  "anyhow",
  "clap",
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "wasefire-applet-api-macro"
-version = "0.3.0"
+version = "0.3.1-git"
 dependencies = [
  "proc-macro2",
  "wasefire-applet-api-desc",
@@ -564,7 +564,7 @@ dependencies = [
 
 [[package]]
 name = "wasefire-stub"
-version = "0.1.0"
+version = "0.1.1-git"
 dependencies = [
  "crypto-common",
  "digest",

--- a/examples/rust/echo/Cargo.lock
+++ b/examples/rust/echo/Cargo.lock
@@ -261,14 +261,14 @@ dependencies = [
 
 [[package]]
 name = "wasefire-applet-api"
-version = "0.3.0"
+version = "0.3.1-git"
 dependencies = [
  "wasefire-applet-api-macro",
 ]
 
 [[package]]
 name = "wasefire-applet-api-desc"
-version = "0.1.3"
+version = "0.2.0-git"
 dependencies = [
  "anyhow",
  "clap",
@@ -280,7 +280,7 @@ dependencies = [
 
 [[package]]
 name = "wasefire-applet-api-macro"
-version = "0.3.0"
+version = "0.3.1-git"
 dependencies = [
  "proc-macro2",
  "wasefire-applet-api-desc",

--- a/examples/rust/gcm_test/Cargo.lock
+++ b/examples/rust/gcm_test/Cargo.lock
@@ -302,14 +302,14 @@ dependencies = [
 
 [[package]]
 name = "wasefire-applet-api"
-version = "0.3.0"
+version = "0.3.1-git"
 dependencies = [
  "wasefire-applet-api-macro",
 ]
 
 [[package]]
 name = "wasefire-applet-api-desc"
-version = "0.1.3"
+version = "0.2.0-git"
 dependencies = [
  "anyhow",
  "clap",
@@ -321,7 +321,7 @@ dependencies = [
 
 [[package]]
 name = "wasefire-applet-api-macro"
-version = "0.3.0"
+version = "0.3.1-git"
 dependencies = [
  "proc-macro2",
  "wasefire-applet-api-desc",

--- a/examples/rust/hash_test/Cargo.lock
+++ b/examples/rust/hash_test/Cargo.lock
@@ -552,14 +552,14 @@ dependencies = [
 
 [[package]]
 name = "wasefire-applet-api"
-version = "0.3.0"
+version = "0.3.1-git"
 dependencies = [
  "wasefire-applet-api-macro",
 ]
 
 [[package]]
 name = "wasefire-applet-api-desc"
-version = "0.1.3"
+version = "0.2.0-git"
 dependencies = [
  "anyhow",
  "clap",
@@ -571,7 +571,7 @@ dependencies = [
 
 [[package]]
 name = "wasefire-applet-api-macro"
-version = "0.3.0"
+version = "0.3.1-git"
 dependencies = [
  "proc-macro2",
  "wasefire-applet-api-desc",
@@ -579,7 +579,7 @@ dependencies = [
 
 [[package]]
 name = "wasefire-stub"
-version = "0.1.0"
+version = "0.1.1-git"
 dependencies = [
  "crypto-common",
  "digest",

--- a/examples/rust/hello/Cargo.lock
+++ b/examples/rust/hello/Cargo.lock
@@ -261,14 +261,14 @@ dependencies = [
 
 [[package]]
 name = "wasefire-applet-api"
-version = "0.3.0"
+version = "0.3.1-git"
 dependencies = [
  "wasefire-applet-api-macro",
 ]
 
 [[package]]
 name = "wasefire-applet-api-desc"
-version = "0.1.3"
+version = "0.2.0-git"
 dependencies = [
  "anyhow",
  "clap",
@@ -280,7 +280,7 @@ dependencies = [
 
 [[package]]
 name = "wasefire-applet-api-macro"
-version = "0.3.0"
+version = "0.3.1-git"
 dependencies = [
  "proc-macro2",
  "wasefire-applet-api-desc",

--- a/examples/rust/hsm/Cargo.lock
+++ b/examples/rust/hsm/Cargo.lock
@@ -269,14 +269,14 @@ dependencies = [
 
 [[package]]
 name = "wasefire-applet-api"
-version = "0.3.0"
+version = "0.3.1-git"
 dependencies = [
  "wasefire-applet-api-macro",
 ]
 
 [[package]]
 name = "wasefire-applet-api-desc"
-version = "0.1.3"
+version = "0.2.0-git"
 dependencies = [
  "anyhow",
  "clap",
@@ -288,7 +288,7 @@ dependencies = [
 
 [[package]]
 name = "wasefire-applet-api-macro"
-version = "0.3.0"
+version = "0.3.1-git"
 dependencies = [
  "proc-macro2",
  "wasefire-applet-api-desc",

--- a/examples/rust/hsm/common/Cargo.lock
+++ b/examples/rust/hsm/common/Cargo.lock
@@ -282,14 +282,14 @@ dependencies = [
 
 [[package]]
 name = "wasefire-applet-api"
-version = "0.3.0"
+version = "0.3.1-git"
 dependencies = [
  "wasefire-applet-api-macro",
 ]
 
 [[package]]
 name = "wasefire-applet-api-desc"
-version = "0.1.3"
+version = "0.2.0-git"
 dependencies = [
  "anyhow",
  "clap",
@@ -301,7 +301,7 @@ dependencies = [
 
 [[package]]
 name = "wasefire-applet-api-macro"
-version = "0.3.0"
+version = "0.3.1-git"
 dependencies = [
  "proc-macro2",
  "wasefire-applet-api-desc",

--- a/examples/rust/led/Cargo.lock
+++ b/examples/rust/led/Cargo.lock
@@ -261,14 +261,14 @@ dependencies = [
 
 [[package]]
 name = "wasefire-applet-api"
-version = "0.3.0"
+version = "0.3.1-git"
 dependencies = [
  "wasefire-applet-api-macro",
 ]
 
 [[package]]
 name = "wasefire-applet-api-desc"
-version = "0.1.3"
+version = "0.2.0-git"
 dependencies = [
  "anyhow",
  "clap",
@@ -280,7 +280,7 @@ dependencies = [
 
 [[package]]
 name = "wasefire-applet-api-macro"
-version = "0.3.0"
+version = "0.3.1-git"
 dependencies = [
  "proc-macro2",
  "wasefire-applet-api-desc",

--- a/examples/rust/memory_game/Cargo.lock
+++ b/examples/rust/memory_game/Cargo.lock
@@ -261,14 +261,14 @@ dependencies = [
 
 [[package]]
 name = "wasefire-applet-api"
-version = "0.3.0"
+version = "0.3.1-git"
 dependencies = [
  "wasefire-applet-api-macro",
 ]
 
 [[package]]
 name = "wasefire-applet-api-desc"
-version = "0.1.3"
+version = "0.2.0-git"
 dependencies = [
  "anyhow",
  "clap",
@@ -280,7 +280,7 @@ dependencies = [
 
 [[package]]
 name = "wasefire-applet-api-macro"
-version = "0.3.0"
+version = "0.3.1-git"
 dependencies = [
  "proc-macro2",
  "wasefire-applet-api-desc",

--- a/examples/rust/panic/Cargo.lock
+++ b/examples/rust/panic/Cargo.lock
@@ -261,14 +261,14 @@ dependencies = [
 
 [[package]]
 name = "wasefire-applet-api"
-version = "0.3.0"
+version = "0.3.1-git"
 dependencies = [
  "wasefire-applet-api-macro",
 ]
 
 [[package]]
 name = "wasefire-applet-api-desc"
-version = "0.1.3"
+version = "0.2.0-git"
 dependencies = [
  "anyhow",
  "clap",
@@ -280,7 +280,7 @@ dependencies = [
 
 [[package]]
 name = "wasefire-applet-api-macro"
-version = "0.3.0"
+version = "0.3.1-git"
 dependencies = [
  "proc-macro2",
  "wasefire-applet-api-desc",

--- a/examples/rust/rand/Cargo.lock
+++ b/examples/rust/rand/Cargo.lock
@@ -261,14 +261,14 @@ dependencies = [
 
 [[package]]
 name = "wasefire-applet-api"
-version = "0.3.0"
+version = "0.3.1-git"
 dependencies = [
  "wasefire-applet-api-macro",
 ]
 
 [[package]]
 name = "wasefire-applet-api-desc"
-version = "0.1.3"
+version = "0.2.0-git"
 dependencies = [
  "anyhow",
  "clap",
@@ -280,7 +280,7 @@ dependencies = [
 
 [[package]]
 name = "wasefire-applet-api-macro"
-version = "0.3.0"
+version = "0.3.1-git"
 dependencies = [
  "proc-macro2",
  "wasefire-applet-api-desc",

--- a/examples/rust/rng_test/Cargo.lock
+++ b/examples/rust/rng_test/Cargo.lock
@@ -261,14 +261,14 @@ dependencies = [
 
 [[package]]
 name = "wasefire-applet-api"
-version = "0.3.0"
+version = "0.3.1-git"
 dependencies = [
  "wasefire-applet-api-macro",
 ]
 
 [[package]]
 name = "wasefire-applet-api-desc"
-version = "0.1.3"
+version = "0.2.0-git"
 dependencies = [
  "anyhow",
  "clap",
@@ -280,7 +280,7 @@ dependencies = [
 
 [[package]]
 name = "wasefire-applet-api-macro"
-version = "0.3.0"
+version = "0.3.1-git"
 dependencies = [
  "proc-macro2",
  "wasefire-applet-api-desc",

--- a/examples/rust/store/Cargo.lock
+++ b/examples/rust/store/Cargo.lock
@@ -261,14 +261,14 @@ dependencies = [
 
 [[package]]
 name = "wasefire-applet-api"
-version = "0.3.0"
+version = "0.3.1-git"
 dependencies = [
  "wasefire-applet-api-macro",
 ]
 
 [[package]]
 name = "wasefire-applet-api-desc"
-version = "0.1.3"
+version = "0.2.0-git"
 dependencies = [
  "anyhow",
  "clap",
@@ -280,7 +280,7 @@ dependencies = [
 
 [[package]]
 name = "wasefire-applet-api-macro"
-version = "0.3.0"
+version = "0.3.1-git"
 dependencies = [
  "proc-macro2",
  "wasefire-applet-api-desc",

--- a/examples/rust/store_test/Cargo.lock
+++ b/examples/rust/store_test/Cargo.lock
@@ -261,14 +261,14 @@ dependencies = [
 
 [[package]]
 name = "wasefire-applet-api"
-version = "0.3.0"
+version = "0.3.1-git"
 dependencies = [
  "wasefire-applet-api-macro",
 ]
 
 [[package]]
 name = "wasefire-applet-api-desc"
-version = "0.1.3"
+version = "0.2.0-git"
 dependencies = [
  "anyhow",
  "clap",
@@ -280,7 +280,7 @@ dependencies = [
 
 [[package]]
 name = "wasefire-applet-api-macro"
-version = "0.3.0"
+version = "0.3.1-git"
 dependencies = [
  "proc-macro2",
  "wasefire-applet-api-desc",

--- a/examples/rust/sync_test/Cargo.lock
+++ b/examples/rust/sync_test/Cargo.lock
@@ -261,14 +261,14 @@ dependencies = [
 
 [[package]]
 name = "wasefire-applet-api"
-version = "0.3.0"
+version = "0.3.1-git"
 dependencies = [
  "wasefire-applet-api-macro",
 ]
 
 [[package]]
 name = "wasefire-applet-api-desc"
-version = "0.1.3"
+version = "0.2.0-git"
 dependencies = [
  "anyhow",
  "clap",
@@ -280,7 +280,7 @@ dependencies = [
 
 [[package]]
 name = "wasefire-applet-api-macro"
-version = "0.3.0"
+version = "0.3.1-git"
 dependencies = [
  "proc-macro2",
  "wasefire-applet-api-desc",

--- a/examples/rust/timer_test/Cargo.lock
+++ b/examples/rust/timer_test/Cargo.lock
@@ -261,14 +261,14 @@ dependencies = [
 
 [[package]]
 name = "wasefire-applet-api"
-version = "0.3.0"
+version = "0.3.1-git"
 dependencies = [
  "wasefire-applet-api-macro",
 ]
 
 [[package]]
 name = "wasefire-applet-api-desc"
-version = "0.1.3"
+version = "0.2.0-git"
 dependencies = [
  "anyhow",
  "clap",
@@ -280,7 +280,7 @@ dependencies = [
 
 [[package]]
 name = "wasefire-applet-api-macro"
-version = "0.3.0"
+version = "0.3.1-git"
 dependencies = [
  "proc-macro2",
  "wasefire-applet-api-desc",


### PR DESCRIPTION
This is to highlight that mutation needs dynamic checks because of possible reentrancy (the callback may wait for callbacks and trigger again resulting in a nested call).