### PR TITLE
Use semihosting for Nordic debug exit

### DIFF
--- a/crates/runner-nordic/Cargo.lock
+++ b/crates/runner-nordic/Cargo.lock
@@ -223,6 +223,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cortex-m-semihosting"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c23234600452033cc77e4b761e740e02d2c4168e11dbf36ab14a0f58973592b0"
+dependencies = [
+ "cortex-m",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -773,6 +782,7 @@ version = "0.1.0"
 dependencies = [
  "cortex-m",
  "cortex-m-rt",
+ "cortex-m-semihosting",
  "critical-section",
  "defmt",
  "defmt-rtt",

--- a/crates/runner-nordic/Cargo.toml
+++ b/crates/runner-nordic/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 [dependencies]
 cortex-m = { version = "0.7.7", features = ["critical-section-single-core"] }
 cortex-m-rt = "0.7.3"
+cortex-m-semihosting = "0.5.0"
 critical-section = "1.1.2"
 defmt = { version = "0.3.5", optional = true }
 defmt-rtt = { version = "0.4.0", optional = true }

--- a/crates/runner-nordic/src/tasks.rs
+++ b/crates/runner-nordic/src/tasks.rs
@@ -40,6 +40,14 @@ impl board::Api for Board {
         }
     }
 
+    fn syscall(x1: u32, x2: u32, x3: u32, x4: u32) -> Option<u32> {
+        match (x1, x2, x3, x4) {
+            // The syscall_test example relies on this.
+            (1, 2, 3, 4) => Some(5),
+            _ => None,
+        }
+    }
+
     type Button = button::Impl;
     type Crypto = crypto::Impl;
     type Debug = debug::Impl;

--- a/crates/runner-nordic/src/tasks/debug.rs
+++ b/crates/runner-nordic/src/tasks/debug.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use cortex_m_semihosting::debug;
 use wasefire_board_api as board;
 
 pub enum Impl {}
@@ -31,15 +32,10 @@ impl board::debug::Api for Impl {
     }
 
     fn exit(success: bool) -> ! {
-        if success {
-            loop {
-                cortex_m::asm::bkpt();
-            }
-        } else {
-            #[cfg(feature = "debug")]
-            panic_probe::hard_fault();
-            #[cfg(feature = "release")]
-            panic!();
-        }
+        #[cfg(feature = "debug")]
+        defmt::flush();
+        let status = if success { debug::EXIT_SUCCESS } else { debug::EXIT_FAILURE };
+        debug::exit(status);
+        unreachable!();
     }
 }


### PR DESCRIPTION
This was broken by #246 because `probe-rs` doesn't consider normal breakpoints as semi-hosting exit command.

Note that `./scripts/hwci.sh nordic` is currently slow with `--release` because of https://github.com/probe-rs/probe-rs/issues/1865