### PR TITLE
Create a sensible Github Codespace template

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,24 @@
+{
+   "image":"mcr.microsoft.com/devcontainers/rust:latest",
+   "postCreateCommand":"rustup self update && rustup update",
+   "capAdd":[
+      "SYS_PTRACE"
+   ],
+   "customizations":{
+      "vscode":{
+         "extensions":[
+            "rust-lang.rust-analyzer"
+         ],
+         "settings":{
+            "terminal.integrated.profiles.linux":{
+               "shell":{
+                  "path":"zsh",
+                  "args":[
+                     "-l"
+                  ]
+               }
+            }
+         }
+      }
+   }
+}


### PR DESCRIPTION
This pull request ensures that Github Codespaces started fromt his git repository ([direct url](https://codespaces.new/google/wasefire?quickstart=1)) will provide an environment that includes:
- rust preinstalled (via rustup)
- PTRACE for debugging
- A Rust-specific extension for vscode
- (colored) ZSH