### PR TITLE
Add LastError trait to check for error after using RustCrypto API

### DIFF
--- a/crates/board/CHANGELOG.md
+++ b/crates/board/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.6.1-git
 
+### Major
+
+- Add `LastError` trait to check for error after using RustCrypto API.
+
 ### Patch
 
 - Document all public API

--- a/crates/board/CHANGELOG.md
+++ b/crates/board/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Major
 
-- Add `LastError` trait to check for error after using RustCrypto API.
+- Add `LastError` trait to check for error after using RustCrypto API
 
 ### Patch
 

--- a/crates/board/CHANGELOG.md
+++ b/crates/board/CHANGELOG.md
@@ -1,10 +1,16 @@
 # Changelog
 
-## 0.6.1-git
+## 0.7.0-git
 
 ### Major
 
-- Add `LastError` trait to check for error after using RustCrypto API
+- Change `crypto::{Hash,Hmac}` to depend on `crypto::WithError`
+
+### Minor
+
+- Add `crypto::{HashApi,HmacApi}` helpers for `crypto::{Hash,Hmac}`
+- Add `crypto::NoError` helper for `crypto::WithError`
+- Add `crypto::WithError` to add error support to RustCrypto (fix #176)
 
 ### Patch
 

--- a/crates/board/Cargo.lock
+++ b/crates/board/Cargo.lock
@@ -860,7 +860,7 @@ dependencies = [
 
 [[package]]
 name = "wasefire-board-api"
-version = "0.6.1-git"
+version = "0.7.0-git"
 dependencies = [
  "aead",
  "aes",

--- a/crates/board/Cargo.toml
+++ b/crates/board/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasefire-board-api"
-version = "0.6.1-git"
+version = "0.7.0-git"
 authors = ["Julien Cretin <cretin@google.com>"]
 license = "Apache-2.0"
 publish = true

--- a/crates/board/src/crypto.rs
+++ b/crates/board/src/crypto.rs
@@ -203,14 +203,14 @@ pub trait LastError {
 #[cfg(feature = "software-crypto-sha256")]
 impl LastError for sha2::Sha256 {
     fn last_error(&self) -> Result<(), Error> {
-        todo!()
+        Ok(())
     }
 }
 
 #[cfg(feature = "software-crypto-sha384")]
 impl LastError for sha2::Sha384 {
     fn last_error(&self) -> Result<(), Error> {
-        todo!()
+        Ok(())
     }
 }
 
@@ -226,7 +226,7 @@ impl<
     > LastError for hmac::SimpleHmac<D>
 {
     fn last_error(&self) -> Result<(), Error> {
-        todo!()
+        Ok(())
     }
 }
 

--- a/crates/board/src/crypto.rs
+++ b/crates/board/src/crypto.rs
@@ -200,6 +200,36 @@ pub trait LastError {
     fn last_error(&self) -> Result<(), Error>;
 }
 
+#[cfg(feature = "software-crypto-sha256")]
+impl LastError for sha2::Sha256 {
+    fn last_error(&self) -> Result<(), Error> {
+        todo!()
+    }
+}
+
+#[cfg(feature = "software-crypto-sha384")]
+impl LastError for sha2::Sha384 {
+    fn last_error(&self) -> Result<(), Error> {
+        todo!()
+    }
+}
+
+#[cfg(feature = "internal-software-crypto-hmac")]
+impl<
+        D: Support<bool>
+            + Default
+            + BlockSizeUser
+            + Update
+            + FixedOutputReset
+            + HashMarker
+            + LastError,
+    > LastError for hmac::SimpleHmac<D>
+{
+    fn last_error(&self) -> Result<(), Error> {
+        todo!()
+    }
+}
+
 /// Wrapper API around Hash that calls last_error.
 #[cfg(feature = "internal-api-crypto-hash")]
 pub struct HashApi<T: Hash>(T);

--- a/crates/board/src/crypto.rs
+++ b/crates/board/src/crypto.rs
@@ -16,7 +16,6 @@
 
 #[cfg(feature = "internal-api-crypto-hash")]
 use crypto_common::BlockSizeUser;
-use crypto_common::Key;
 #[cfg(feature = "internal-api-crypto-hmac")]
 use crypto_common::KeyInit;
 #[cfg(any(feature = "internal-api-crypto-hash", feature = "internal-api-crypto-hmac"))]
@@ -197,7 +196,7 @@ impl<T: Hash> HashApi<T> {
         let hash = T::default();
         let error = T::last_error(&hash);
         match error {
-            Ok(()) => hash,
+            Ok(()) => Ok(hash),
             Err(error) => Err(error),
         }
     }
@@ -205,10 +204,10 @@ impl<T: Hash> HashApi<T> {
 
 impl<T: Hmac> HmacApi<T> {
     pub fn new(key: &[u8]) -> Result<Self, Error> {
-        let hash = T::new_from_slice(key)?;
+        let hash = T::new_from_slice(key).map_err(|_| Error)?;
         let error = T::last_error(&hash);
         match error {
-            Ok(()) => hash,
+            Ok(()) => Ok(hash),
             Err(error) => Err(error),
         }
     }

--- a/crates/board/src/crypto.rs
+++ b/crates/board/src/crypto.rs
@@ -191,41 +191,29 @@ pub trait LastError {
     fn last_error(&self) -> Result<(), Error>;
 }
 
-// Wrapper API around Hash that calls last_error().
+/// Wrapper API around Hash that calls last_error.
 #[cfg(feature = "internal-api-crypto-hash")]
-#[allow(missing_docs)]
 pub struct HashApi<T: Hash>(T);
 
-// Wrapper API around Hmac that calls last_error().
+/// Wrapper API around Hmac that calls last_error.
 #[cfg(feature = "internal-api-crypto-hmac")]
-#[allow(missing_docs)]
 pub struct HmacApi<T: Hmac>(T);
 
-#[allow(missing_docs)]
 #[cfg(feature = "internal-api-crypto-hash")]
 impl<T: Hash> HashApi<T> {
-    // Constructor of HashApi
+    /// Constructor of HmacApi
     pub fn new() -> Result<Self, Error> {
         let hash = T::default();
-        let error = T::last_error(&hash);
-        match error {
-            Ok(()) => Ok(HashApi(hash)),
-            Err(error) => Err(error),
-        }
+        hash.last_error().map(|()| HashApi(hash))
     }
 }
 
-#[allow(missing_docs)]
 #[cfg(feature = "internal-api-crypto-hmac")]
 impl<T: Hmac> HmacApi<T> {
-    // Constructor of HmacApi
+    /// Constructor of HmacApi
     pub fn new(key: &[u8]) -> Result<Self, Error> {
         let hash =
             T::new_from_slice(key).map_err(|_| Error::new(Space::User, Code::InvalidLength))?;
-        let error = T::last_error(&hash);
-        match error {
-            Ok(()) => Ok(HmacApi(hash)),
-            Err(error) => Err(error),
-        }
+        hash.last_error().map(|()| HmacApi(hash))
     }
 }

--- a/crates/board/src/crypto.rs
+++ b/crates/board/src/crypto.rs
@@ -210,19 +210,19 @@ pub struct HmacApi<T: Hmac>(T);
 
 #[cfg(feature = "internal-api-crypto-hash")]
 impl<T: Hash> HashApi<T> {
-    /// Create a hash wrapper.
+    /// Creates a hash wrapper.
     pub fn new() -> Result<Self, Error> {
         let hash = T::default();
         hash.last_error().map(|()| HashApi(hash))
     }
 
-    /// Update the hash with the provided data.
+    /// Updates the hash with the provided data.
     pub fn update(&mut self, data: &[u8]) -> Result<(), Error> {
         self.0.update(data);
         self.0.last_error()
     }
 
-    /// Finalize the hash to the provided output.
+    /// Finalizes the hash to the provided output.
     pub fn finalize_into(mut self, out: &mut Output<T>) -> Result<(), Error> {
         self.0.finalize_into_reset(out);
         self.0.last_error()
@@ -231,7 +231,7 @@ impl<T: Hash> HashApi<T> {
 
 #[cfg(feature = "internal-api-crypto-hmac")]
 impl<T: Hmac> HmacApi<T> {
-    /// Create a HMAC wrapper.
+    /// Creates a HMAC wrapper.
     pub fn new(key: &[u8]) -> Result<Self, Error> {
         let hash = T::new_from_slice(key).map_err(|_| Error::user(Code::InvalidLength))?;
         hash.last_error().map(|()| HmacApi(hash))

--- a/crates/board/src/crypto.rs
+++ b/crates/board/src/crypto.rs
@@ -270,13 +270,13 @@ impl<T: Hmac> HmacApi<T> {
         hash.last_error().map(|()| HmacApi(hash))
     }
 
-    /// Update the HMAC with the provided data.
+    /// Updates the HMAC with the provided data.
     pub fn update(&mut self, data: &[u8]) -> Result<(), Error> {
         self.0.update(data);
         self.0.last_error()
     }
 
-    /// Finalize the HMAC to the provided output.
+    /// Finalizes the HMAC to the provided output.
     pub fn finalize_into(mut self, out: &mut Output<T>) -> Result<(), Error> {
         self.0.finalize_into_reset(out);
         self.0.last_error()

--- a/crates/board/src/crypto.rs
+++ b/crates/board/src/crypto.rs
@@ -203,6 +203,7 @@ pub trait LastError {
 #[cfg(feature = "software-crypto-sha256")]
 impl LastError for sha2::Sha256 {
     fn last_error(&self) -> Result<(), Error> {
+        // TODO: Implement the error.
         Ok(())
     }
 }
@@ -210,6 +211,7 @@ impl LastError for sha2::Sha256 {
 #[cfg(feature = "software-crypto-sha384")]
 impl LastError for sha2::Sha384 {
     fn last_error(&self) -> Result<(), Error> {
+        // TODO: Implement the error.
         Ok(())
     }
 }
@@ -226,6 +228,7 @@ impl<
     > LastError for hmac::SimpleHmac<D>
 {
     fn last_error(&self) -> Result<(), Error> {
+        // TODO: Implement the error.
         Ok(())
     }
 }

--- a/crates/board/src/crypto.rs
+++ b/crates/board/src/crypto.rs
@@ -88,23 +88,19 @@ pub trait Hmac:
 }
 
 #[cfg(feature = "internal-api-crypto-hash")]
-impl<
-        T: Support<bool>
-            + Send
-            + Default
-            + BlockSizeUser
-            + Update
-            + FixedOutputReset
-            + HashMarker
-            + LastError,
-    > Hash for T
+impl<T> Hash for T where T: Support<bool>
+        + Send
+        + Default
+        + BlockSizeUser
+        + Update
+        + FixedOutputReset
+        + HashMarker
+        + LastError
 {
 }
 #[cfg(feature = "internal-api-crypto-hmac")]
-impl<T: Support<bool> + Send + KeyInit + Update + FixedOutputReset + MacMarker + LastError> Hmac
-    for T
-{
-}
+impl<T> Hmac for T where T: Support<bool> + Send + KeyInit + Update + FixedOutputReset + MacMarker + LastError
+{}
 
 /// AES-128-CCM interface.
 #[cfg(feature = "api-crypto-aes128-ccm")]
@@ -177,15 +173,8 @@ impl crate::Supported for sha2::Sha256 {}
 impl crate::Supported for sha2::Sha384 {}
 
 #[cfg(feature = "internal-software-crypto-hmac")]
-impl<
-        D: Support<bool>
-            + Default
-            + BlockSizeUser
-            + Update
-            + FixedOutputReset
-            + HashMarker
-            + LastError,
-    > Support<bool> for hmac::SimpleHmac<D>
+impl<D> Support<bool> for hmac::SimpleHmac<D>
+where D: Support<bool> + Default + BlockSizeUser + Update + FixedOutputReset + HashMarker + LastError
 {
     const SUPPORT: bool = D::SUPPORT;
 }
@@ -217,15 +206,8 @@ impl LastError for sha2::Sha384 {
 }
 
 #[cfg(feature = "internal-software-crypto-hmac")]
-impl<
-        D: Support<bool>
-            + Default
-            + BlockSizeUser
-            + Update
-            + FixedOutputReset
-            + HashMarker
-            + LastError,
-    > LastError for hmac::SimpleHmac<D>
+impl<D> LastError for hmac::SimpleHmac<D>
+where D: Support<bool> + Default + BlockSizeUser + Update + FixedOutputReset + HashMarker + LastError
 {
     fn last_error(&self) -> Result<(), Error> {
         // TODO: Implement the error.

--- a/crates/board/src/crypto.rs
+++ b/crates/board/src/crypto.rs
@@ -221,6 +221,7 @@ impl<T: Hash> HashApi<T> {
         self.0.last_error()
     }
 
+    /// Get the wrapped hash.
     pub fn get_hash(self) -> T {
         self.0
     }
@@ -247,6 +248,7 @@ impl<T: Hmac> HmacApi<T> {
         self.0.last_error()
     }
 
+    /// Get the wrapped hmac.
     pub fn get_hmac(self) -> T {
         self.0
     }

--- a/crates/board/src/crypto.rs
+++ b/crates/board/src/crypto.rs
@@ -19,7 +19,7 @@ use crypto_common::BlockSizeUser;
 #[cfg(feature = "internal-api-crypto-hmac")]
 use crypto_common::KeyInit;
 #[cfg(any(feature = "internal-api-crypto-hash", feature = "internal-api-crypto-hmac"))]
-use crypto_common::Output;
+use crypto_common::{Output, OutputSizeUser};
 #[cfg(feature = "internal-api-crypto-hash")]
 use digest::HashMarker;
 #[cfg(feature = "internal-api-crypto-hmac")]
@@ -201,6 +201,15 @@ pub struct HashApi<T: Hash>(pub T);
 #[cfg(feature = "internal-api-crypto-hmac")]
 pub struct HmacApi<T: Hmac>(pub T);
 
+#[cfg(feature = "internal-api-crypto-hash")]
+impl<T: Hash> OutputSizeUser for HashApi<T> {
+    type OutputSize = T::OutputSize;
+}
+
+#[cfg(feature = "internal-api-crypto-hmac")]
+impl<T: Hmac> OutputSizeUser for HmacApi<T> {
+    type OutputSize = T::OutputSize;
+}
 
 #[cfg(feature = "internal-api-crypto-hash")]
 impl<T: Hash> HashApi<T> {

--- a/crates/board/src/crypto.rs
+++ b/crates/board/src/crypto.rs
@@ -18,6 +18,8 @@
 use crypto_common::BlockSizeUser;
 #[cfg(feature = "internal-api-crypto-hmac")]
 use crypto_common::KeyInit;
+#[cfg(any(feature = "internal-api-crypto-hash", feature = "internal-api-crypto-hmac"))]
+use crypto_common::Output;
 #[cfg(feature = "internal-api-crypto-hash")]
 use digest::HashMarker;
 #[cfg(feature = "internal-api-crypto-hmac")]
@@ -199,6 +201,7 @@ pub struct HashApi<T: Hash>(pub T);
 #[cfg(feature = "internal-api-crypto-hmac")]
 pub struct HmacApi<T: Hmac>(pub T);
 
+
 #[cfg(feature = "internal-api-crypto-hash")]
 impl<T: Hash> HashApi<T> {
     /// Constructor of HmacApi.
@@ -210,6 +213,12 @@ impl<T: Hash> HashApi<T> {
     /// Call update from RustCrypto API and then last_error.
     pub fn update(&mut self, data: &[u8]) -> Result<(), Error> {
         self.0.update(data);
+        self.0.last_error()
+    }
+
+    /// Call finalize_into_reset from RustCrypto API and then last_error.
+    pub fn finalize_into_reset(&mut self, out: &mut Output<Self>) -> Result<(), Error> {
+        self.0.finalize_into_reset(out);
         self.0.last_error()
     }
 }
@@ -226,6 +235,12 @@ impl<T: Hmac> HmacApi<T> {
     /// Call update from RustCrypto API and then last_error.    
     pub fn update(&mut self, data: &[u8]) -> Result<(), Error> {
         self.0.update(data);
+        self.0.last_error()
+    }
+
+    /// Call finalize_into_reset from RustCrypto API and then last_error.
+    pub fn finalize_into_reset(&mut self, out: &mut Output<Self>) -> Result<(), Error> {
+        self.0.finalize_into_reset(out);
         self.0.last_error()
     }
 }

--- a/crates/board/src/crypto.rs
+++ b/crates/board/src/crypto.rs
@@ -201,19 +201,31 @@ pub struct HmacApi<T: Hmac>(pub T);
 
 #[cfg(feature = "internal-api-crypto-hash")]
 impl<T: Hash> HashApi<T> {
-    /// Constructor of HmacApi
+    /// Constructor of HmacApi.
     pub fn new() -> Result<Self, Error> {
         let hash = T::default();
         hash.last_error().map(|()| HashApi(hash))
+    }
+
+    /// Call update from RustCrypto API and then last_error.
+    pub fn update(&mut self, data: &[u8]) -> Result<(), Error> {
+        self.0.update(data);
+        self.0.last_error()
     }
 }
 
 #[cfg(feature = "internal-api-crypto-hmac")]
 impl<T: Hmac> HmacApi<T> {
-    /// Constructor of HmacApi
+    /// Constructor of HmacApi.
     pub fn new(key: &[u8]) -> Result<Self, Error> {
         let hash =
             T::new_from_slice(key).map_err(|_| Error::new(Space::User, Code::InvalidLength))?;
         hash.last_error().map(|()| HmacApi(hash))
+    }
+
+    /// Call update from RustCrypto API and then last_error.    
+    pub fn update(&mut self, data: &[u8]) -> Result<(), Error> {
+        self.0.update(data);
+        self.0.last_error()
     }
 }

--- a/crates/board/src/crypto.rs
+++ b/crates/board/src/crypto.rs
@@ -177,8 +177,15 @@ impl crate::Supported for sha2::Sha256 {}
 impl crate::Supported for sha2::Sha384 {}
 
 #[cfg(feature = "internal-software-crypto-hmac")]
-impl<D: Support<bool> + Default + BlockSizeUser + Update + FixedOutputReset + HashMarker>
-    Support<bool> for hmac::SimpleHmac<D>
+impl<
+        D: Support<bool>
+            + Default
+            + BlockSizeUser
+            + Update
+            + FixedOutputReset
+            + HashMarker
+            + LastError,
+    > Support<bool> for hmac::SimpleHmac<D>
 {
     const SUPPORT: bool = D::SUPPORT;
 }

--- a/crates/board/src/crypto.rs
+++ b/crates/board/src/crypto.rs
@@ -193,14 +193,18 @@ pub trait LastError {
 
 // Wrapper API around Hash that calls last_error().
 #[cfg(feature = "internal-api-crypto-hash")]
+#[allow(missing_docs)]
 pub struct HashApi<T: Hash>(T);
 
 // Wrapper API around Hmac that calls last_error().
 #[cfg(feature = "internal-api-crypto-hmac")]
+#[allow(missing_docs)]
 pub struct HmacApi<T: Hmac>(T);
 
+#[allow(missing_docs)]
 #[cfg(feature = "internal-api-crypto-hash")]
 impl<T: Hash> HashApi<T> {
+    // Constructor of HashApi
     pub fn new() -> Result<Self, Error> {
         let hash = T::default();
         let error = T::last_error(&hash);
@@ -211,8 +215,10 @@ impl<T: Hash> HashApi<T> {
     }
 }
 
+#[allow(missing_docs)]
 #[cfg(feature = "internal-api-crypto-hmac")]
 impl<T: Hmac> HmacApi<T> {
+    // Constructor of HmacApi
     pub fn new(key: &[u8]) -> Result<Self, Error> {
         let hash =
             T::new_from_slice(key).map_err(|_| Error::new(Space::User, Code::InvalidLength))?;

--- a/crates/board/src/crypto.rs
+++ b/crates/board/src/crypto.rs
@@ -195,11 +195,11 @@ pub trait LastError {
 
 /// Wrapper API around Hash that calls last_error.
 #[cfg(feature = "internal-api-crypto-hash")]
-pub struct HashApi<T: Hash>(T);
+pub struct HashApi<T: Hash>(pub T);
 
 /// Wrapper API around Hmac that calls last_error.
 #[cfg(feature = "internal-api-crypto-hmac")]
-pub struct HmacApi<T: Hmac>(T);
+pub struct HmacApi<T: Hmac>(pub T);
 
 #[cfg(feature = "internal-api-crypto-hash")]
 impl<T: Hash> HashApi<T> {
@@ -219,11 +219,6 @@ impl<T: Hash> HashApi<T> {
     pub fn finalize_into(mut self, out: &mut Output<T>) -> Result<(), Error> {
         self.0.finalize_into_reset(out);
         self.0.last_error()
-    }
-
-    /// Get the wrapped hash.
-    pub fn get_hash(self) -> T {
-        self.0
     }
 }
 
@@ -246,10 +241,5 @@ impl<T: Hmac> HmacApi<T> {
     pub fn finalize_into(mut self, out: &mut Output<T>) -> Result<(), Error> {
         self.0.finalize_into_reset(out);
         self.0.last_error()
-    }
-
-    /// Get the wrapped hmac.
-    pub fn get_hmac(self) -> T {
-        self.0
     }
 }

--- a/crates/board/src/crypto.rs
+++ b/crates/board/src/crypto.rs
@@ -193,11 +193,11 @@ pub trait LastError {
 
 /// Wrapper API around Hash that calls last_error.
 #[cfg(feature = "internal-api-crypto-hash")]
-pub struct HashApi<T: Hash>(T);
+pub struct HashApi<T: Hash>(pub T);
 
 /// Wrapper API around Hmac that calls last_error.
 #[cfg(feature = "internal-api-crypto-hmac")]
-pub struct HmacApi<T: Hmac>(T);
+pub struct HmacApi<T: Hmac>(pub T);
 
 #[cfg(feature = "internal-api-crypto-hash")]
 impl<T: Hash> HashApi<T> {

--- a/crates/runner-host/Cargo.lock
+++ b/crates/runner-host/Cargo.lock
@@ -1855,7 +1855,7 @@ dependencies = [
 
 [[package]]
 name = "wasefire-board-api"
-version = "0.6.1-git"
+version = "0.7.0-git"
 dependencies = [
  "aead",
  "aes",

--- a/crates/runner-nordic/Cargo.lock
+++ b/crates/runner-nordic/Cargo.lock
@@ -1164,7 +1164,7 @@ dependencies = [
 
 [[package]]
 name = "wasefire-board-api"
-version = "0.6.1-git"
+version = "0.7.0-git"
 dependencies = [
  "aead",
  "aes-gcm",

--- a/crates/scheduler/CHANGELOG.md
+++ b/crates/scheduler/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.3.1-git
 
+### Minor
+
+- Refactor `applet::HashContext` to take `board::crypto::{Hash,Hmac}Api`
+
 ### Patch
 
 - Simplify `#[cfg(all)]` attributes between board and applet features

--- a/crates/scheduler/CHANGELOG.md
+++ b/crates/scheduler/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Minor
 
-- Refactor `applet::HashContext` to take `board::crypto::{Hash,Hmac}Api`
+- Migrate to `crypto::{Hash,Hmac}` depending on `crypto::WithError`
 - Change `led::{get,set}()` to never trap and return an error instead
 
 ### Patch
@@ -125,4 +125,4 @@
 
 ## 0.1.0
 
-<!-- Increment to skip CHANGELOG.md test: 32 -->
+<!-- Increment to skip CHANGELOG.md test: 33 -->

--- a/crates/scheduler/Cargo.lock
+++ b/crates/scheduler/Cargo.lock
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "wasefire-board-api"
-version = "0.6.1-git"
+version = "0.7.0-git"
 dependencies = [
  "aead",
  "aes",

--- a/crates/scheduler/Cargo.toml
+++ b/crates/scheduler/Cargo.toml
@@ -24,7 +24,7 @@ generic-array = { version = "0.14.7", default-features = false }
 portable-atomic = { version = "1.6.0", default-features = false }
 typenum = { version = "1.17.0", default-features = false }
 wasefire-applet-api = { version = "0.6.0", path = "../api", features = ["host"] }
-wasefire-board-api = { version = "0.6.1-git", path = "../board" }
+wasefire-board-api = { version = "0.7.0-git", path = "../board" }
 wasefire-error = { version = "0.1.0", path = "../error" }
 wasefire-logger = { version = "0.1.4", path = "../logger" }
 wasefire-store = { version = "0.2.4-git", path = "../store", optional = true }

--- a/crates/scheduler/src/applet.rs
+++ b/crates/scheduler/src/applet.rs
@@ -71,13 +71,13 @@ impl<B: Board> Default for AppletHashes<B> {
 #[cfg(feature = "internal-hash-context")]
 pub enum HashContext<B: Board> {
     #[cfg(feature = "board-api-crypto-sha256")]
-    Sha256(board::crypto::Sha256<B>),
+    Sha256(board::crypto::HashApi<board::crypto::Sha256<B>>),
     #[cfg(feature = "board-api-crypto-sha384")]
-    Sha384(board::crypto::Sha384<B>),
+    Sha384(board::crypto::HashApi<board::crypto::Sha384<B>>),
     #[cfg(feature = "board-api-crypto-hmac-sha256")]
-    HmacSha256(board::crypto::HmacSha256<B>),
+    HmacSha256(board::crypto::HmacApi<board::crypto::HmacSha256<B>>),
     #[cfg(feature = "board-api-crypto-hmac-sha384")]
-    HmacSha384(board::crypto::HmacSha384<B>),
+    HmacSha384(board::crypto::HmacApi<board::crypto::HmacSha384<B>>),
     _Impossible(board::Impossible<B>),
 }
 

--- a/crates/scheduler/src/call/crypto/hash.rs
+++ b/crates/scheduler/src/call/crypto/hash.rs
@@ -82,7 +82,7 @@ fn update<B: Board>(mut call: SchedulerCall<B, api::update::Sig>) {
     let api::update::Params { id, data, length } = call.read();
     let scheduler = call.scheduler();
     let memory = scheduler.applet.store.memory();
-    let result = try {
+    let result: Result<Result<(), _>, _> = try {
         let data = memory.get(*data, *length)?;
         match scheduler.applet.hashes.get_mut(*id as usize)? {
             #[cfg(feature = "board-api-crypto-sha256")]
@@ -154,7 +154,7 @@ fn hmac_update<B: Board>(mut call: SchedulerCall<B, api::hmac_update::Sig>) {
     let api::hmac_update::Params { id, data, length } = call.read();
     let scheduler = call.scheduler();
     let memory = scheduler.applet.store.memory();
-    let result = try {
+    let result: Result<Result<(), _>, _> = try {
         let data = memory.get(*data, *length)?;
         match scheduler.applet.hashes.get_mut(*id as usize)? {
             #[cfg(feature = "board-api-crypto-hmac-sha256")]

--- a/crates/scheduler/src/call/crypto/hash.rs
+++ b/crates/scheduler/src/call/crypto/hash.rs
@@ -68,10 +68,10 @@ fn initialize<B: Board>(mut call: SchedulerCall<B, api::initialize::Sig>) {
         let context = match convert_hash_algorithm::<B>(*algorithm)?? {
             #[cfg(feature = "board-api-crypto-sha256")]
             Algorithm::Sha256 => HashApi::<board::crypto::Sha256<B>>::new()
-                .map(|hash_api| HashContext::Sha256(hash_api.get_hash())),
+                .map(|hash_api| HashContext::Sha256(hash_api.0)),
             #[cfg(feature = "board-api-crypto-sha384")]
             Algorithm::Sha384 => HashApi::<board::crypto::Sha384<B>>::new()
-                .map(|hash_api| HashContext::Sha384(hash_api.get_hash())),
+                .map(|hash_api| HashContext::Sha384(hash_api.0)),
             #[allow(unreachable_patterns)]
             _ => Err(Trap)?,
         };
@@ -142,10 +142,10 @@ fn hmac_initialize<B: Board>(mut call: SchedulerCall<B, api::hmac_initialize::Si
         let context = match convert_hmac_algorithm::<B>(*algorithm)?? {
             #[cfg(feature = "board-api-crypto-hmac-sha256")]
             Algorithm::Sha256 => HmacApi::<board::crypto::HmacSha256<B>>::new(key)
-                .map(|hmac_api| HashContext::HmacSha256(hmac_api.get_hmac())),
+                .map(|hmac_api| HashContext::HmacSha256(hmac_api.0)),
             #[cfg(feature = "board-api-crypto-hmac-sha384")]
             Algorithm::Sha384 => HmacApi::<board::crypto::HmacSha384<B>>::new(key)
-                .map(|hmac_api| HashContext::HmacSha384(hmac_api.get_hmac())),
+                .map(|hmac_api| HashContext::HmacSha384(hmac_api.0)),
 
             #[allow(unreachable_patterns)]
             _ => trap_use!(key),

--- a/crates/scheduler/src/call/crypto/hash.rs
+++ b/crates/scheduler/src/call/crypto/hash.rs
@@ -111,14 +111,14 @@ fn finalize<B: Board>(mut call: SchedulerCall<B, api::finalize::Sig>) {
         match context {
             _ if *digest == 0 => Ok(()),
             #[cfg(feature = "board-api-crypto-sha256")]
-            HashContext::Sha256(hash) => {
+            HashContext::Sha256(context) => {
                 let digest = memory.get_array_mut::<32>(*digest)?;
-                HashApi(hash).finalize_into_reset(GenericArray::from_mut_slice(digest))
+                HashApi(context).finalize_into_reset(GenericArray::from_mut_slice(digest))
             }
             #[cfg(feature = "board-api-crypto-sha384")]
             HashContext::Sha384(context) => {
                 let digest = memory.get_array_mut::<48>(*digest)?;
-                HashApi(hash).finalize_into_reset(GenericArray::from_mut_slice(digest))
+                HashApi(context).finalize_into_reset(GenericArray::from_mut_slice(digest))
             }
             _ => trap_use!(memory),
         }

--- a/crates/scheduler/src/call/crypto/hash.rs
+++ b/crates/scheduler/src/call/crypto/hash.rs
@@ -68,10 +68,10 @@ fn initialize<B: Board>(mut call: SchedulerCall<B, api::initialize::Sig>) {
         let context = match convert_hash_algorithm::<B>(*algorithm)?? {
             #[cfg(feature = "board-api-crypto-sha256")]
             Algorithm::Sha256 => HashApi::<board::crypto::Sha256<B>>::new()
-                .map(|hash_api| HashContext::Sha256(hash_api.0)),
+                .map(|hash_api| HashContext::Sha256(hash_api.get_hash())),
             #[cfg(feature = "board-api-crypto-sha384")]
             Algorithm::Sha384 => HashApi::<board::crypto::Sha384<B>>::new()
-                .map(|hash_api| HashContext::Sha384(hash_api.0)),
+                .map(|hash_api| HashContext::Sha384(hash_api.get_hash())),
             #[allow(unreachable_patterns)]
             _ => Err(Trap)?,
         };
@@ -90,16 +90,12 @@ fn update<B: Board>(mut call: SchedulerCall<B, api::update::Sig>) {
     let memory = scheduler.applet.store.memory();
     let result = try {
         let data = memory.get(*data, *length)?;
-        let context = match scheduler.applet.hashes.take(*id as usize)? {
+        match scheduler.applet.hashes.take(*id as usize)? {
             #[cfg(feature = "board-api-crypto-sha256")]
             HashContext::Sha256(hash) => HashApi(hash).update(data),
             #[cfg(feature = "board-api-crypto-sha384")]
             HashContext::Sha384(hash) => HashApi(hash).update(data),
             _ => trap_use!(data),
-        };
-        match context {
-            Ok(()) => Ok(()),
-            Err(error) => Err(error),
         }
     };
     call.reply(result);
@@ -117,12 +113,12 @@ fn finalize<B: Board>(mut call: SchedulerCall<B, api::finalize::Sig>) {
             #[cfg(feature = "board-api-crypto-sha256")]
             HashContext::Sha256(context) => {
                 let digest = memory.get_array_mut::<32>(*digest)?;
-                HashApi(context).finalize_into_reset(GenericArray::from_mut_slice(digest))
+                HashApi(context).finalize_into(GenericArray::from_mut_slice(digest))
             }
             #[cfg(feature = "board-api-crypto-sha384")]
             HashContext::Sha384(context) => {
                 let digest = memory.get_array_mut::<48>(*digest)?;
-                HashApi(context).finalize_into_reset(GenericArray::from_mut_slice(digest))
+                HashApi(context).finalize_into(GenericArray::from_mut_slice(digest))
             }
             _ => trap_use!(memory),
         }
@@ -146,10 +142,10 @@ fn hmac_initialize<B: Board>(mut call: SchedulerCall<B, api::hmac_initialize::Si
         let context = match convert_hmac_algorithm::<B>(*algorithm)?? {
             #[cfg(feature = "board-api-crypto-hmac-sha256")]
             Algorithm::Sha256 => HmacApi::<board::crypto::HmacSha256<B>>::new(key)
-                .map(|hash_api| HashContext::HmacSha256(hash_api.0)),
+                .map(|hmac_api| HashContext::HmacSha256(hmac_api.get_hmac())),
             #[cfg(feature = "board-api-crypto-hmac-sha384")]
             Algorithm::Sha384 => HmacApi::<board::crypto::HmacSha384<B>>::new(key)
-                .map(|hash_api| HashContext::HmacSha384(hash_api.0)),
+                .map(|hmac_api| HashContext::HmacSha384(hmac_api.get_hmac())),
 
             #[allow(unreachable_patterns)]
             _ => trap_use!(key),
@@ -169,16 +165,12 @@ fn hmac_update<B: Board>(mut call: SchedulerCall<B, api::hmac_update::Sig>) {
     let memory = scheduler.applet.store.memory();
     let result = try {
         let data = memory.get(*data, *length)?;
-        let context = match scheduler.applet.hashes.take(*id as usize)? {
+        match scheduler.applet.hashes.take(*id as usize)? {
             #[cfg(feature = "board-api-crypto-hmac-sha256")]
             HashContext::HmacSha256(hmac) => HmacApi(hmac).update(data),
             #[cfg(feature = "board-api-crypto-hmac-sha384")]
             HashContext::HmacSha384(hmac) => HmacApi(hmac).update(data),
             _ => trap_use!(data),
-        };
-        match context {
-            Ok(()) => Ok(()),
-            Err(error) => Err(error),
         }
     };
     call.reply(result);
@@ -196,12 +188,12 @@ fn hmac_finalize<B: Board>(mut call: SchedulerCall<B, api::hmac_finalize::Sig>) 
             #[cfg(feature = "board-api-crypto-hmac-sha256")]
             HashContext::HmacSha256(context) => {
                 let hmac = memory.get_array_mut::<32>(*hmac)?;
-                HmacApi(context).finalize_into_reset(GenericArray::from_mut_slice(hmac))
+                HmacApi(context).finalize_into(GenericArray::from_mut_slice(hmac))
             }
             #[cfg(feature = "board-api-crypto-hmac-sha384")]
             HashContext::HmacSha384(context) => {
                 let hmac = memory.get_array_mut::<48>(*hmac)?;
-                HmacApi(context).finalize_into_reset(GenericArray::from_mut_slice(hmac))
+                HmacApi(context).finalize_into(GenericArray::from_mut_slice(hmac))
             }
             _ => trap_use!(memory),
         }

--- a/crates/scheduler/src/call/crypto/hash.rs
+++ b/crates/scheduler/src/call/crypto/hash.rs
@@ -67,13 +67,11 @@ fn initialize<B: Board>(mut call: SchedulerCall<B, api::initialize::Sig>) {
     let result = try {
         let context = match convert_hash_algorithm::<B>(*algorithm)?? {
             #[cfg(feature = "board-api-crypto-sha256")]
-            Algorithm::Sha256 => {
-                HashApi::<board::crypto::Sha256<B>>::new().map(HashContext::Sha256)
-            }
+            Algorithm::Sha256 => HashApi::<board::crypto::Sha256<B>>::new()
+                .map(|hash_api| HashContext::Sha256(hash_api.0)),
             #[cfg(feature = "board-api-crypto-sha384")]
-            Algorithm::Sha384 => {
-                HashApi::<board::crypto::Sha384<B>>::new().map(HashContext::Sha384)
-            }
+            Algorithm::Sha384 => HashApi::<board::crypto::Sha384<B>>::new()
+                .map(|hash_api| HashContext::Sha384(hash_api.0)),
             #[allow(unreachable_patterns)]
             _ => Err(Trap)?,
         };
@@ -151,13 +149,12 @@ fn hmac_initialize<B: Board>(mut call: SchedulerCall<B, api::hmac_initialize::Si
         let key = memory.get(*key, *key_len)?;
         let context = match convert_hmac_algorithm::<B>(*algorithm)?? {
             #[cfg(feature = "board-api-crypto-hmac-sha256")]
-            Algorithm::Sha256 => {
-                HmacApi::<board::crypto::HmacSha256<B>>::new(key).map(HashContext::HmacSha256)
-            }
+            Algorithm::Sha256 => HmacApi::<board::crypto::HmacSha256<B>>::new(key)
+                .map(|hash_api| HashContext::HmacSha256(hash_api.0)),
             #[cfg(feature = "board-api-crypto-hmac-sha384")]
-            Algorithm::Sha384 => {
-                HmacApi::<board::crypto::HmacSha384<B>>::new(key).map(HashContext::HmacSha384)
-            }
+            Algorithm::Sha384 => HmacApi::<board::crypto::HmacSha384<B>>::new(key)
+                .map(|hash_api| HashContext::HmacSha384(hash_api.0)),
+
             #[allow(unreachable_patterns)]
             _ => trap_use!(key),
         };

--- a/crates/scheduler/src/call/crypto/hash.rs
+++ b/crates/scheduler/src/call/crypto/hash.rs
@@ -60,7 +60,7 @@ fn is_supported<B: Board>(call: SchedulerCall<B, api::is_supported::Sig>) {
 fn initialize<B: Board>(mut call: SchedulerCall<B, api::initialize::Sig>) {
     let api::initialize::Params { algorithm } = call.read();
     let scheduler = call.scheduler();
-    let result: Result<Result<u32, _>, _> = try {
+    let result = try {
         let context = match convert_hash_algorithm::<B>(*algorithm)?? {
             #[cfg(feature = "board-api-crypto-sha256")]
             Algorithm::Sha256 => board::crypto::HashApi::new().map(HashContext::Sha256),
@@ -131,7 +131,7 @@ fn hmac_initialize<B: Board>(mut call: SchedulerCall<B, api::hmac_initialize::Si
     let api::hmac_initialize::Params { algorithm, key, key_len } = call.read();
     let scheduler = call.scheduler();
     let memory = scheduler.applet.memory();
-    let result: Result<Result<u32, _>, _> = try {
+    let result = try {
         let key = memory.get(*key, *key_len)?;
         let context = match convert_hmac_algorithm::<B>(*algorithm)?? {
             #[cfg(feature = "board-api-crypto-hmac-sha256")]

--- a/crates/scheduler/src/call/crypto/hash.rs
+++ b/crates/scheduler/src/call/crypto/hash.rs
@@ -90,12 +90,16 @@ fn update<B: Board>(mut call: SchedulerCall<B, api::update::Sig>) {
     let memory = scheduler.applet.store.memory();
     let result = try {
         let data = memory.get(*data, *length)?;
-        match scheduler.applet.hashes.take(*id as usize)? {
+        let context = match scheduler.applet.hashes.take(*id as usize)? {
             #[cfg(feature = "board-api-crypto-sha256")]
             HashContext::Sha256(hash) => HashApi(hash).update(data),
             #[cfg(feature = "board-api-crypto-sha384")]
             HashContext::Sha384(hash) => HashApi(hash).update(data),
             _ => trap_use!(data),
+        };
+        match context {
+            Ok(()) => Ok(()),
+            Err(error) => Err(error),
         }
     };
     call.reply(result);
@@ -165,12 +169,16 @@ fn hmac_update<B: Board>(mut call: SchedulerCall<B, api::hmac_update::Sig>) {
     let memory = scheduler.applet.store.memory();
     let result = try {
         let data = memory.get(*data, *length)?;
-        match scheduler.applet.hashes.take(*id as usize)? {
+        let context = match scheduler.applet.hashes.take(*id as usize)? {
             #[cfg(feature = "board-api-crypto-hmac-sha256")]
             HashContext::HmacSha256(hmac) => HmacApi(hmac).update(data),
             #[cfg(feature = "board-api-crypto-hmac-sha384")]
             HashContext::HmacSha384(hmac) => HmacApi(hmac).update(data),
             _ => trap_use!(data),
+        };
+        match context {
+            Ok(()) => Ok(()),
+            Err(error) => Err(error),
         }
     };
     call.reply(result);

--- a/crates/scheduler/src/call/crypto/hash.rs
+++ b/crates/scheduler/src/call/crypto/hash.rs
@@ -65,27 +65,19 @@ fn initialize<B: Board>(mut call: SchedulerCall<B, api::initialize::Sig>) {
     let api::initialize::Params { algorithm } = call.read();
     let scheduler = call.scheduler();
     let result = try {
-        let context_or_error = match convert_hash_algorithm::<B>(*algorithm)?? {
+        let context = match convert_hash_algorithm::<B>(*algorithm)?? {
             #[cfg(feature = "board-api-crypto-sha256")]
             Algorithm::Sha256 => {
-                let hash_or_error = HashApi::<board::crypto::Sha256<B>>::new();
-                match hash_or_error {
-                    Ok(hash) => Ok(HashContext::Sha256(hash)),
-                    Err(error) => Err(error),
-                }
+                HashApi::<board::crypto::Sha256<B>>::new().map(HashContext::Sha256)
             }
             #[cfg(feature = "board-api-crypto-sha384")]
             Algorithm::Sha384 => {
-                let hash_or_error = HashApi::<board::crypto::Sha384<B>>::new();
-                match hash_or_error {
-                    Ok(hash) => Ok(HashContext::Sha384(hash)),
-                    Err(error) => Err(error),
-                }
+                HashApi::<board::crypto::Sha384<B>>::new().map(HashContext::Sha384)
             }
             #[allow(unreachable_patterns)]
             _ => Err(Trap)?,
         };
-        match context_or_error {
+        match context {
             Ok(context) => Ok(scheduler.applet.hashes.insert(context)? as u32),
             Err(error) => Err(error),
         }
@@ -157,27 +149,19 @@ fn hmac_initialize<B: Board>(mut call: SchedulerCall<B, api::hmac_initialize::Si
     let memory = scheduler.applet.memory();
     let result = try {
         let key = memory.get(*key, *key_len)?;
-        let context_or_error = match convert_hmac_algorithm::<B>(*algorithm)?? {
+        let context = match convert_hmac_algorithm::<B>(*algorithm)?? {
             #[cfg(feature = "board-api-crypto-hmac-sha256")]
             Algorithm::Sha256 => {
-                let hmac_or_error = HmacApi::<board::crypto::HmacSha256<B>>::new(key);
-                match hmac_or_error {
-                    Ok(hmac) => Ok(HashContext::HmacSha256(hmac)),
-                    Err(error) => Err(error),
-                }
+                HmacApi::<board::crypto::HmacSha256<B>>::new(key).map(HashContext::HmacSha256)
             }
             #[cfg(feature = "board-api-crypto-hmac-sha384")]
             Algorithm::Sha384 => {
-                let hmac_or_error = HmacApi::<board::crypto::HmacSha384<B>>::new(key);
-                match hmac_or_error {
-                    Ok(hmac) => Ok(HashContext::HmacSha384(hmac)),
-                    Err(error) => Err(error),
-                }
+                HmacApi::<board::crypto::HmacSha384<B>>::new(key).map(HashContext::HmacSha384)
             }
             #[allow(unreachable_patterns)]
             _ => trap_use!(key),
         };
-        match context_or_error {
+        match context {
             Ok(context) => Ok(scheduler.applet.hashes.insert(context)? as u32),
             Err(error) => Err(error),
         }

--- a/crates/scheduler/src/call/crypto/hash.rs
+++ b/crates/scheduler/src/call/crypto/hash.rs
@@ -97,7 +97,10 @@ fn update<B: Board>(mut call: SchedulerCall<B, api::update::Sig>) {
                 context.last_error()?
             }
             #[cfg(feature = "board-api-crypto-sha384")]
-            HashContext::Sha384(context) => context.update(data),
+            HashContext::Sha384(context) => {
+                context.update(data);
+                context.last_error()?
+            }
             _ => trap_use!(data),
         }
         Ok(())

--- a/crates/scheduler/src/call/crypto/hash.rs
+++ b/crates/scheduler/src/call/crypto/hash.rs
@@ -109,21 +109,19 @@ fn finalize<B: Board>(mut call: SchedulerCall<B, api::finalize::Sig>) {
     let result = try {
         let context = scheduler.applet.hashes.take(*id as usize)?;
         match context {
-            _ if *digest == 0 => (),
+            _ if *digest == 0 => Ok(()),
             #[cfg(feature = "board-api-crypto-sha256")]
-            HashContext::Sha256(context) => {
+            HashContext::Sha256(hash) => {
                 let digest = memory.get_array_mut::<32>(*digest)?;
-                context.finalize_into(GenericArray::from_mut_slice(digest));
-                context.last_error()
+                HashApi(hash).finalize_into_reset(GenericArray::from_mut_slice(digest))
             }
             #[cfg(feature = "board-api-crypto-sha384")]
             HashContext::Sha384(context) => {
                 let digest = memory.get_array_mut::<48>(*digest)?;
-                context.finalize_into(GenericArray::from_mut_slice(digest));
-                context.last_error()
+                HashApi(hash).finalize_into_reset(GenericArray::from_mut_slice(digest))
             }
             _ => trap_use!(memory),
-        };
+        }
     };
     call.reply(result);
 }
@@ -186,18 +184,16 @@ fn hmac_finalize<B: Board>(mut call: SchedulerCall<B, api::hmac_finalize::Sig>) 
     let result = try {
         let context = scheduler.applet.hashes.take(*id as usize)?;
         match context {
-            _ if *hmac == 0 => (),
+            _ if *hmac == 0 => Ok(()),
             #[cfg(feature = "board-api-crypto-hmac-sha256")]
             HashContext::HmacSha256(context) => {
                 let hmac = memory.get_array_mut::<32>(*hmac)?;
-                context.finalize_into(GenericArray::from_mut_slice(hmac));
-                context.last_error()
+                HmacApi(context).finalize_into_reset(GenericArray::from_mut_slice(hmac))
             }
             #[cfg(feature = "board-api-crypto-hmac-sha384")]
             HashContext::HmacSha384(context) => {
                 let hmac = memory.get_array_mut::<48>(*hmac)?;
-                context.finalize_into(GenericArray::from_mut_slice(hmac));
-                context.last_error()
+                HmacApi(context).finalize_into_reset(GenericArray::from_mut_slice(hmac))
             }
             _ => trap_use!(memory),
         }


### PR DESCRIPTION
To resolve #176.

Please let me know any issue or improvement. Thanks!

1) I was wondering if there is any existing test in `wasefire/examples` that could be used to check if these changes break anything, especially using `FixedOutputReset` for the `Hmac` trait.

2) What Rust format tool do you use? As you can see, I use a different format tool and I'm happy to change to yours.