### PR TITLE
`led::{get, set}`: panic with an `InvalidArgument` error instead of trapping

### DIFF
--- a/crates/prelude/CHANGELOG.md
+++ b/crates/prelude/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Document all public API
 - Remove deprecated `println!` macro
 - Add `Sha384` and `HmacSha384` to the `rust-crypto` feature
+- Led returns error instead of trapping when indexing out of bounds.
 
 ## 0.5.0
 

--- a/crates/prelude/CHANGELOG.md
+++ b/crates/prelude/CHANGELOG.md
@@ -4,10 +4,10 @@
 
 ### Minor
 
+- Change `led::{get,set}()` to never trap and return an error instead
 - Document all public API
 - Remove deprecated `println!` macro
 - Add `Sha384` and `HmacSha384` to the `rust-crypto` feature
-- Led returns error instead of trapping when indexing out of bounds.
 
 ## 0.5.0
 

--- a/crates/prelude/src/led.rs
+++ b/crates/prelude/src/led.rs
@@ -32,6 +32,7 @@ pub fn count() -> usize {
 /// Returns the status of a LED.
 ///
 /// The `led` argument is the index of the LED. It must be less than [count()].
+#[track_caller]
 pub fn get(led: usize) -> api::Status {
     let status = convert_bool(unsafe { api::get(api::get::Params { led }) }).unwrap();
     match status {
@@ -44,6 +45,7 @@ pub fn get(led: usize) -> api::Status {
 ///
 /// The `led` argument is the index of the LED. It must be less than [count()]. The `status`
 /// argument is the new status.
+#[track_caller]
 pub fn set(led: usize, status: api::Status) {
     let params = api::set::Params { led, status: status as usize };
     convert_unit(unsafe { api::set(params) }).unwrap();

--- a/crates/scheduler/CHANGELOG.md
+++ b/crates/scheduler/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.3.1-git
 
+### Minor
+
+- Change `led::{get,set}()` to never trap and return an error instead
+
 ### Patch
 
 - Simplify `#[cfg(all)]` attributes between board and applet features
@@ -38,7 +42,6 @@
 - Permit applets to call `debup::println()` during `init()`
 - Use `debug::exit()` board API when the applet traps
 - Use `log::panic!()` on interpreter errors
-- Change led scheduler calls to return out of bounds errors instead of trapping
 
 ### Patch
 

--- a/crates/scheduler/CHANGELOG.md
+++ b/crates/scheduler/CHANGELOG.md
@@ -38,6 +38,7 @@
 - Permit applets to call `debup::println()` during `init()`
 - Use `debug::exit()` board API when the applet traps
 - Use `log::panic!()` on interpreter errors
+- Change led scheduler calls to return out of bounds errors instead of trapping
 
 ### Patch
 

--- a/crates/scheduler/src/call/led.rs
+++ b/crates/scheduler/src/call/led.rs
@@ -18,9 +18,9 @@ use wasefire_board_api::led::Api as _;
 use wasefire_board_api::Api as Board;
 #[cfg(feature = "board-api-led")]
 use wasefire_board_api::{self as board, Id, Support};
+#[cfg(feature = "board-api-led")]
 use wasefire_error::{Code, Error};
 
-#[cfg(feature = "board-api-led")]
 use crate::{DispatchSchedulerCall, SchedulerCall};
 
 pub fn process<B: Board>(call: Api<DispatchSchedulerCall<B>>) {

--- a/crates/scheduler/src/call/led.rs
+++ b/crates/scheduler/src/call/led.rs
@@ -18,7 +18,7 @@ use wasefire_board_api::led::Api as _;
 use wasefire_board_api::Api as Board;
 #[cfg(feature = "board-api-led")]
 use wasefire_board_api::{self as board, Id, Support};
-use wasefire_error::{Code, Error, Space};
+use wasefire_error::{Code, Error};
 
 #[cfg(feature = "board-api-led")]
 use crate::{DispatchSchedulerCall, SchedulerCall};
@@ -46,7 +46,7 @@ fn get<B: Board>(call: SchedulerCall<B, api::get::Sig>) {
     let result = try {
         match Id::new(*led as usize) {
             Some(id) => board::Led::<B>::get(id),
-            None => Err(Error::new(Space::User, Code::InvalidArgument)),
+            None => Err(Error::user(Code::InvalidArgument)),
         }
     };
     call.reply(result);
@@ -61,7 +61,7 @@ fn set<B: Board>(call: SchedulerCall<B, api::set::Sig>) {
                 let on = matches!(api::Status::try_from(*status)?, api::Status::On);
                 board::Led::<B>::set(id, on)
             }
-            None => Err(Error::new(Space::User, Code::InvalidArgument)),
+            None => Err(Error::user(Code::InvalidArgument)),
         }
     };
     call.reply(result);


### PR DESCRIPTION
panic with an `InvalidArgument` error instead of trapping, also ensure we track the callers for #43.

For example the editing [`examples/rust/blink/src/lib.rs`](https://github.com/google/wasefire/blob/main/examples/rust/blink/src/lib.rs) to the following,

```rust
#![no_std]
wasefire::applet!();

use core::time::Duration;

fn main() {
    // Make sure there is at least one LED.
    let num_leds = led::count();
    assert!(num_leds > 0, "Board has no LEDs.");
    led::set(led_index, led::On);
}
```

and running `cargo xtask applet rust blink runner host `, would result in the following error:

```rust
Board initialized. Starting scheduler.                                                                                                                                                    
0.000848: panicked at src/lib.rs:29:5:                                                                                                                                                   
called `Result::unwrap()` on an `Err` value: User:InvalidArgument                                                                                                                        
Applet aborted (probably a panic).
```

I couldn't find an `OutOfBounds` error  [here](https://github.com/google/wasefire/blob/33fe4839e4927cf19cfde86c2b56dd63df65954a/crates/error/src/lib.rs#L141-L173), so decided to use `InvalidArgument`. Let me know if we should add an `OutOfBounds` error if that would be better.