### PR TITLE
Permit multiple storage by sharing ownership of NVMC

### DIFF
--- a/crates/runner-nordic/Cargo.lock
+++ b/crates/runner-nordic/Cargo.lock
@@ -873,6 +873,7 @@ dependencies = [
  "wasefire-logger",
  "wasefire-scheduler",
  "wasefire-store",
+ "wasefire-sync",
 ]
 
 [[package]]

--- a/crates/runner-nordic/Cargo.toml
+++ b/crates/runner-nordic/Cargo.toml
@@ -28,6 +28,7 @@ wasefire-interpreter = { path = "../interpreter", optional = true }
 wasefire-logger = { path = "../logger" }
 wasefire-scheduler = { path = "../scheduler" }
 wasefire-store = { path = "../store" }
+wasefire-sync = { path = "../sync" }
 
 [features]
 software-crypto = ["wasefire-board-api/software-crypto"]

--- a/crates/runner-nordic/src/main.rs
+++ b/crates/runner-nordic/src/main.rs
@@ -131,7 +131,8 @@ fn main() -> ! {
         .build();
     let rng = Rng::new(p.RNG);
     let ccm = Ccm::init(p.CCM, p.AAR, DataRate::_1Mbit);
-    let storage = Some(Storage::new(p.NVMC));
+    storage::init(p.NVMC);
+    let storage = Some(Storage::new_store());
     let pins = uarte::Pins {
         txd: port0.p0_06.into_push_pull_output(gpio::Level::High).degrade(),
         rxd: port0.p0_08.into_floating_input().degrade(),

--- a/crates/runner-nordic/src/storage.rs
+++ b/crates/runner-nordic/src/storage.rs
@@ -14,7 +14,6 @@
 
 use alloc::borrow::Cow;
 use alloc::vec;
-use core::cell::RefCell;
 use core::slice;
 
 use embedded_storage::nor_flash::{
@@ -23,31 +22,60 @@ use embedded_storage::nor_flash::{
 use nrf52840_hal::nvmc::Nvmc;
 use nrf52840_hal::pac::NVMC;
 use wasefire_store::{self as store, StorageError, StorageIndex, StorageResult};
+use wasefire_sync::TakeCell;
 
 const PAGE_SIZE: usize = <Nvmc<NVMC>>::ERASE_SIZE;
 
-pub struct Storage(RefCell<Nvmc<NVMC>>);
+static DRIVER: TakeCell<NVMC> = TakeCell::new(None);
+
+pub fn init(nvmc: NVMC) {
+    DRIVER.put(nvmc);
+}
+
+pub struct Storage(TakeCell<&'static mut [u8]>);
+
+macro_rules! take_storage {
+    ($start:ident .. $end:ident) => {{
+        assert!(!wasefire_sync::executed!());
+        extern "C" {
+            static mut $start: u32;
+            static mut $end: u32;
+        }
+        let start = unsafe { &mut $start as *mut u32 as *mut u8 };
+        let end = unsafe { &mut $end as *mut u32 as usize };
+        let length = end.checked_sub(start as usize).unwrap();
+        assert_eq!(length % PAGE_SIZE, 0);
+        unsafe { slice::from_raw_parts_mut(start, length) }
+    }};
+}
 
 impl Storage {
-    pub fn new(nvmc: NVMC) -> Self {
-        // SAFETY: We assume only one NVMC instance can exist, so this function is called at most
-        // once, and so we call inner at most once.
-        Storage(RefCell::new(Nvmc::new(nvmc, unsafe { Self::inner() })))
+    pub fn new_store() -> Self {
+        Storage(TakeCell::new(Some(take_storage!(__sstore .. __estore))))
+    }
+}
+
+struct Helper<'a> {
+    storage: &'a TakeCell<&'static mut [u8]>,
+    nvmc: Option<Nvmc<NVMC>>,
+}
+
+impl<'a> Helper<'a> {
+    fn new(storage: &'a TakeCell<&'static mut [u8]>) -> Self {
+        let nvmc = Some(Nvmc::new(DRIVER.take(), storage.take()));
+        Helper { storage, nvmc }
     }
 
-    // SAFETY: Must be called at most once.
-    unsafe fn inner() -> &'static mut [u8] {
-        extern "C" {
-            static mut __sstore: u32;
-            static mut __estore: u32;
-        }
-        let start = &mut __sstore as *mut u32 as *mut u8;
-        let sstore = start as usize;
-        let estore = &mut __estore as *mut u32 as usize;
-        assert!(sstore < estore);
-        let length = estore - sstore;
-        assert_eq!(length % PAGE_SIZE, 0);
-        slice::from_raw_parts_mut(start, length)
+    fn nvmc(&mut self) -> &mut Nvmc<NVMC> {
+        self.nvmc.as_mut().unwrap()
+    }
+}
+
+impl<'a> Drop for Helper<'a> {
+    fn drop(&mut self) {
+        let (driver, storage) = self.nvmc.take().unwrap().free();
+        DRIVER.put(driver);
+        self.storage.put(storage);
     }
 }
 
@@ -61,7 +89,7 @@ impl store::Storage for Storage {
     }
 
     fn num_pages(&self) -> usize {
-        self.0.borrow().capacity() / PAGE_SIZE
+        self.0.with(|x| x.len()) / PAGE_SIZE
     }
 
     fn max_word_writes(&self) -> usize {
@@ -75,19 +103,22 @@ impl store::Storage for Storage {
     fn read_slice(&self, index: StorageIndex, length: usize) -> StorageResult<Cow<[u8]>> {
         let offset = offset(self, length, index)?;
         let mut result = vec![0; length];
-        self.0.borrow_mut().read(offset, &mut result).map_err(convert)?;
+        let mut helper = Helper::new(&self.0);
+        helper.nvmc().read(offset, &mut result).map_err(convert)?;
         Ok(Cow::Owned(result))
     }
 
     fn write_slice(&mut self, index: StorageIndex, value: &[u8]) -> StorageResult<()> {
         let offset = offset(self, value.len(), index)?;
-        self.0.get_mut().write(offset, value).map_err(convert)
+        let mut helper = Helper::new(&self.0);
+        helper.nvmc().write(offset, value).map_err(convert)
     }
 
     fn erase_page(&mut self, page: usize) -> StorageResult<()> {
         let from = offset(self, PAGE_SIZE, StorageIndex { page, byte: 0 })?;
         let to = from + PAGE_SIZE as u32;
-        self.0.get_mut().erase(from, to).map_err(convert)
+        let mut helper = Helper::new(&self.0);
+        helper.nvmc().erase(from, to).map_err(convert)
     }
 }
 

--- a/crates/sync/CHANGELOG.md
+++ b/crates/sync/CHANGELOG.md
@@ -2,4 +2,4 @@
 
 ## 0.1.0-git
 
-<!-- Increment to skip CHANGELOG.md test: 1 -->
+<!-- Increment to skip CHANGELOG.md test: 2 -->

--- a/crates/sync/src/lib.rs
+++ b/crates/sync/src/lib.rs
@@ -19,6 +19,8 @@
 
 pub use mutex::{Mutex, MutexGuard};
 pub use portable_atomic::*;
+pub use take::TakeCell;
 
 mod mutex;
 mod once;
+mod take;

--- a/crates/sync/src/take.rs
+++ b/crates/sync/src/take.rs
@@ -1,0 +1,65 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::Mutex;
+
+/// Convenient wrapper around `Mutex<Option<T>>`.
+pub struct TakeCell<T>(Mutex<Option<T>>);
+
+impl<T> TakeCell<T> {
+    /// Creates a new mutex-protected option.
+    pub const fn new(init: Option<T>) -> Self {
+        TakeCell(Mutex::new(init))
+    }
+
+    /// Takes the content of the option.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the mutex is locked or the option is empty.
+    #[track_caller]
+    pub fn take(&self) -> T {
+        self.0.lock().take().unwrap()
+    }
+
+    /// Replaces the content of the option.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the mutex is locked.
+    #[track_caller]
+    pub fn replace(&self, value: T) -> Option<T> {
+        self.0.lock().replace(value)
+    }
+
+    /// Sets the content of the option.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the mutex is locked or the option is not empty.
+    #[track_caller]
+    pub fn put(&self, value: T) {
+        assert!(self.replace(value).is_none())
+    }
+
+    /// Executes a closure on the content of the option.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the mutex is locked or the option is empty.
+    #[track_caller]
+    pub fn with<R>(&self, f: impl FnOnce(&mut T) -> R) -> R {
+        f(self.0.lock().as_mut().unwrap())
+    }
+}


### PR DESCRIPTION
This will be useful for #47 where the non-running flash partition will be a storage where the new firmware can be written.