### PR TITLE
Remove unecessary calls to call.read()

### DIFF
--- a/crates/scheduler/src/call/button.rs
+++ b/crates/scheduler/src/call/button.rs
@@ -32,7 +32,6 @@ pub fn process<B: Board>(call: Api<DispatchSchedulerCall<B>>) {
 }
 
 fn count<B: Board>(call: SchedulerCall<B, api::count::Sig>) {
-    let api::count::Params {} = call.read();
     #[cfg(feature = "board-api-button")]
     let count = board::Button::<B>::SUPPORT as u32;
     #[cfg(not(feature = "board-api-button"))]

--- a/crates/scheduler/src/call/crypto/ccm.rs
+++ b/crates/scheduler/src/call/crypto/ccm.rs
@@ -34,7 +34,6 @@ pub fn process<B: Board>(call: Api<DispatchSchedulerCall<B>>) {
 }
 
 fn is_supported<B: Board>(call: SchedulerCall<B, api::is_supported::Sig>) {
-    let api::is_supported::Params {} = call.read();
     #[cfg(feature = "board-api-crypto-aes128-ccm")]
     let supported = bool::from(board::crypto::Aes128Ccm::<B>::SUPPORT) as u32;
     #[cfg(not(feature = "board-api-crypto-aes128-ccm"))]

--- a/crates/scheduler/src/call/crypto/gcm.rs
+++ b/crates/scheduler/src/call/crypto/gcm.rs
@@ -35,7 +35,6 @@ pub fn process<B: Board>(call: Api<DispatchSchedulerCall<B>>) {
 }
 
 fn support<B: Board>(call: SchedulerCall<B, api::support::Sig>) {
-    let api::support::Params {} = call.read();
     #[cfg(feature = "board-api-crypto-aes256-gcm")]
     let support = {
         use wasefire_applet_api::crypto::gcm::Support;
@@ -50,7 +49,6 @@ fn support<B: Board>(call: SchedulerCall<B, api::support::Sig>) {
 
 #[cfg(feature = "board-api-crypto-aes256-gcm")]
 fn tag_length<B: Board>(call: SchedulerCall<B, api::tag_length::Sig>) {
-    let api::tag_length::Params {} = call.read();
     call.reply(Ok(Ok(tag_len::<B>() as u32)))
 }
 

--- a/crates/scheduler/src/call/gpio.rs
+++ b/crates/scheduler/src/call/gpio.rs
@@ -34,7 +34,6 @@ pub fn process<B: Board>(call: Api<DispatchSchedulerCall<B>>) {
 }
 
 fn count<B: Board>(call: SchedulerCall<B, api::count::Sig>) {
-    let api::count::Params {} = call.read();
     #[cfg(feature = "board-api-gpio")]
     let count = board::Gpio::<B>::SUPPORT as u32;
     #[cfg(not(feature = "board-api-gpio"))]

--- a/crates/scheduler/src/call/led.rs
+++ b/crates/scheduler/src/call/led.rs
@@ -32,7 +32,6 @@ pub fn process<B: Board>(call: Api<DispatchSchedulerCall<B>>) {
 }
 
 fn count<B: Board>(call: SchedulerCall<B, api::count::Sig>) {
-    let api::count::Params {} = call.read();
     #[cfg(feature = "board-api-led")]
     let count = board::Led::<B>::SUPPORT as u32;
     #[cfg(not(feature = "board-api-led"))]

--- a/crates/scheduler/src/call/platform.rs
+++ b/crates/scheduler/src/call/platform.rs
@@ -55,6 +55,5 @@ fn version<B: Board>(mut call: SchedulerCall<B, api::version::Sig>) {
 
 #[cfg(feature = "board-api-platform")]
 fn reboot<B: Board>(call: SchedulerCall<B, api::reboot::Sig>) {
-    let api::reboot::Params {} = call.read();
     call.reply(Ok(board::Platform::<B>::reboot()));
 }

--- a/crates/scheduler/src/call/platform/update.rs
+++ b/crates/scheduler/src/call/platform/update.rs
@@ -36,7 +36,6 @@ pub fn process<B: Board>(call: Api<DispatchSchedulerCall<B>>) {
 }
 
 fn is_supported<B: Board>(call: SchedulerCall<B, api::is_supported::Sig>) {
-    let api::is_supported::Params {} = call.read();
     #[cfg(feature = "board-api-platform-update")]
     let supported = board::platform::Update::<B>::SUPPORT as u32;
     #[cfg(not(feature = "board-api-platform-update"))]
@@ -93,7 +92,6 @@ fn process_<B: Board>(mut call: SchedulerCall<B, api::process::Sig>) {
 
 #[cfg(feature = "board-api-platform-update")]
 fn finalize<B: Board>(call: SchedulerCall<B, api::finalize::Sig>) {
-    let api::finalize::Params {} = call.read();
     let result = try { board::platform::Update::<B>::finalize() };
     call.reply(result);
 }

--- a/crates/scheduler/src/call/scheduling.rs
+++ b/crates/scheduler/src/call/scheduling.rs
@@ -26,19 +26,16 @@ pub fn process<B: Board>(call: Api<DispatchSchedulerCall<B>>) {
 }
 
 fn wait_for_callback<B: Board>(mut call: SchedulerCall<B, api::wait_for_callback::Sig>) {
-    let api::wait_for_callback::Params {} = call.read();
     if call.scheduler().process_event() {
         call.reply(Ok(Ok(())));
     }
 }
 
 fn num_pending_callbacks<B: Board>(mut call: SchedulerCall<B, api::num_pending_callbacks::Sig>) {
-    let api::num_pending_callbacks::Params {} = call.read();
     let count = call.applet().len() as u32;
     call.reply(Ok(Ok(count)));
 }
 
 fn abort<B: Board>(call: SchedulerCall<B, api::abort::Sig>) {
-    let api::abort::Params {} = call.read();
     call.reply_(Err(crate::Trap));
 }

--- a/crates/scheduler/src/call/uart.rs
+++ b/crates/scheduler/src/call/uart.rs
@@ -41,7 +41,6 @@ pub fn process<B: Board>(call: Api<DispatchSchedulerCall<B>>) {
 }
 
 fn count<B: Board>(call: SchedulerCall<B, api::count::Sig>) {
-    let api::count::Params {} = call.read();
     #[cfg(feature = "board-api-uart")]
     let count = board::Uart::<B>::SUPPORT as u32;
     #[cfg(not(feature = "board-api-uart"))]

--- a/crates/scheduler/src/call/usb/serial.rs
+++ b/crates/scheduler/src/call/usb/serial.rs
@@ -96,7 +96,6 @@ fn unregister<B: Board>(mut call: SchedulerCall<B, api::unregister::Sig>) {
 
 #[cfg(feature = "board-api-usb-serial")]
 fn flush<B: Board>(call: SchedulerCall<B, api::flush::Sig>) {
-    let api::flush::Params {} = call.read();
     let result = try { board::usb::Serial::<B>::flush() };
     call.reply(result);
 }


### PR DESCRIPTION
I believe these calls do not require any args and that having them around adds some minor confusion.