### PR TITLE
Do not erase the flash to reset the storage on Nordic

### DIFF
--- a/crates/runner-nordic/memory.x
+++ b/crates/runner-nordic/memory.x
@@ -21,6 +21,7 @@ __flash_origin = __header_origin + __header_length;
 __flash_length = 0x00070000 - __header_length;
 __sother = 0x00010000 + (1 - RUNNER_SIDE) * 0x00070000;
 __eother = __sother + 0x00070000;
+/* Keep those values in sync with --reset-storage in xtask */
 __sstore = 0x000f0000;
 __estore = 0x00100000;
 

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -636,7 +636,7 @@ impl RunnerOptions {
             )?)
         });
         if self.reset_storage {
-            println!("Erasing the persistent storage");
+            println!("Erasing the persistent storage.");
             // Keep those values in sync with crates/runner-nordic/memory.x.
             flashing::erase_sectors(session.get()?, None, 240, 16)?;
         }


### PR DESCRIPTION
Otherwise the UICR registers are also reset which, among others, resets the PSELRESET registers that permits resetting the dev-board from the reset button.