### PR TITLE
Disable interrupts when locking state

### DIFF
--- a/crates/runner-nordic/Cargo.lock
+++ b/crates/runner-nordic/Cargo.lock
@@ -871,7 +871,6 @@ dependencies = [
  "wasefire-board-api",
  "wasefire-interpreter",
  "wasefire-logger",
- "wasefire-mutex",
  "wasefire-scheduler",
  "wasefire-store",
 ]

--- a/crates/runner-nordic/Cargo.toml
+++ b/crates/runner-nordic/Cargo.toml
@@ -26,7 +26,6 @@ wasefire-applet-api = { path = "../api" }
 wasefire-board-api = { path = "../board" }
 wasefire-interpreter = { path = "../interpreter", optional = true }
 wasefire-logger = { path = "../logger" }
-wasefire-mutex = { path = "../mutex" }
 wasefire-scheduler = { path = "../scheduler" }
 wasefire-store = { path = "../store" }
 

--- a/crates/runner-nordic/src/main.rs
+++ b/crates/runner-nordic/src/main.rs
@@ -24,10 +24,12 @@ mod storage;
 mod systick;
 mod tasks;
 
+use core::cell::RefCell;
 use core::mem::MaybeUninit;
 
 use cortex_m::peripheral::NVIC;
 use cortex_m_rt::entry;
+use critical_section::Mutex;
 #[cfg(feature = "debug")]
 use defmt_rtt as _;
 use nrf52840_hal::ccm::{Ccm, DataRate};
@@ -48,7 +50,6 @@ use usb_device::device::{StringDescriptors, UsbDevice, UsbDeviceBuilder, UsbVidP
 use usbd_serial::{SerialPort, USB_CLASS_CDC};
 use wasefire_board_api::usb::serial::Serial;
 use wasefire_board_api::{Id, Support};
-use wasefire_mutex::Mutex;
 use wasefire_scheduler::Scheduler;
 use {wasefire_board_api as board, wasefire_logger as log};
 
@@ -83,10 +84,10 @@ struct State {
 
 pub enum Board {}
 
-static STATE: Mutex<Option<State>> = Mutex::new(None);
+static STATE: Mutex<RefCell<Option<State>>> = Mutex::new(RefCell::new(None));
 
 fn with_state<R>(f: impl FnOnce(&mut State) -> R) -> R {
-    f(STATE.lock().as_mut().unwrap())
+    critical_section::with(|cs| f(STATE.borrow_ref_mut(cs).as_mut().unwrap()))
 }
 
 #[entry]
@@ -142,7 +143,7 @@ fn main() -> ! {
         State { events, buttons, gpiote, serial, timers, ccm, leds, rng, storage, uarts, usb_dev };
     // We first set the board and then enable interrupts so that interrupts may assume the board is
     // always present.
-    STATE.lock().replace(state);
+    critical_section::with(|cs| STATE.replace(cs, Some(state)));
     for &interrupt in INTERRUPTS {
         unsafe { NVIC::unmask(interrupt) };
     }


### PR DESCRIPTION
Fixes a regression introduced by #300. Interrupts may lock the state while it being already locked by the main thread.