### PR TITLE
Avoid nightly regression by using older nightly

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2023-12-15"
+channel = "nightly-2023-11-14"
 components = ["clippy", "llvm-tools", "rust-src", "rustfmt"]
 targets = [
   "i686-unknown-linux-gnu",


### PR DESCRIPTION
nightly-2023-12-15 breaks compilation of native applets by having symbols from `compiler_builtins` conflict between the applet static library and the platform during linking. This was not the case with nightly-2023-11-14.

This rollback is temporary until https://github.com/rust-lang/rust/issues/118609 is fixed or provides guidance on how to address this issue. Currently the only work-arounds are:

- Compile the applet to an object file (like `applet.o`) and let the platform link all the dependencies of the applet. This is not obvious to do generically at the moment.

- Require applets that need to compile natively to directly depend on `compiler_builtins` with the `weak-intrinsics` feature. If the dependency could been indirect, the prelude would have been the perfect place to introduce it. But given the dependency must be direct, this adds a small burden on applets.