### PR TITLE
Disable fail-fast for checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [checks, cache] # The cache is used by the checks.
     strategy:
+      fail-fast: false
       matrix:
         check: ${{ fromJSON(needs.checks.outputs.checks) }}
     name: ${{ matrix.check }}


### PR DESCRIPTION
It's rarely useful, since most often it's the changelog job failing.