### PR TITLE
Simplify cfg(all) between board and applet features in scheduler

### DIFF
--- a/crates/scheduler/CHANGELOG.md
+++ b/crates/scheduler/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Patch
 
+- Simplify `#[cfg(all)]` attributes between board and applet features
 - Update dependencies
 - Fix HKDF-SHA-384 for outputs longer than 32 bytes
 

--- a/crates/scheduler/src/event.rs
+++ b/crates/scheduler/src/event.rs
@@ -23,15 +23,15 @@ use wasefire_logger as log;
 
 use crate::Scheduler;
 
-#[cfg(all(feature = "board-api-button", feature = "applet-api-button"))]
+#[cfg(feature = "board-api-button")]
 pub mod button;
-#[cfg(all(feature = "internal-board-api-radio", feature = "internal-applet-api-radio"))]
+#[cfg(feature = "internal-board-api-radio")]
 pub mod radio;
-#[cfg(all(feature = "board-api-timer", feature = "applet-api-timer"))]
+#[cfg(feature = "board-api-timer")]
 pub mod timer;
-#[cfg(all(feature = "board-api-uart", feature = "applet-api-uart"))]
+#[cfg(feature = "board-api-uart")]
 pub mod uart;
-#[cfg(all(feature = "internal-board-api-usb", feature = "internal-applet-api-usb"))]
+#[cfg(feature = "internal-board-api-usb")]
 pub mod usb;
 
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
@@ -44,15 +44,15 @@ pub struct InstId;
 #[derivative(PartialEq(bound = ""), Eq(bound = ""), Ord(bound = ""))]
 #[derivative(Ord = "feature_allow_slow_enum")]
 pub enum Key<B: Board> {
-    #[cfg(all(feature = "board-api-button", feature = "applet-api-button"))]
+    #[cfg(feature = "board-api-button")]
     Button(button::Key<B>),
-    #[cfg(all(feature = "internal-board-api-radio", feature = "internal-applet-api-radio"))]
+    #[cfg(feature = "internal-board-api-radio")]
     Radio(radio::Key),
-    #[cfg(all(feature = "board-api-timer", feature = "applet-api-timer"))]
+    #[cfg(feature = "board-api-timer")]
     Timer(timer::Key<B>),
-    #[cfg(all(feature = "board-api-uart", feature = "applet-api-uart"))]
+    #[cfg(feature = "board-api-uart")]
     Uart(uart::Key<B>),
-    #[cfg(all(feature = "internal-board-api-usb", feature = "internal-applet-api-usb"))]
+    #[cfg(feature = "internal-board-api-usb")]
     Usb(usb::Key),
     _Impossible(Impossible<B>),
 }

--- a/crates/scheduler/src/event/radio.rs
+++ b/crates/scheduler/src/event/radio.rs
@@ -15,12 +15,12 @@
 use wasefire_board_api::radio::Event;
 use wasefire_board_api::Api as Board;
 
-#[cfg(all(feature = "board-api-radio-ble", feature = "applet-api-radio-ble"))]
+#[cfg(feature = "board-api-radio-ble")]
 pub mod ble;
 
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Key {
-    #[cfg(all(feature = "board-api-radio-ble", feature = "applet-api-radio-ble"))]
+    #[cfg(feature = "board-api-radio-ble")]
     Ble(ble::Key),
 }
 
@@ -33,7 +33,7 @@ impl<B: Board> From<Key> for crate::event::Key<B> {
 impl<'a> From<&'a Event> for Key {
     fn from(event: &'a Event) -> Self {
         match event {
-            #[cfg(all(feature = "board-api-radio-ble", feature = "applet-api-radio-ble"))]
+            #[cfg(feature = "board-api-radio-ble")]
             Event::Ble(event) => Key::Ble(event.into()),
         }
     }
@@ -41,7 +41,7 @@ impl<'a> From<&'a Event> for Key {
 
 pub fn process(event: Event) {
     match event {
-        #[cfg(all(feature = "board-api-radio-ble", feature = "applet-api-radio-ble"))]
+        #[cfg(feature = "board-api-radio-ble")]
         Event::Ble(_) => ble::process(),
     }
 }

--- a/crates/scheduler/src/event/usb.rs
+++ b/crates/scheduler/src/event/usb.rs
@@ -15,12 +15,12 @@
 use wasefire_board_api::usb::Event;
 use wasefire_board_api::Api as Board;
 
-#[cfg(all(feature = "board-api-usb-serial", feature = "applet-api-usb-serial"))]
+#[cfg(feature = "board-api-usb-serial")]
 pub mod serial;
 
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Key {
-    #[cfg(all(feature = "board-api-usb-serial", feature = "applet-api-usb-serial"))]
+    #[cfg(feature = "board-api-usb-serial")]
     Serial(serial::Key),
 }
 
@@ -33,7 +33,7 @@ impl<B: Board> From<Key> for crate::event::Key<B> {
 impl<'a> From<&'a Event> for Key {
     fn from(event: &'a Event) -> Self {
         match event {
-            #[cfg(all(feature = "board-api-usb-serial", feature = "applet-api-usb-serial"))]
+            #[cfg(feature = "board-api-usb-serial")]
             Event::Serial(event) => Key::Serial(event.into()),
         }
     }
@@ -41,7 +41,7 @@ impl<'a> From<&'a Event> for Key {
 
 pub fn process(event: Event) {
     match event {
-        #[cfg(all(feature = "board-api-usb-serial", feature = "applet-api-usb-serial"))]
+        #[cfg(feature = "board-api-usb-serial")]
         Event::Serial(_) => serial::process(),
     }
 }

--- a/crates/scheduler/src/lib.rs
+++ b/crates/scheduler/src/lib.rs
@@ -29,16 +29,16 @@ use core::marker::PhantomData;
 use derivative::Derivative;
 use event::Key;
 use wasefire_applet_api::{self as api, Api, ArrayU32, Dispatch, Id, Signature, U32};
-#[cfg(all(feature = "board-api-storage", feature = "internal-applet-api-store"))]
+#[cfg(feature = "board-api-storage")]
 use wasefire_board_api::Singleton;
-#[cfg(all(feature = "board-api-timer", feature = "applet-api-timer"))]
+#[cfg(feature = "board-api-timer")]
 use wasefire_board_api::Support;
 use wasefire_board_api::{self as board, Api as Board};
 use wasefire_error::Error;
 #[cfg(feature = "wasm")]
 use wasefire_interpreter::{self as interpreter, Call, Module, RunAnswer, Val};
 use wasefire_logger as log;
-#[cfg(all(feature = "board-api-storage", feature = "internal-applet-api-store"))]
+#[cfg(feature = "board-api-storage")]
 use wasefire_store as store;
 
 use crate::applet::store::{Memory, Store, StoreApi};
@@ -87,11 +87,11 @@ impl<B: Board> Events<B> {
 }
 
 pub struct Scheduler<B: Board> {
-    #[cfg(all(feature = "board-api-storage", feature = "internal-applet-api-store"))]
+    #[cfg(feature = "board-api-storage")]
     store: store::Store<B::Storage>,
     host_funcs: Vec<Api<Id>>,
     applet: Applet<B>,
-    #[cfg(all(feature = "board-api-timer", feature = "applet-api-timer"))]
+    #[cfg(feature = "board-api-timer")]
     timers: Vec<Option<Timer>>,
     #[cfg(feature = "internal-debug")]
     perf: perf::Perf<B>,
@@ -296,11 +296,11 @@ impl<B: Board> Scheduler<B> {
         #[cfg(feature = "native")]
         let applet = Applet::default();
         Self {
-            #[cfg(all(feature = "board-api-storage", feature = "internal-applet-api-store"))]
+            #[cfg(feature = "board-api-storage")]
             store: store::Store::new(board::Storage::<B>::take().unwrap()).ok().unwrap(),
             host_funcs,
             applet,
-            #[cfg(all(feature = "board-api-timer", feature = "applet-api-timer"))]
+            #[cfg(feature = "board-api-timer")]
             timers: alloc::vec![None; board::Timer::<B>::SUPPORT],
             #[cfg(feature = "internal-debug")]
             perf: perf::Perf::default(),


### PR DESCRIPTION
Enabling a board feature automatically enables the applet feature, so it's enough to check for the board feature.