### PR TITLE
Install Node.js v16 from nodesource instead of apt-get

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -43,6 +43,6 @@ ensure bin cc
 ensure lib libudev
 ensure lib libusb-1.0
 
-# Transitive dependencies of the host runner. This should ideally be installed
-# on demand by xtask.
+# Transitive dependencies of runner-host. This should ideally be installed on
+# demand by xtask.
 ensure bin usbip

--- a/scripts/system.sh
+++ b/scripts/system.sh
@@ -1,0 +1,56 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+has() {
+  case "$1" in
+    bin) which "$2" >/dev/null 2>&1 ;;
+    lib) pkg-config --exists "$2" ;;
+    *) e "Internal error: expected bin or lib, got $1" ;;
+  esac
+}
+
+ensure() {
+  has "$1" "$2" || install "$1" "$2"
+}
+
+install() {
+  if has bin apt-get; then
+    case "$1" in
+      bin)
+        case "$2" in
+          cc) set build-essential ;;
+          curl) set curl ;;
+          npm)
+            # AssemblyScript needs Node 16 or later.
+            curl -fsSL https://deb.nodesource.com/setup_16.x | sudo -E bash -
+            set nodejs
+            ;;
+          pkg-config) set pkgconf ;;
+          usbip) set usbip ;;
+          wasm-opt) set binaryen ;;
+          wasm-strip) set wabt ;;
+          *) e "Internal error: _install_apt unimplemented for $*" ;;
+        esac ;;
+      lib)
+        case "$2" in
+          libudev) set libudev-dev ;;
+          libusb-1.0) set libusb-1.0-0-dev ;;
+          *) e "Internal error: _install_apt unimplemented for $*" ;;
+        esac ;;
+    esac
+    x sudo apt-get install "$1"
+  else
+    e "Unsupported system. Install $1 '$2' and rerun the command."
+  fi
+}

--- a/scripts/wrapper.sh
+++ b/scripts/wrapper.sh
@@ -17,6 +17,9 @@ set -e
 
 # This script runs the provided command possibly installing it if needed.
 
+. scripts/log.sh
+. scripts/system.sh
+
 ROOT="$(dirname "$0")"
 # We don't support running from the scripts directory itself.
 [ "${ROOT%scripts}" != "$ROOT" ]
@@ -55,22 +58,5 @@ case "$1" in
 esac
 [ $IS_CARGO = y ] && PATH="$CARGO_ROOT/bin:$PATH" run "$@"
 
-has_bin() {
-  which "$1" >/dev/null 2>&1
-}
-
-has_bin "$1" && run "$@"
-
-has_bin apt-get || e 'Wrapper only supports apt-get.'
-
-ensure_bin() {
-  x sudo apt-get install "$1"
-}
-
-case "$1" in
-  npm) ensure_bin npm ;;
-  wasm-opt) ensure_bin binaryen ;;
-  wasm-strip) ensure_bin wabt ;;
-  *) e "Wrapper does not support '$1'" ;;
-esac
+ensure bin "$1"
 run "$@"

--- a/scripts/wrapper.sh
+++ b/scripts/wrapper.sh
@@ -17,15 +17,13 @@ set -e
 
 # This script runs the provided command possibly installing it if needed.
 
-. scripts/log.sh
-. scripts/system.sh
-
 ROOT="$(dirname "$0")"
 # We don't support running from the scripts directory itself.
 [ "${ROOT%scripts}" != "$ROOT" ]
 ROOT="${ROOT%/scripts}"
 
 . "$ROOT/scripts/log.sh"
+. "$ROOT/scripts/system.sh"
 
 CARGO_ROOT="$ROOT/.root"
 


### PR DESCRIPTION
On Ubuntu 22.04 LTS, there's only Node.js v12 which does not support AssemblyScript. We could also check the system version but that would add complexity for a feature that is not yet used.

Fixes #203