### PR TITLE
Correctly gate events of nested APIs

### DIFF
--- a/crates/scheduler/CHANGELOG.md
+++ b/crates/scheduler/CHANGELOG.md
@@ -25,6 +25,7 @@
 
 ### Patch
 
+- Correctly gate events of nested APIs
 - Rename `debug` internal feature to `internal-debug`
 - Fix double-lock issue for native callbacks
 - Fix parsing of `WASEFIRE_MEMORY_PAGE_COUNT`

--- a/crates/scheduler/src/event/radio.rs
+++ b/crates/scheduler/src/event/radio.rs
@@ -15,10 +15,12 @@
 use wasefire_board_api::radio::Event;
 use wasefire_board_api::Api as Board;
 
+#[cfg(all(feature = "board-api-radio-ble", feature = "applet-api-radio-ble"))]
 pub mod ble;
 
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Key {
+    #[cfg(all(feature = "board-api-radio-ble", feature = "applet-api-radio-ble"))]
     Ble(ble::Key),
 }
 
@@ -31,6 +33,7 @@ impl<B: Board> From<Key> for crate::event::Key<B> {
 impl<'a> From<&'a Event> for Key {
     fn from(event: &'a Event) -> Self {
         match event {
+            #[cfg(all(feature = "board-api-radio-ble", feature = "applet-api-radio-ble"))]
             Event::Ble(event) => Key::Ble(event.into()),
         }
     }
@@ -38,6 +41,7 @@ impl<'a> From<&'a Event> for Key {
 
 pub fn process(event: Event) {
     match event {
+        #[cfg(all(feature = "board-api-radio-ble", feature = "applet-api-radio-ble"))]
         Event::Ble(_) => ble::process(),
     }
 }

--- a/crates/scheduler/src/event/usb.rs
+++ b/crates/scheduler/src/event/usb.rs
@@ -15,10 +15,12 @@
 use wasefire_board_api::usb::Event;
 use wasefire_board_api::Api as Board;
 
+#[cfg(all(feature = "board-api-usb-serial", feature = "applet-api-usb-serial"))]
 pub mod serial;
 
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Key {
+    #[cfg(all(feature = "board-api-usb-serial", feature = "applet-api-usb-serial"))]
     Serial(serial::Key),
 }
 
@@ -31,6 +33,7 @@ impl<B: Board> From<Key> for crate::event::Key<B> {
 impl<'a> From<&'a Event> for Key {
     fn from(event: &'a Event) -> Self {
         match event {
+            #[cfg(all(feature = "board-api-usb-serial", feature = "applet-api-usb-serial"))]
             Event::Serial(event) => Key::Serial(event.into()),
         }
     }
@@ -38,6 +41,7 @@ impl<'a> From<&'a Event> for Key {
 
 pub fn process(event: Event) {
     match event {
+        #[cfg(all(feature = "board-api-usb-serial", feature = "applet-api-usb-serial"))]
         Event::Serial(_) => serial::process(),
     }
 }


### PR DESCRIPTION
It's not easy to test those without creating impossible configurations by enabling internal features. They will anyway be eventually tested when siblings are added, which is when it matters.