### PR TITLE
Update scorecard action from v2 to v2.3.1

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
-      - uses: ossf/scorecard-action@v2
+      - uses: ossf/scorecard-action@v2.3.1
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
Apparently v2 does not exist.