### PR TITLE
Mention the board implementation in all events

### DIFF
--- a/crates/board/CHANGELOG.md
+++ b/crates/board/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Major
 
+- Mention the board implementation in all events
 - Update `platform::update::Api` to return `Error` instead of `usize`
 - Replace `Error` type with `wasefire-error`
 - Add `Api::Gpio` for low-level GPIOs

--- a/crates/board/src/lib.rs
+++ b/crates/board/src/lib.rs
@@ -113,7 +113,7 @@ pub enum Event<B: Api + ?Sized> {
     Button(button::Event<B>),
 
     /// Radio event.
-    Radio(radio::Event),
+    Radio(radio::Event, PhantomData<B>),
 
     /// Timer event.
     Timer(timer::Event<B>),
@@ -122,7 +122,7 @@ pub enum Event<B: Api + ?Sized> {
     Uart(uart::Event<B>),
 
     /// USB event.
-    Usb(usb::Event),
+    Usb(usb::Event, PhantomData<B>),
 }
 
 pub type Button<B> = <B as Api>::Button;

--- a/crates/board/src/radio.rs
+++ b/crates/board/src/radio.rs
@@ -14,6 +14,8 @@
 
 //! Radio interface.
 
+use core::marker::PhantomData;
+
 use crate::Unsupported;
 
 pub mod ble;
@@ -27,7 +29,7 @@ pub enum Event {
 
 impl<B: crate::Api> From<Event> for crate::Event<B> {
     fn from(event: Event) -> Self {
-        crate::Event::Radio(event)
+        crate::Event::Radio(event, PhantomData)
     }
 }
 

--- a/crates/board/src/usb.rs
+++ b/crates/board/src/usb.rs
@@ -14,6 +14,8 @@
 
 //! USB interface.
 
+use core::marker::PhantomData;
+
 use crate::Unsupported;
 
 pub mod serial;
@@ -27,7 +29,7 @@ pub enum Event {
 
 impl<B: crate::Api> From<Event> for crate::Event<B> {
     fn from(event: Event) -> Self {
-        crate::Event::Usb(event)
+        crate::Event::Usb(event, PhantomData)
     }
 }
 

--- a/crates/scheduler/CHANGELOG.md
+++ b/crates/scheduler/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Minor
 
+- Migrate to all events mentioning the board implementation
 - Migrate to `platform::update` returning `Error`
 - Migrate to `wasefire-error`
 - Support `gpio` module

--- a/crates/scheduler/src/event.rs
+++ b/crates/scheduler/src/event.rs
@@ -64,10 +64,10 @@ impl<'a, B: Board> From<&'a Event<B>> for Key<B> {
     fn from(event: &'a Event<B>) -> Self {
         match event {
             Event::Button(event) => Key::Button(event.into()),
-            Event::Radio(event) => Key::Radio(event.into()),
+            Event::Radio(event, _) => Key::Radio(event.into()),
             Event::Timer(event) => Key::Timer(event.into()),
             Event::Uart(event) => Key::Uart(event.into()),
-            Event::Usb(event) => Key::Usb(event.into()),
+            Event::Usb(event, _) => Key::Usb(event.into()),
         }
     }
 }
@@ -109,10 +109,10 @@ pub fn process<B: Board>(scheduler: &mut Scheduler<B>, event: Event<B>) {
     let mut params = vec![*func, *data];
     match event {
         Event::Button(event) => button::process(event, &mut params),
-        Event::Radio(event) => radio::process(event),
+        Event::Radio(event, _) => radio::process(event),
         Event::Timer(_) => timer::process(),
         Event::Uart(_) => uart::process(),
-        Event::Usb(event) => usb::process(event),
+        Event::Usb(event, _) => usb::process(event),
     }
     #[cfg(feature = "wasm")]
     {


### PR DESCRIPTION
This is useful for #50 where only a subset of events may be present, because if none of them mentions the board implementation, then the compiler cannot guess the board implementation.