### PR TITLE
Keep github version of rustup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,9 +29,6 @@ jobs:
     permissions:
       contents: read
     steps:
-      # Do not rely on the pre-installed rustup. This also checks the rustup
-      # installation procedure of the setup script.
-      - run: rustup self uninstall -y
       - uses: actions/checkout@v3
       - uses: actions/cache@v3
         if: github.event_name != 'schedule'

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -35,8 +35,7 @@ ensure bin pkg-config
 
 if ! has bin rustup; then
   x git submodule update --init third_party/rust-lang/rustup
-  x ./third_party/rust-lang/rustup/rustup-init.sh \
-    --default-toolchain=none --profile=minimal -y
+  x ./third_party/rust-lang/rustup/rustup-init.sh
 fi
 
 # Transitive dependencies of xtask.


### PR DESCRIPTION
We would need to add it to the cache but it's big.