### PR TITLE
Add --web-host and --web-port flags to xtask and host runner

### DIFF
--- a/crates/runner-host/Cargo.lock
+++ b/crates/runner-host/Cargo.lock
@@ -62,10 +62,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b09b5178381e0874812a9b157f7fe84982617e48f71f4e3235482775e5b540"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "utf8parse",
+]
+
+[[package]]
 name = "anstyle"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "anyhow"
@@ -232,8 +274,10 @@ version = "4.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4df4df40ec50c46000231c914968278b1eb05098cf8f1b3a518a95030e71d1c7"
 dependencies = [
+ "anstream",
  "anstyle",
  "clap_lex",
+ "strsim",
 ]
 
 [[package]]
@@ -253,6 +297,12 @@ name = "clap_lex"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "const-oid"
@@ -1193,6 +1243,7 @@ name = "runner-host"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "clap",
  "data-encoding",
  "env_logger",
  "rand",
@@ -1420,6 +1471,12 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "subtle"
@@ -1706,6 +1763,12 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "version_check"

--- a/crates/runner-host/Cargo.toml
+++ b/crates/runner-host/Cargo.toml
@@ -11,6 +11,7 @@ anyhow = "1.0.79"
 data-encoding = "2.5.0"
 env_logger = "0.10.2"
 rand = "0.8.5"
+clap = { version = "4.4.18", features = ["derive"] }
 tokio = { version = "1.35.1", features = ["full"] }
 usb-device = { version = "0.3.1", optional = true }
 usbd-serial = { version = "0.2.0", optional = true }

--- a/crates/runner-host/Cargo.toml
+++ b/crates/runner-host/Cargo.toml
@@ -8,10 +8,10 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.79"
+clap = { version = "4.4.18", features = ["derive"] }
 data-encoding = "2.5.0"
 env_logger = "0.10.2"
 rand = "0.8.5"
-clap = { version = "4.4.18", features = ["derive"] }
 tokio = { version = "1.35.1", features = ["full"] }
 usb-device = { version = "0.3.1", optional = true }
 usbd-serial = { version = "0.2.0", optional = true }

--- a/crates/runner-host/src/main.rs
+++ b/crates/runner-host/src/main.rs
@@ -48,16 +48,17 @@ struct WebOptions {
     /// Host to start the webserver.
     #[clap(long, default_value = "127.0.0.1")]
     web_host: String,
+
     /// Port to start the webserver.
     #[clap(long, default_value = "5000")]
-    web_port: usize,    
+    web_port: u16,
 }
-
 
 #[tokio::main]
 async fn main() -> Result<()> {
     env_logger::init();
-    let _flags = Flags::parse();
+    #[cfg_attr(not(feature = "web"), allow(unused_variables))]
+    let flags = Flags::parse();
     // TODO: Should be a flag controlled by xtask (value is duplicated there).
     const STORAGE: &str = "../../target/wasefire/storage.bin";
     let options = FileOptions { word_size: 4, page_size: 4096, num_pages: 16 };
@@ -76,7 +77,7 @@ async fn main() -> Result<()> {
                 }
             }
         });
-        let url = format!("{}:{}", _flags.web_options.web_host, _flags.web_options.web_port);
+        let url = format!("{}:{}", flags.web_options.web_host, flags.web_options.web_port);
         web_server::Client::new(&url, sender).await?
     };
     *STATE.lock().unwrap() = Some(board::State {

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -216,11 +216,12 @@ struct RunnerOptions {
     web: bool,
 
     /// Host to start the webserver.
-    #[clap(long, default_value = "127.0.0.1")]
-    web_host: String,
+    #[clap(long)]
+    web_host: Option<String>,
+
     /// Port to start the webserver.
-    #[clap(long, default_value = "5000")]
-    web_port: usize,
+    #[clap(long)]
+    web_port: Option<u16>,
 
     /// Measures bloat after building.
     // TODO: Make this a subcommand taking additional options for cargo bloat.
@@ -566,10 +567,12 @@ impl RunnerOptions {
         }
         if self.name == "host" && self.web {
             features.push("web".to_string());
-            runner_args.push("--web-host".to_string());
-            runner_args.push(self.web_host.clone());
-            runner_args.push("--web-port".to_string());
-            runner_args.push(format!("{}", self.web_port));
+            if let Some(host) = &self.web_host {
+                runner_args.push(format!("--web-host={host}"));
+            }
+            if let Some(port) = &self.web_port {
+                runner_args.push(format!("--web-port={port}"));
+            }
         }
         if self.stack_sizes.is_some() {
             rustflags.push("-Z emit-stack-sizes".to_string());


### PR DESCRIPTION
This change allows developer to customize the web-server host & port, so it's easier to develop in remote environments.