### PR TITLE
Fix unnecessary double asterisk

### DIFF
--- a/scripts/announce.sh
+++ b/scripts/announce.sh
@@ -31,7 +31,7 @@ new() { sed -n 's/^## //p' CHANGELOG.md | sed -n 1p; }
 dif() { sed -n '/^## /{:a;n;/^## /q;s/^#/##/;p;ba}' CHANGELOG.md; }
 old() { sed -n 's/^## //p' CHANGELOG.md | sed -n 2p; }
 
-CRATES=($(git show --oneline --stat -- '**/CHANGELOG.md' \
+CRATES=($(git show --oneline --stat -- '*/CHANGELOG.md' \
   | sed -n 's#^ \(.*\)/CHANGELOG.md.*#\1#p'))
 rem() {
   local new=()

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -47,7 +47,7 @@ for crate in $(ls crates); do
   x cargo xtask --release runner $name
 done
 
-for dir in $(git ls-files '**/test.sh'); do
+for dir in $(git ls-files '*/test.sh'); do
   dir=$(dirname $dir)
   i "Run tests in $dir"
   ( cd $dir && ./test.sh )

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -65,7 +65,7 @@ for crate in "${TOPOLOGICAL_ORDER[@]}"; do
 done
 
 i "Remove all -git suffixes"
-sed -i 's/-git//' $(git ls-files '**/'{Cargo.{toml,lock},CHANGELOG.md})
+sed -i 's/-git//' $(git ls-files '*/'{Cargo.{toml,lock},CHANGELOG.md})
 if [ -n "$(git status -s)" ]; then
   i "Commit release"
   git commit -aqm'Release all crates'

--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -27,10 +27,10 @@ for submodule in WebAssembly/spec; do
     git checkout origin/main
   )
 done
-for path in $(git ls-files '**/Cargo.toml'); do
+for path in $(git ls-files '*/Cargo.toml'); do
   ./scripts/wrapper.sh cargo upgrade --manifest-path=$path --incompatible
 done
-for path in $(git ls-files '**/Cargo.toml'); do
+for path in $(git ls-files '*/Cargo.toml'); do
   cargo update --manifest-path=$path
 done
 


### PR DESCRIPTION
By default pathspecs use fnmatch where `*` matches slashes too. The `**` is when using the glob magic word which sets `FNM_PATHNAME` when calling `fnmatch`.