### PR TITLE
Remove `impl From<Error> for Trap`

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -16,6 +16,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      # TODO(https://github.com/microsoft/linux-package-repositories/issues/130): Remove when fixed.
+      - run: sudo rm /etc/apt/sources.list.d/microsoft-prod.list
       - run: sudo apt-get update
       - run: ./scripts/setup.sh
       - run: ./scripts/pages.sh

--- a/crates/scheduler/CHANGELOG.md
+++ b/crates/scheduler/CHANGELOG.md
@@ -4,14 +4,13 @@
 
 ### Minor
 
-- Migrate implicit conversions of Error to Trap to explicit conversions
-- Remove conversion from Error to Trap
 - Migrate to `Id::new` returning `Result` instead of `Option`
 - Migrate to `crypto::{Hash,Hmac}` depending on `crypto::WithError`
 - Change `led::{get,set}()` to never trap and return an error instead
 
 ### Patch
 
+- Use explicit conversion from `Error` to `Trap`
 - Simplify `#[cfg(all)]` attributes between board and applet features
 - Update dependencies
 - Fix HKDF-SHA-384 for outputs longer than 32 bytes

--- a/crates/scheduler/CHANGELOG.md
+++ b/crates/scheduler/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Minor
 
+- Migrate implicit conversions of Error to Trap to explicit conversions
+- Remove conversion from Error to Trap
 - Migrate to `Id::new` returning `Result` instead of `Option`
 - Migrate to `crypto::{Hash,Hmac}` depending on `crypto::WithError`
 - Change `led::{get,set}()` to never trap and return an error instead

--- a/crates/scheduler/src/call/radio/ble.rs
+++ b/crates/scheduler/src/call/radio/ble.rs
@@ -82,7 +82,7 @@ fn read_advertisement<B: Board>(mut call: SchedulerCall<B, api::read_advertiseme
 
 #[cfg(feature = "board-api-radio-ble")]
 fn convert_event(event: u32) -> Result<Event, Trap> {
-    Ok(match api::Event::try_from(event)? {
+    Ok(match api::Event::try_from(event).map_err(|_| Trap)? {
         api::Event::Advertisement => Event::Advertisement,
     })
 }

--- a/crates/scheduler/src/call/timer.rs
+++ b/crates/scheduler/src/call/timer.rs
@@ -67,7 +67,7 @@ fn start<B: Board>(mut call: SchedulerCall<B, api::start::Sig>) {
     let timer = *id as usize;
     let result = try {
         let id = get_timer(call.scheduler(), timer)?;
-        let periodic = matches!(api::Mode::try_from(*mode)?, api::Mode::Periodic);
+        let periodic = matches!(api::Mode::try_from(*mode).map_err(|_| Trap)?, api::Mode::Periodic);
         let duration_ms = *duration_ms as usize;
         let command = Command { periodic, duration_ms };
         board::Timer::<B>::arm(id, &command)

--- a/crates/scheduler/src/call/uart.rs
+++ b/crates/scheduler/src/call/uart.rs
@@ -140,7 +140,7 @@ fn unregister<B: Board>(mut call: SchedulerCall<B, api::unregister::Sig>) {
 
 #[cfg(feature = "board-api-uart")]
 fn convert_event<B: Board>(uart: Id<board::Uart<B>>, event: u32) -> Result<Event<B>, Trap> {
-    let direction = match api::Event::try_from(event)? {
+    let direction = match api::Event::try_from(event).map_err(|_| Trap)? {
         api::Event::Read => Direction::Read,
         api::Event::Write => Direction::Write,
     };

--- a/crates/scheduler/src/call/usb/serial.rs
+++ b/crates/scheduler/src/call/usb/serial.rs
@@ -103,7 +103,7 @@ fn flush<B: Board>(call: SchedulerCall<B, api::flush::Sig>) {
 
 #[cfg(feature = "board-api-usb-serial")]
 fn convert_event(event: u32) -> Result<Event, Trap> {
-    Ok(match api::Event::try_from(event)? {
+    Ok(match api::Event::try_from(event).map_err(|_| Trap)? {
         api::Event::Read => Event::Read,
         api::Event::Write => Event::Write,
     })

--- a/crates/scheduler/src/lib.rs
+++ b/crates/scheduler/src/lib.rs
@@ -437,12 +437,6 @@ fn applet_trapped<B: Board>(reason: Option<&'static str>) -> ! {
 
 struct Trap;
 
-impl From<wasefire_error::Error> for Trap {
-    fn from(_: wasefire_error::Error) -> Self {
-        Trap
-    }
-}
-
 #[cfg(feature = "wasm")]
 const fn memory_size() -> usize {
     let page = match option_env!("WASEFIRE_MEMORY_PAGE_COUNT") {


### PR DESCRIPTION
Remove `impl From<Error> for Trap` as per [this comment](https://github.com/google/wasefire/pull/437#discussion_r1575107894) and migrate callers to use `map_err(|_| Trap)` instead for an explicit conversion.