### PR TITLE
Add a textreview check

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+# All files are assumed to be reviewed in a printed form by default.
+* textreview
+# Binary files are not reviewed in printed form.
+*.pdf -textreview
+*.png -textreview
+*.wasm -textreview
+# Submodules are not reviewed in printed form.
+/third_party/** -textreview

--- a/.github/actions/ci-checks/action.yml
+++ b/.github/actions/ci-checks/action.yml
@@ -26,6 +26,9 @@ runs:
     - if: ${{ contains(fromJSON(inputs.checks), 'changelog') }}
       run: ./scripts/ci-changelog.sh
       shell: bash
+    - if: ${{ contains(fromJSON(inputs.checks), 'textreview') }}
+      run: cargo xtask textreview
+      shell: bash
     - if: ${{ contains(fromJSON(inputs.checks), 'sync') }}
       run: ./scripts/sync.sh
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,19 +35,20 @@ jobs:
             done
             true
           }
-          x  copyright  pull_request
-          x  changelog  pull_request
-          x       sync  pull_request  push  schedule
-          x    publish  pull_request  push  schedule
-          x      taplo  pull_request  push  schedule
-          x    applets  pull_request  push  schedule
-          x    runners  pull_request  push  schedule
-          x    tests-0  pull_request  push  schedule
-          x    tests-1  pull_request  push  schedule
-          x    tests-2  pull_request  push  schedule
-          x    hw-host  pull_request  push  schedule
-          x       book  pull_request  push  schedule
-          x  footprint  pull_request  push
+          x   copyright  pull_request
+          x   changelog  pull_request
+          x  textreview  pull_request
+          x        sync  pull_request  push  schedule
+          x     publish  pull_request  push  schedule
+          x       taplo  pull_request  push  schedule
+          x     applets  pull_request  push  schedule
+          x     runners  pull_request  push  schedule
+          x     tests-0  pull_request  push  schedule
+          x     tests-1  pull_request  push  schedule
+          x     tests-2  pull_request  push  schedule
+          x     hw-host  pull_request  push  schedule
+          x        book  pull_request  push  schedule
+          x   footprint  pull_request  push
           echo "checks=[$CHECKS]" >> $GITHUB_OUTPUT
     outputs:
       checks: ${{ steps.checks.outputs.checks }}

--- a/book/src/applet/run.md
+++ b/book/src/applet/run.md
@@ -56,8 +56,8 @@ After a bunch of compilation steps, you should see something that ends like:
 
 ```plaintext
 ".../wrapper.sh" "probe-rs" "run" "--chip=nRF52840_xxAA" "target/.../runner-nordic"
-     Erasing sectors ✔ [00:00:05] [################################]
- Programming pages   ✔ [00:00:04] [################################]
+     Erasing sectors [00:00:05] [################################]
+ Programming pages   [00:00:04] [################################]
 0.090527: hello world
 ```
 

--- a/crates/board/CHANGELOG.md
+++ b/crates/board/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Patch
 
+- Update dependencies
 - Document all public API
 
 ## 0.6.0

--- a/crates/board/Cargo.lock
+++ b/crates/board/Cargo.lock
@@ -906,7 +906,7 @@ dependencies = [
 
 [[package]]
 name = "wasefire-store"
-version = "0.2.3"
+version = "0.2.4-git"
 
 [[package]]
 name = "zeroize"

--- a/crates/board/Cargo.toml
+++ b/crates/board/Cargo.toml
@@ -38,7 +38,7 @@ usbd-serial = { version = "0.2.0", default-features = false }
 wasefire-applet-api = { version = "0.6.0", path = "../api", features = ["host"] }
 wasefire-error = { version = "0.1.0", path = "../error" }
 wasefire-logger = { version = "0.1.4", path = "../logger" }
-wasefire-store = { version = "0.2.3", path = "../store", optional = true }
+wasefire-store = { version = "0.2.4-git", path = "../store", optional = true }
 
 [features]
 std = ["wasefire-store?/std"]

--- a/crates/runner-host/Cargo.lock
+++ b/crates/runner-host/Cargo.lock
@@ -1927,7 +1927,7 @@ dependencies = [
 
 [[package]]
 name = "wasefire-store"
-version = "0.2.3"
+version = "0.2.4-git"
 
 [[package]]
 name = "wasefire-sync"

--- a/crates/runner-nordic/Cargo.lock
+++ b/crates/runner-nordic/Cargo.lock
@@ -1235,7 +1235,7 @@ dependencies = [
 
 [[package]]
 name = "wasefire-store"
-version = "0.2.3"
+version = "0.2.4-git"
 
 [[package]]
 name = "wasefire-sync"

--- a/crates/scheduler/CHANGELOG.md
+++ b/crates/scheduler/CHANGELOG.md
@@ -124,4 +124,4 @@
 
 ## 0.1.0
 
-<!-- Increment to skip CHANGELOG.md test: 31 -->
+<!-- Increment to skip CHANGELOG.md test: 32 -->

--- a/crates/scheduler/Cargo.lock
+++ b/crates/scheduler/Cargo.lock
@@ -943,7 +943,7 @@ dependencies = [
 
 [[package]]
 name = "wasefire-store"
-version = "0.2.3"
+version = "0.2.4-git"
 
 [[package]]
 name = "wasefire-sync"

--- a/crates/scheduler/Cargo.toml
+++ b/crates/scheduler/Cargo.toml
@@ -27,7 +27,7 @@ wasefire-applet-api = { version = "0.6.0", path = "../api", features = ["host"] 
 wasefire-board-api = { version = "0.6.1-git", path = "../board" }
 wasefire-error = { version = "0.1.0", path = "../error" }
 wasefire-logger = { version = "0.1.4", path = "../logger" }
-wasefire-store = { version = "0.2.3", path = "../store", optional = true }
+wasefire-store = { version = "0.2.4-git", path = "../store", optional = true }
 wasefire-sync = { version = "0.1.0", path = "../sync" }
 
 [dependencies.wasefire-interpreter]

--- a/crates/store/CHANGELOG.md
+++ b/crates/store/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.2.4-git
+
+### Patch
+
+- Use pure ASCII instead of UTF-8 in documentation
+
 ## 0.2.3
 
 ### Minor

--- a/crates/store/Cargo.lock
+++ b/crates/store/Cargo.lock
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "wasefire-store"
-version = "0.2.3"
+version = "0.2.4-git"
 dependencies = [
  "tempfile",
 ]

--- a/crates/store/Cargo.toml
+++ b/crates/store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasefire-store"
-version = "0.2.3"
+version = "0.2.4-git"
 authors = ["Julien Cretin <cretin@google.com>"]
 license = "Apache-2.0"
 publish = true

--- a/crates/store/fuzz/Cargo.lock
+++ b/crates/store/fuzz/Cargo.lock
@@ -147,4 +147,4 @@ checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "wasefire-store"
-version = "0.2.3"
+version = "0.2.4-git"

--- a/crates/store/src/format.rs
+++ b/crates/store/src/format.rs
@@ -208,7 +208,7 @@ impl Format {
 
     /// The number of pages in the storage, denoted by N.
     ///
-    /// We have [`MIN_NUM_PAGES`] ≤ N ≤ [`MAX_PAGE_INDEX`] + 1.
+    /// We have [`MIN_NUM_PAGES`] <= N <= [`MAX_PAGE_INDEX`] + 1.
     pub fn num_pages(&self) -> Nat {
         self.num_pages
     }
@@ -222,7 +222,7 @@ impl Format {
 
     /// The maximum number of times a page can be erased, denoted by E.
     ///
-    /// We have E ≤ [`MAX_ERASE_CYCLE`].
+    /// We have E <= [`MAX_ERASE_CYCLE`].
     pub fn max_page_erases(&self) -> Nat {
         self.max_page_erases
     }
@@ -241,7 +241,7 @@ impl Format {
     ///
     /// A virtual page is stored in a physical page after the page header.
     ///
-    /// We have [`MIN_PAGE_SIZE`] - 2 ≤ Q ≤ [`MAX_VIRT_PAGE_SIZE`].
+    /// We have [`MIN_PAGE_SIZE`] - 2 <= Q <= [`MAX_VIRT_PAGE_SIZE`].
     pub fn virt_page_size(&self) -> Nat {
         self.page_size() / self.word_size() - CONTENT_WORD
     }
@@ -258,7 +258,7 @@ impl Format {
     /// A prefix is the first words of a virtual page that belong to the last entry of the previous
     /// virtual page. This happens because entries may overlap up to 2 virtual pages.
     ///
-    /// We have [`MIN_PAGE_SIZE`] - 3 ≤ M < Q.
+    /// We have [`MIN_PAGE_SIZE`] - 3 <= M < Q.
     pub fn max_prefix_len(&self) -> Nat {
         self.bytes_to_words(self.max_value_len())
     }
@@ -268,7 +268,7 @@ impl Format {
     /// This is the span of virtual storage that is accessible. In particular, all store content
     /// fits within this window.
     ///
-    /// We have W = (N - 1) × Q - M.
+    /// We have W = (N - 1) * Q - M.
     pub fn window_size(&self) -> Nat {
         (self.num_pages() - 1) * self.virt_page_size() - self.max_prefix_len()
     }
@@ -279,19 +279,19 @@ impl Format {
     /// than the virtual window because compaction may transiently overflow out of this virtual
     /// capacity.
     ///
-    /// We have V = W - (N - 1) = (N - 1) × (Q - 1) - M.
+    /// We have V = W - (N - 1) = (N - 1) * (Q - 1) - M.
     pub fn virt_size(&self) -> Nat {
         (self.num_pages() - 1) * (self.virt_page_size() - 1) - self.max_prefix_len()
     }
 
     /// The total user capacity in words, denoted by C.
     ///
-    /// We have C = V - N = (N - 1) × (Q - 2) - M - 1.
+    /// We have C = V - N = (N - 1) * (Q - 2) - M - 1.
     ///
-    /// We can show C ≥ (N - 2) × (Q - 2) - 2 with the following steps:
-    /// - M ≤ Q - 1 from M < Q from [M](Format::max_prefix_len)'s definition
-    /// - C ≥ (N - 1) × (Q - 2) - (Q - 1) - 1 from C's definition
-    /// - C ≥ (N - 2) × (Q - 2) - 2 by calculus
+    /// We can show C >= (N - 2) * (Q - 2) - 2 with the following steps:
+    /// - M <= Q - 1 from M < Q from [M](Format::max_prefix_len)'s definition
+    /// - C >= (N - 1) * (Q - 2) - (Q - 1) - 1 from C's definition
+    /// - C >= (N - 2) * (Q - 2) - 2 by calculus
     pub fn total_capacity(&self) -> Nat {
         // From the virtual capacity, we reserve N - 1 words for `Erase` entries and 1 word for a
         // `Clear` entry.
@@ -300,7 +300,7 @@ impl Format {
 
     /// The total virtual lifetime in words, denoted by L.
     ///
-    /// We have L = (E × N + N - 1) × Q.
+    /// We have L = (E * N + N - 1) * Q.
     pub fn total_lifetime(&self) -> Position {
         Position::new(self, self.max_page_erases(), self.num_pages() - 1, 0)
     }
@@ -705,7 +705,7 @@ bitfield! {
 /// - p denote a page offset, thus between 0 and N - 1
 /// - c denote the number of times a page was erased, thus between 0 and E
 ///
-/// The position of a word is (c × N + p) × Q + w. This position monotonically increases and
+/// The position of a word is (c * N + p) * Q + w. This position monotonically increases and
 /// represents the consumed lifetime of the storage.
 ///
 /// This type is kept abstract to avoid possible confusion with [`Nat`] and [`Word`] if they happen

--- a/crates/store/src/lib.rs
+++ b/crates/store/src/lib.rs
@@ -76,7 +76,7 @@
 //! -   The pages are sequentially indexed from 0. If the actual underlying storage is segmented,
 //!     then the storage layer should translate those indices to actual page addresses.
 //!
-//! The store has a _total capacity_ of C = (N - 1) × (P - 4) - M - 1 words, where:
+//! The store has a _total capacity_ of C = (N - 1) * (P - 4) - M - 1 words, where:
 //! -   P is the number of words per page
 //! -   [N](format::Format::num_pages) is the number of pages
 //! -   [M](format::Format::max_prefix_len) is the maximum length in words of a value (256 for large
@@ -95,7 +95,7 @@
 //!
 //! \*0 if the update is alone in the transaction, otherwise 1.
 //!
-//! The _total lifetime_ of the store is below L = ((E + 1) × N - 1) × (P - 2) and above L - M
+//! The _total lifetime_ of the store is below L = ((E + 1) * N - 1) * (P - 2) and above L - M
 //! words, where E is the maximum number of erase cycles. The lifetime is used when capacity is
 //! used, including transiently, as well as when compaction occurs. Compaction frequency and
 //! lifetime consumption are positively correlated to the store load factor (the ratio of used
@@ -132,15 +132,15 @@
 //! # Implementation
 //!
 //! We define the following constants:
-//! -   [E](format::Format::max_page_erases) ≤ [65535](format::MAX_ERASE_CYCLE) the number of times
+//! -   [E](format::Format::max_page_erases) <= [65535](format::MAX_ERASE_CYCLE) the number of times
 //!     a page can be erased.
-//! -   3 ≤ [N](format::Format::num_pages) < 64 the number of pages in the storage.
-//! -   8 ≤ P ≤ 1024 the number of words in a page.
+//! -   3 <= [N](format::Format::num_pages) < 64 the number of pages in the storage.
+//! -   8 <= P <= 1024 the number of words in a page.
 //! -   [Q](format::Format::virt_page_size) = P - 2 the number of words in a virtual page.
 //! -   [M](format::Format::max_prefix_len) = min(Q - 1, 256) the maximum length in words of a
 //!     value.
-//! -   [W](format::Format::window_size) = (N - 1) × Q - M the window size.
-//! -   [V](format::Format::virt_size) = (N - 1) × (Q - 1) - M the virtual capacity.
+//! -   [W](format::Format::window_size) = (N - 1) * Q - M the window size.
+//! -   [V](format::Format::virt_size) = (N - 1) * (Q - 1) - M the virtual capacity.
 //! -   [C](format::Format::total_capacity) = V - N the user capacity.
 //!
 //! We build a virtual storage from the physical storage using the first 2 words of each page:
@@ -148,27 +148,27 @@
 //! -   The second word contains the starting word to which this page is being moved during
 //!     compaction.
 //!
-//! The virtual storage has a length of (E + 1) × N × Q words and represents the lifetime of the
+//! The virtual storage has a length of (E + 1) * N * Q words and represents the lifetime of the
 //! store. (We reserve the last Q + M words to support adding emergency lifetime.) This virtual
 //! storage has a linear address space.
 //!
-//! We define a set of overlapping windows of N × Q words at each Q-aligned boundary. We call i the
-//! window spanning from i × Q to (i + N) × Q. Only those windows actually exist in the underlying
+//! We define a set of overlapping windows of N * Q words at each Q-aligned boundary. We call i the
+//! window spanning from i * Q to (i + N) * Q. Only those windows actually exist in the underlying
 //! storage. We use compaction to shift the current window from i to i + 1, preserving the content
 //! of the store.
 //!
 //! For a given state of the virtual storage, we define h\_i as the position of the first entry of
 //! the window i. We call it the head of the window i. Because entries are at most M + 1 words, they
-//! can overlap on the next page only by M words. So we have i × Q ≤ h_i ≤ i × Q + M . Since there
+//! can overlap on the next page only by M words. So we have i * Q <= h_i <= i * Q + M . Since there
 //! are no entries before the first page, we have h\_0 = 0.
 //!
 //! We define t\_i as one past the last entry of the window i. If there are no entries in that
 //! window, we have t\_i = h\_i. We call t\_i the tail of the window i. We define the compaction
-//! invariant as t\_i - h\_i ≤ V and the window invariant as t\_i - h\_i ≤ W. The compaction
+//! invariant as t\_i - h\_i <= V and the window invariant as t\_i - h\_i <= W. The compaction
 //! invariant may temporarily be broken during a sequence of (at most N - 1) compactions.
 //!
-//! We define |x| as the capacity used before position x. We have |x| ≤ x. We define the capacity
-//! invariant as |t\_i| - |h\_i| ≤ C.
+//! We define |x| as the capacity used before position x. We have |x| <= x. We define the capacity
+//! invariant as |t\_i| - |h\_i| <= C.
 //!
 //! Using this virtual storage, entries are appended to the tail as long as there is both virtual
 //! capacity to preserve the compaction invariant and capacity to preserve the capacity invariant.
@@ -218,7 +218,7 @@
 //! We first show that after each compaction, the window invariant is preserved.
 //!
 //! ```text
-//! ∀(1 ≤ i ≤ N - 1)   t_{I + i} - h_{I + i}  ≤  W
+//! for all (1 <= i <= N - 1)   t_{I + i} - h_{I + i}  <=  W
 //! ```
 //!
 //! We assume i between 1 and N - 1.
@@ -227,7 +227,7 @@
 //! window with the last entry possibly overlapping on the next page.
 //!
 //! ```text
-//! ∀j   t_{j + 1}  =  t_j + |h_{j + 1}| - |h_j| + 1
+//! for all j   t_{j + 1}  =  t_j + |h_{j + 1}| - |h_j| + 1
 //! ```
 //!
 //! By induction, we have:
@@ -239,56 +239,56 @@
 //! We have the following properties:
 //!
 //! ```text
-//! t_I  ≤  h_I + V
-//! |h_{I + i}| - |h_I|  ≤  h_{I + i} - h_I
+//! t_I  <=  h_I + V
+//! |h_{I + i}| - |h_I|  <=  h_{I + i} - h_I
 //! ```
 //!
 //! Replacing into our previous equality, we can conclude:
 //!
 //! ```text
 //! t_{I + i}  =  t_I + |h_{I + i}| - |h_I| + i
-//!            ≤  h_I + V + h_{I + 1} - h_I + i
+//!           <=  h_I + V + h_{I + 1} - h_I + i
 //! iff
-//! t_{I + i} - h_{I + 1}  ≤  V + i
-//!                        ≤  V + N - 1
-//!                        =  W
+//! t_{I + i} - h_{I + 1}  <=  V + i
+//!                        <=  V + N - 1
+//!                         =  W
 //! ```
 //!
 //! An important corollary is that the tail stays within the window:
 //!
 //! ```text
-//! t_{I + i}  ≤  (I + i + N - 1) × Q
+//! t_{I + i}  <=  (I + i + N - 1) * Q
 //! ```
 //!
 //! We have the following property:
 //!
 //! ```text
-//! h_{I + i}  ≤  (I + i) × Q + M
+//! h_{I + i}  <=  (I + i) * Q + M
 //! ```
 //!
 //! From which we conclude with the definition of W:
 //!
 //! ```text
-//! t_{I + i}  ≤  h_{I + i} + W
-//!            ≤  (I + i) × Q + M + (N - 1) × Q - M
-//!            =  (I + i + N - 1) × Q
+//! t_{I + i}  <=  h_{I + i} + W
+//!            <=  (I + i) * Q + M + (N - 1) * Q - M
+//!             =  (I + i + N - 1) * Q
 //! ```
 //!
 //! We finally show that after N - 1 compactions, the compaction invariant is restored. In
 //! particular, the remaining capacity is available without compaction.
 //!
 //! ```text
-//! V - (t_{I + N - 1} - h_{I + N - 1})  ≥  C - (|t_{I + N - 1}| - |h_{I + N - 1}|) + 1
-//! ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~   ~
-//!         immediate capacity                        remaining capacity              |
-//!                                                                         reserved for clear
+//! V - (t_{I + N - 1} - h_{I + N - 1})  >=  C - (|t_{I + N - 1}| - |h_{I + N - 1}|) + 1
+//! ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~   ~
+//!         immediate capacity                         remaining capacity              |
+//!                                                                          reserved for clear
 //! ```
 //!
 //! We can replace the definition of C and simplify:
 //!
 //! ```text
-//! V - (t_{I + N - 1} - h_{I + N - 1})  ≥  V - N - (|t_{I + N - 1}| - |h_{I + N - 1}|) + 1
-//! iff  t_{I + N - 1} - h_{I + N - 1}  ≤  |t_{I + N - 1}| - |h_{I + N - 1}| + N - 1
+//! V - (t_{I + N - 1} - h_{I + N - 1})  >=  V - N - (|t_{I + N - 1}| - |h_{I + N - 1}|) + 1
+//! iff  t_{I + N - 1} - h_{I + N - 1}  <=  |t_{I + N - 1}| - |h_{I + N - 1}| + N - 1
 //! ```
 //!
 //! We have the following properties:
@@ -296,16 +296,16 @@
 //! ```text
 //! t_{I + N - 1}  =  t_I + |h_{I + N - 1}| - |h_I| + N - 1
 //! |t_{I + N - 1}| - |h_{I + N - 1}|  =  |t_I| - |h_I|
-//! |h_{I + N - 1}| - |t_I|  ≤  h_{I + N - 1} - t_I
+//! |h_{I + N - 1}| - |t_I|  <=  h_{I + N - 1} - t_I
 //! ```
 //!
 //! From which we conclude:
 //!
 //! ```text
-//!      t_{I + N - 1} - h_{I + N - 1}  ≤  |t_{I + N - 1}| - |h_{I + N - 1}| + N - 1
-//! iff  t_I + |h_{I + N - 1}| - |h_I| + N - 1 - h_{I + N - 1}  ≤  |t_I| - |h_I| + N - 1
-//! iff  t_I + |h_{I + N - 1}| - h_{I + N - 1}  ≤  |t_I|
-//! iff  |h_{I + N - 1}| - |t_I|  ≤  h_{I + N - 1} - t_I
+//!      t_{I + N - 1} - h_{I + N - 1}  <=  |t_{I + N - 1}| - |h_{I + N - 1}| + N - 1
+//! iff  t_I + |h_{I + N - 1}| - |h_I| + N - 1 - h_{I + N - 1}  <=  |t_I| - |h_I| + N - 1
+//! iff  t_I + |h_{I + N - 1}| - h_{I + N - 1}  <=  |t_I|
+//! iff  |h_{I + N - 1}| - |t_I|  <=  h_{I + N - 1} - t_I
 //! ```
 //!
 //! ## Checksum

--- a/crates/store/src/store.rs
+++ b/crates/store/src/store.rs
@@ -92,7 +92,7 @@ fn or_invalid<T>(x: Option<T>) -> StoreResult<T> {
 ///
 /// # Invariant
 ///
-/// - The used value does not exceed the total: `used` ≤ `total`.
+/// - The used value does not exceed the total: `used` <= `total`.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct StoreRatio {
     /// How much of the metric is used.

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -29,6 +29,7 @@ use wasefire_cli_tools::{action, cmd, fs};
 
 mod footprint;
 mod lazy;
+mod textreview;
 
 #[derive(Parser)]
 struct Flags {
@@ -93,6 +94,9 @@ enum MainCommand {
         /// The markdown table is written to this file.
         output: String,
     },
+
+    /// Ensures review can be done in printed form.
+    Textreview,
 }
 
 #[derive(clap::Args)]
@@ -248,6 +252,7 @@ impl Flags {
                 cmd::execute(&mut cargo)?;
             }
             MainCommand::Footprint { output } => footprint::compare(&output)?,
+            MainCommand::Textreview => textreview::execute()?,
         }
         Ok(())
     }

--- a/crates/xtask/src/textreview.rs
+++ b/crates/xtask/src/textreview.rs
@@ -1,0 +1,151 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::io::BufRead;
+use std::process::Command;
+
+use anyhow::{ensure, Context, Result};
+use wasefire_cli_tools::cmd;
+
+pub fn execute() -> Result<()> {
+    let paths = cmd::output(Command::new("git").args(["ls-files", ":(attr:textreview)"]))?;
+    let mut errors = Vec::new();
+    for path in paths.stdout.lines() {
+        let path = path?;
+        let content = std::fs::read(&path).with_context(|| format!("reading {path}"))?;
+        verify_file(&path, content.as_slice(), &mut errors)?;
+    }
+    for error in &errors {
+        let Error { path, count, kind, line } = error;
+        println!("{path}:{count}: {kind}\n{line}");
+    }
+    ensure!(errors.is_empty(), "Found {} errors.", errors.len());
+    Ok(())
+}
+
+fn verify_file(path: &str, mut content: &[u8], errors: &mut Vec<Error>) -> Result<()> {
+    for count in 1 .. {
+        let mut line = String::new();
+        if content.read_line(&mut line)? == 0 {
+            return Ok(());
+        }
+        if let Err(kind) = verify_line(line.as_bytes()) {
+            let path = path.to_string();
+            errors.push(Error { path, count, kind, line });
+        }
+    }
+    Ok(())
+}
+
+// Verifies the following properties (that all lines in a file must satisfy):
+// - The line must end with a line-feed (0x0a).
+// - The line-feed may only be preceded by a graphic character (from 0x21 to 0x7f).
+// - The line may start with a sequence of tabs (0x09).
+// - Otherwise, the line must only contain space or graphic characters (from 0x20 to 0x7f).
+fn verify_line(mut bytes: &[u8]) -> std::result::Result<(), Kind> {
+    match bytes.split_last().unwrap() {
+        (b'\n', x) => bytes = x,
+        (&x, _) => return Err(Kind::End(x)),
+    }
+    match bytes.last() {
+        Some(b'!' ..= b'~') => (),
+        Some(&x) => return Err(Kind::Trail(x)),
+        None => return Ok(()), // empty line
+    }
+    while let Some((b'\t', x)) = bytes.split_first() {
+        bytes = x;
+    }
+    for &byte in bytes {
+        match byte {
+            b' ' ..= b'~' => (),
+            x => return Err(Kind::Inner(x)),
+        }
+    }
+    Ok(())
+}
+
+struct Error {
+    path: String,
+    count: usize,
+    kind: Kind,
+    line: String,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+enum Kind {
+    End(u8),
+    Trail(u8),
+    Inner(u8),
+}
+
+impl std::fmt::Display for Kind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match *self {
+            Kind::End(x) => write!(f, "line ends with {x:#02x} instead of 0x0a"),
+            Kind::Trail(x) => write!(f, "line trails with {x:#02x} outside of 0x21 to 0x7f"),
+            Kind::Inner(b'\t') => write!(f, "line contains 0x09 outside indentation"),
+            Kind::Inner(x) => write!(f, "line contains {x:#02x} outside of 0x20 to 0x7f"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn verify_line_ok() {
+        assert_eq!(verify_line(b"\n"), Ok(()));
+        assert_eq!(verify_line(b"hello\n"), Ok(()));
+        assert_eq!(verify_line(b"\thello\n"), Ok(()));
+        assert_eq!(verify_line(b"\t\thello world\n"), Ok(()));
+    }
+
+    #[test]
+    fn verify_line_err_end() {
+        assert_eq!(verify_line(b"hello "), Err(Kind::End(b' ')));
+        assert_eq!(verify_line(b"\t\t"), Err(Kind::End(b'\t')));
+        assert_eq!(verify_line(b"\xff"), Err(Kind::End(0xff)));
+    }
+
+    #[test]
+    fn verify_line_err_trail() {
+        assert_eq!(verify_line(b"hello \n"), Err(Kind::Trail(b' ')));
+        assert_eq!(verify_line(b"\t\t\n"), Err(Kind::Trail(b'\t')));
+        assert_eq!(verify_line(b"\xff\n"), Err(Kind::Trail(0xff)));
+    }
+
+    #[test]
+    fn verify_line_err_inner() {
+        assert_eq!(verify_line(b"\xffworld\n"), Err(Kind::Inner(0xff)));
+        assert_eq!(verify_line(b"\t\t\xffworld\n"), Err(Kind::Inner(0xff)));
+        assert_eq!(verify_line(b"hello\xffworld\n"), Err(Kind::Inner(0xff)));
+        assert_eq!(verify_line(b"hello\tworld\n"), Err(Kind::Inner(b'\t')));
+    }
+
+    #[test]
+    fn verify_file_correct() {
+        #[track_caller]
+        fn test(content: &[u8], expected: &[(usize, Kind)]) {
+            let mut actual = Vec::new();
+            verify_file("", content, &mut actual).unwrap();
+            let actual: Vec<_> = actual.into_iter().map(|x| (x.count, x.kind)).collect();
+            assert_eq!(actual, expected);
+        }
+        test(b"", &[]);
+        test(b"hello\nworld\n", &[]);
+        test(b"hello \nworld", &[(1, Kind::Trail(b' ')), (2, Kind::End(b'd'))]);
+        test(b"hel\xce\xbbo\nworld\toeu\n", &[(1, Kind::Inner(0xce)), (2, Kind::Inner(b'\t'))]);
+    }
+}

--- a/scripts/ci-copyright.sh
+++ b/scripts/ci-copyright.sh
@@ -21,12 +21,12 @@ set -e
 
 for file in $(git ls-files); do
   case "$file" in
-    *.gitignore|.gitmodules) continue ;;
+    *.gitignore|.git*) continue ;;
     third_party/*) continue ;;
     *LICENSE) continue ;;
     *.css|*.html|*.pdf|*.png|*.svg) continue ;;
     *.cff|*.json|*.lock|*.md|*.toml|*.x|*.wasm|*.yml) continue ;;
     */data/*.rs) continue ;;
   esac
-  sed -n 'N;/Copyright/q;q1' $file || e "No copyright notice in $file"
+  sed -n 'N;/Copyright/q;q1' "$file" || e "No copyright notice in $file"
 done

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -20,6 +20,7 @@ set -e
 
 x ./scripts/ci-copyright.sh
 x ./scripts/ci-changelog.sh
+x cargo xtask textreview
 x ./scripts/sync.sh
 x ./scripts/publish.sh --dry-run
 x ./scripts/ci-taplo.sh

--- a/scripts/log.sh
+++ b/scripts/log.sh
@@ -13,6 +13,11 @@
 # limitations under the License.
 
 x() { ( set -x; "$@"; ); }
-i() { echo "[1;36mInfo:[m $*"; }
-d() { echo "[1;32mDone:[m $*"; exit 0; }
-e() { echo "[1;31mError:[m $*"; exit 1; }
+i() { _log '1;36' Info "$*"; }
+d() { _log '1;32' Done "$*"; exit 0; }
+e() { _log '1;31' Error "$*"; exit 1; }
+
+# We put the escape character in a variable because bash doesn't interpret escaped characters and
+# some scripts use bash instead of sh.
+_LOG=$(printf '\e')
+_log() { echo "$_LOG[$1m$2:$_LOG[m $3"; }


### PR DESCRIPTION
It should be possible to review text files on a screen without missing (or misinterpreting) any information contained in the file. This is needed because GitHub doesn't show trailing white-space, and UTF-8 is too permissive.