### PR TITLE
Change Id::new to return a Result instead of an Option

### DIFF
--- a/crates/board/CHANGELOG.md
+++ b/crates/board/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Major
 
+- Change `Id::new` to return `Result` instead of `Option`
 - Change `crypto::{Hash,Hmac}` to depend on `crypto::WithError`
 
 ### Minor

--- a/crates/board/src/lib.rs
+++ b/crates/board/src/lib.rs
@@ -27,6 +27,7 @@ use core::marker::PhantomData;
 use core::ops::Deref;
 
 use derivative::Derivative;
+use wasefire_error::Code;
 pub use wasefire_error::Error;
 
 #[cfg(feature = "api-button")]
@@ -283,8 +284,11 @@ impl<T: Support<usize> + ?Sized> PartialOrd for Id<T> {
 
 impl<T: Support<usize>> Id<T> {
     /// Creates a safe identifier for an API with countable support.
-    pub fn new(value: usize) -> Option<Self> {
-        (value < T::SUPPORT).then_some(Self { value, count: PhantomData })
+    pub fn new(value: usize) -> Result<Self, Error> {
+        match value < T::SUPPORT {
+            true => Ok(Self { value, count: PhantomData }),
+            false => Err(Error::user(Code::InvalidArgument)),
+        }
     }
 }
 

--- a/crates/scheduler/CHANGELOG.md
+++ b/crates/scheduler/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Minor
 
+- Migrate to `Id::new` returning `Result` instead of `Option`
 - Migrate to `crypto::{Hash,Hmac}` depending on `crypto::WithError`
 - Change `led::{get,set}()` to never trap and return an error instead
 

--- a/crates/scheduler/src/call/button.rs
+++ b/crates/scheduler/src/call/button.rs
@@ -45,7 +45,7 @@ fn register<B: Board>(mut call: SchedulerCall<B, api::register::Sig>) {
     let api::register::Params { button, handler_func, handler_data } = call.read();
     let inst = call.inst();
     let result = try {
-        let button = Id::new(*button as usize).ok_or(Trap)?;
+        let button = Id::new(*button as usize).map_err(|_| Trap)?;
         call.scheduler().applet.enable(Handler {
             key: Key { button }.into(),
             inst,
@@ -62,7 +62,7 @@ fn register<B: Board>(mut call: SchedulerCall<B, api::register::Sig>) {
 fn unregister<B: Board>(mut call: SchedulerCall<B, api::unregister::Sig>) {
     let api::unregister::Params { button } = call.read();
     let result = try {
-        let button = Id::new(*button as usize).ok_or(Trap)?;
+        let button = Id::new(*button as usize).map_err(|_| Trap)?;
         board::Button::<B>::disable(button).map_err(|_| Trap)?;
         call.scheduler().disable_event(Key { button }.into())?;
         Ok(())

--- a/crates/scheduler/src/call/gpio.rs
+++ b/crates/scheduler/src/call/gpio.rs
@@ -46,7 +46,7 @@ fn count<B: Board>(call: SchedulerCall<B, api::count::Sig>) {
 fn configure<B: Board>(call: SchedulerCall<B, api::configure::Sig>) {
     let api::configure::Params { gpio, mode } = call.read();
     let result = try {
-        let gpio = Id::new(*gpio as usize).ok_or(Trap)?;
+        let gpio = Id::new(*gpio as usize).map_err(|_| Trap)?;
         let config = *bytemuck::checked::try_from_bytes(&mode.to_le_bytes()).map_err(|_| Trap)?;
         board::Gpio::<B>::configure(gpio, config)
     };
@@ -57,7 +57,7 @@ fn configure<B: Board>(call: SchedulerCall<B, api::configure::Sig>) {
 fn read<B: Board>(call: SchedulerCall<B, api::read::Sig>) {
     let api::read::Params { gpio } = call.read();
     let result = try {
-        let gpio = Id::new(*gpio as usize).ok_or(Trap)?;
+        let gpio = Id::new(*gpio as usize).map_err(|_| Trap)?;
         board::Gpio::<B>::read(gpio)
     };
     call.reply(result);
@@ -67,7 +67,7 @@ fn read<B: Board>(call: SchedulerCall<B, api::read::Sig>) {
 fn write<B: Board>(call: SchedulerCall<B, api::write::Sig>) {
     let api::write::Params { gpio, val } = call.read();
     let result = try {
-        let gpio = Id::new(*gpio as usize).ok_or(Trap)?;
+        let gpio = Id::new(*gpio as usize).map_err(|_| Trap)?;
         let value = match *val {
             0 => false,
             1 => true,
@@ -82,7 +82,7 @@ fn write<B: Board>(call: SchedulerCall<B, api::write::Sig>) {
 fn last_write<B: Board>(call: SchedulerCall<B, api::last_write::Sig>) {
     let api::last_write::Params { gpio } = call.read();
     let result = try {
-        let gpio = Id::new(*gpio as usize).ok_or(Trap)?;
+        let gpio = Id::new(*gpio as usize).map_err(|_| Trap)?;
         board::Gpio::<B>::last_write(gpio)
     };
     call.reply(result);

--- a/crates/scheduler/src/call/led.rs
+++ b/crates/scheduler/src/call/led.rs
@@ -18,8 +18,6 @@ use wasefire_board_api::led::Api as _;
 use wasefire_board_api::Api as Board;
 #[cfg(feature = "board-api-led")]
 use wasefire_board_api::{self as board, Id, Support};
-#[cfg(feature = "board-api-led")]
-use wasefire_error::{Code, Error};
 
 use crate::{DispatchSchedulerCall, SchedulerCall};
 
@@ -44,25 +42,19 @@ fn count<B: Board>(call: SchedulerCall<B, api::count::Sig>) {
 fn get<B: Board>(call: SchedulerCall<B, api::get::Sig>) {
     let api::get::Params { led } = call.read();
     let result = try {
-        match Id::new(*led as usize) {
-            Some(id) => board::Led::<B>::get(id),
-            None => Err(Error::user(Code::InvalidArgument)),
-        }
+        let id = Id::new(*led as usize)?;
+        board::Led::<B>::get(id)?
     };
-    call.reply(result);
+    call.reply(Ok(result));
 }
 
 #[cfg(feature = "board-api-led")]
 fn set<B: Board>(call: SchedulerCall<B, api::set::Sig>) {
     let api::set::Params { led, status } = call.read();
     let result = try {
-        match Id::new(*led as usize) {
-            Some(id) => {
-                let on = matches!(api::Status::try_from(*status)?, api::Status::On);
-                board::Led::<B>::set(id, on)
-            }
-            None => Err(Error::user(Code::InvalidArgument)),
-        }
+        let id = Id::new(*led as usize)?;
+        let on = matches!(api::Status::try_from(*status)?, api::Status::On);
+        board::Led::<B>::set(id, on)?
     };
-    call.reply(result);
+    call.reply(Ok(result));
 }

--- a/crates/scheduler/src/call/timer.rs
+++ b/crates/scheduler/src/call/timer.rs
@@ -104,7 +104,7 @@ fn free<B: Board>(mut call: SchedulerCall<B, api::free::Sig>) {
 fn get_timer<B: Board>(
     scheduler: &Scheduler<B>, timer: usize,
 ) -> Result<Id<board::Timer<B>>, Trap> {
-    let id = Id::new(timer).ok_or(Trap)?;
+    let id = Id::new(timer).map_err(|_| Trap)?;
     if scheduler.timers[timer].is_none() {
         return Err(Trap);
     }

--- a/crates/scheduler/src/call/uart.rs
+++ b/crates/scheduler/src/call/uart.rs
@@ -53,7 +53,7 @@ fn count<B: Board>(call: SchedulerCall<B, api::count::Sig>) {
 fn set_baudrate<B: Board>(call: SchedulerCall<B, api::set_baudrate::Sig>) {
     let api::set_baudrate::Params { uart, baudrate } = call.read();
     let result = try {
-        let uart = Id::new(*uart as usize).ok_or(Trap)?;
+        let uart = Id::new(*uart as usize).map_err(|_| Trap)?;
         board::Uart::<B>::set_baudrate(uart, *baudrate as usize)
     };
     call.reply(result);
@@ -63,7 +63,7 @@ fn set_baudrate<B: Board>(call: SchedulerCall<B, api::set_baudrate::Sig>) {
 fn start<B: Board>(call: SchedulerCall<B, api::start::Sig>) {
     let api::start::Params { uart } = call.read();
     let result = try {
-        let uart = Id::new(*uart as usize).ok_or(Trap)?;
+        let uart = Id::new(*uart as usize).map_err(|_| Trap)?;
         board::Uart::<B>::start(uart)
     };
     call.reply(result);
@@ -73,7 +73,7 @@ fn start<B: Board>(call: SchedulerCall<B, api::start::Sig>) {
 fn stop<B: Board>(call: SchedulerCall<B, api::stop::Sig>) {
     let api::stop::Params { uart } = call.read();
     let result = try {
-        let uart = Id::new(*uart as usize).ok_or(Trap)?;
+        let uart = Id::new(*uart as usize).map_err(|_| Trap)?;
         board::Uart::<B>::stop(uart)
     };
     call.reply(result);
@@ -85,7 +85,7 @@ fn read<B: Board>(mut call: SchedulerCall<B, api::read::Sig>) {
     let scheduler = call.scheduler();
     let memory = scheduler.applet.memory();
     let result = try {
-        let uart = Id::new(*uart as usize).ok_or(Trap)?;
+        let uart = Id::new(*uart as usize).map_err(|_| Trap)?;
         let output = memory.get_mut(*ptr, *len)?;
         board::Uart::<B>::read(uart, output).map(|x| x as u32)
     };
@@ -98,7 +98,7 @@ fn write<B: Board>(mut call: SchedulerCall<B, api::write::Sig>) {
     let scheduler = call.scheduler();
     let memory = scheduler.applet.memory();
     let result = try {
-        let uart = Id::new(*uart as usize).ok_or(Trap)?;
+        let uart = Id::new(*uart as usize).map_err(|_| Trap)?;
         let input = memory.get(*ptr, *len)?;
         board::Uart::<B>::write(uart, input).map(|x| x as u32)
     };
@@ -111,7 +111,7 @@ fn register<B: Board>(mut call: SchedulerCall<B, api::register::Sig>) {
     let inst = call.inst();
     let scheduler = call.scheduler();
     let result = try {
-        let uart = Id::new(*uart as usize).ok_or(Trap)?;
+        let uart = Id::new(*uart as usize).map_err(|_| Trap)?;
         let event = convert_event(uart, *event)?;
         scheduler.applet.enable(Handler {
             key: Key::from(&event).into(),
@@ -129,7 +129,7 @@ fn unregister<B: Board>(mut call: SchedulerCall<B, api::unregister::Sig>) {
     let api::unregister::Params { uart, event } = call.read();
     let scheduler = call.scheduler();
     let result = try {
-        let uart = Id::new(*uart as usize).ok_or(Trap)?;
+        let uart = Id::new(*uart as usize).map_err(|_| Trap)?;
         let event = convert_event(uart, *event)?;
         board::Uart::<B>::disable(uart, event.direction).map_err(|_| Trap)?;
         scheduler.disable_event(Key::from(&event).into())?;


### PR DESCRIPTION
Change `Id::new` to return a `Result` instead of an `Option` and migrate callers in the scheduler