### PR TITLE
Change `scheduler::call::button::new` to never trap

### DIFF
--- a/book/src/applet/prelude/button1.rs
+++ b/book/src/applet/prelude/button1.rs
@@ -38,7 +38,7 @@ fn main() {
 
         //{ ANCHOR: listener
         // We start listening for state changes with the handler.
-        let listener = button::Listener::new(index, handler);
+        let listener = button::Listener::new(index, handler).unwrap();
         //} ANCHOR_END: listener
 
         //{ ANCHOR: leak

--- a/book/src/applet/prelude/button2.rs
+++ b/book/src/applet/prelude/button2.rs
@@ -65,7 +65,7 @@ fn main() {
 
         //{ ANCHOR: listener
         // We indefinitely listen by creating and leaking a listener.
-        button::Listener::new(button_index, handler).leak();
+        button::Listener::new(button_index, handler).unwrap().leak();
         //} ANCHOR_END: listener
     }
 }

--- a/book/src/applet/prelude/timer.rs
+++ b/book/src/applet/prelude/timer.rs
@@ -66,7 +66,8 @@ fn main() {
                 button::Released if pressed.get() => released.set(true),
                 button::Released => (),
             }
-        });
+        })
+        .unwrap();
         //} ANCHOR_END: button
 
         //{ ANCHOR: pressed

--- a/crates/prelude/CHANGELOG.md
+++ b/crates/prelude/CHANGELOG.md
@@ -4,9 +4,7 @@
 
 ### Major
 
-- Change `button::Listener::new()` to never panic and return an error instead.
-
-## 0.5.1-git
+- Change `button::Listener::new()` to never panic and return an error instead
 
 ### Minor
 

--- a/crates/prelude/CHANGELOG.md
+++ b/crates/prelude/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.6.0-git
+
+### Major
+
+- Change `button::Listener::new()` to never panic and return an error instead.
+
 ## 0.5.1-git
 
 ### Minor

--- a/crates/prelude/Cargo.lock
+++ b/crates/prelude/Cargo.lock
@@ -312,7 +312,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasefire"
-version = "0.5.1-git"
+version = "0.6.0-git"
 dependencies = [
  "aead",
  "bytemuck",

--- a/crates/prelude/Cargo.toml
+++ b/crates/prelude/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasefire"
-version = "0.5.1-git"
+version = "0.6.0-git"
 authors = ["Julien Cretin <cretin@google.com>"]
 license = "Apache-2.0"
 publish = true

--- a/crates/prelude/src/button.rs
+++ b/crates/prelude/src/button.rs
@@ -21,6 +21,7 @@
 use alloc::boxed::Box;
 
 use wasefire_applet_api::button as api;
+use wasefire_error::Error;
 
 pub use self::api::State;
 pub use self::api::State::*;
@@ -64,15 +65,15 @@ impl<H: Handler> Listener<H> {
     /// # Examples
     ///
     /// ```ignore
-    /// Listener::new(index, |state| debug!("Button has been {state:?}"))
+    /// Listener::new(index, |state| debug!("Button has been {state:?}"))?
     /// ```
-    pub fn new(button: usize, handler: H) -> Self {
+    pub fn new(button: usize, handler: H) -> Result<Self, Error> {
         let handler_func = Self::call;
         let handler = Box::into_raw(Box::new(handler));
         let handler_data = handler as *const u8;
         let params = api::register::Params { button, handler_func, handler_data };
-        convert_unit(unsafe { api::register(params) }).unwrap();
-        Listener { button, handler }
+        convert_unit(unsafe { api::register(params) })?;
+        Ok(Listener { button, handler })
     }
 
     /// Stops listening.

--- a/crates/scheduler/CHANGELOG.md
+++ b/crates/scheduler/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Minor
 
+- Change `button::{register, unregister}()` to never trap and return an error instead
 - Migrate to `Id::new` returning `Result` instead of `Option`
 - Migrate to `crypto::{Hash,Hmac}` depending on `crypto::WithError`
 - Change `led::{get,set}()` to never trap and return an error instead

--- a/crates/scheduler/src/call/button.rs
+++ b/crates/scheduler/src/call/button.rs
@@ -16,11 +16,11 @@ use wasefire_applet_api::button::{self as api, Api};
 use wasefire_board_api::Api as Board;
 #[cfg(feature = "board-api-button")]
 use wasefire_board_api::{self as board, button::Api as _, Id, Support};
+#[cfg(feature = "board-api-button")]
+use wasefire_error::{Code, Error};
 
 #[cfg(feature = "board-api-button")]
 use crate::event::{button::Key, Handler};
-#[cfg(feature = "board-api-button")]
-use crate::Trap;
 use crate::{DispatchSchedulerCall, SchedulerCall};
 
 pub fn process<B: Board>(call: Api<DispatchSchedulerCall<B>>) {
@@ -45,27 +45,30 @@ fn register<B: Board>(mut call: SchedulerCall<B, api::register::Sig>) {
     let api::register::Params { button, handler_func, handler_data } = call.read();
     let inst = call.inst();
     let result = try {
-        let button = Id::new(*button as usize).map_err(|_| Trap)?;
-        call.scheduler().applet.enable(Handler {
-            key: Key { button }.into(),
-            inst,
-            func: *handler_func,
-            data: *handler_data,
-        })?;
-        board::Button::<B>::enable(button).map_err(|_| Trap)?;
-        Ok(())
+        let button = Id::new(*button as usize)?;
+        call.scheduler()
+            .applet
+            .enable(Handler {
+                key: Key { button }.into(),
+                inst,
+                func: *handler_func,
+                data: *handler_data,
+            })
+            .map_err(|_| Error::user(Code::InvalidState))?;
+        board::Button::<B>::enable(button)?;
     };
-    call.reply(result);
+    call.reply(Ok(result));
 }
 
 #[cfg(feature = "board-api-button")]
 fn unregister<B: Board>(mut call: SchedulerCall<B, api::unregister::Sig>) {
     let api::unregister::Params { button } = call.read();
     let result = try {
-        let button = Id::new(*button as usize).map_err(|_| Trap)?;
-        board::Button::<B>::disable(button).map_err(|_| Trap)?;
-        call.scheduler().disable_event(Key { button }.into())?;
-        Ok(())
+        let button = Id::new(*button as usize)?;
+        board::Button::<B>::disable(button)?;
+        call.scheduler()
+            .disable_event(Key { button }.into())
+            .map_err(|_| Error::user(Code::InvalidState))?;
     };
-    call.reply(result);
+    call.reply(Ok(result));
 }

--- a/examples/rust/blink/Cargo.lock
+++ b/examples/rust/blink/Cargo.lock
@@ -283,7 +283,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasefire"
-version = "0.5.1-git"
+version = "0.6.0-git"
 dependencies = [
  "bytemuck",
  "const-default",

--- a/examples/rust/blink_periodic/Cargo.lock
+++ b/examples/rust/blink_periodic/Cargo.lock
@@ -283,7 +283,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasefire"
-version = "0.5.1-git"
+version = "0.6.0-git"
 dependencies = [
  "bytemuck",
  "const-default",

--- a/examples/rust/button/Cargo.lock
+++ b/examples/rust/button/Cargo.lock
@@ -283,7 +283,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasefire"
-version = "0.5.1-git"
+version = "0.6.0-git"
 dependencies = [
  "bytemuck",
  "const-default",

--- a/examples/rust/button/src/lib.rs
+++ b/examples/rust/button/src/lib.rs
@@ -34,7 +34,7 @@ fn main() {
         let handler = move |state| debug!("Button {index} has been {state:?}.");
 
         // We start listening for state changes with the handler.
-        let listener = button::Listener::new(index, handler);
+        let listener = button::Listener::new(index, handler).unwrap();
 
         // We leak the listener to continue listening for events.
         listener.leak();

--- a/examples/rust/button_abort/Cargo.lock
+++ b/examples/rust/button_abort/Cargo.lock
@@ -283,7 +283,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasefire"
-version = "0.5.1-git"
+version = "0.6.0-git"
 dependencies = [
  "bytemuck",
  "const-default",

--- a/examples/rust/button_abort/src/lib.rs
+++ b/examples/rust/button_abort/src/lib.rs
@@ -62,7 +62,8 @@ fn main() {
                 button::Released if pressed.get() => released.set(true),
                 button::Released => (),
             }
-        });
+        })
+        .unwrap();
 
         // Wait for the button to be pressed.
         scheduling::wait_until(|| pressed.get());

--- a/examples/rust/ccm/Cargo.lock
+++ b/examples/rust/ccm/Cargo.lock
@@ -283,7 +283,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasefire"
-version = "0.5.1-git"
+version = "0.6.0-git"
 dependencies = [
  "bytemuck",
  "const-default",

--- a/examples/rust/ctap/Cargo.lock
+++ b/examples/rust/ctap/Cargo.lock
@@ -283,7 +283,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasefire"
-version = "0.5.1-git"
+version = "0.6.0-git"
 dependencies = [
  "bytemuck",
  "const-default",

--- a/examples/rust/ctap/src/lib.rs
+++ b/examples/rust/ctap/src/lib.rs
@@ -269,7 +269,8 @@ impl Touch {
                 blink: blink.clone(),
                 timeout: timeout.clone(),
             },
-        );
+        )
+        .unwrap();
         Some(Self { console, light, touched, blink, timeout, _button })
     }
 

--- a/examples/rust/ec_test/Cargo.lock
+++ b/examples/rust/ec_test/Cargo.lock
@@ -559,7 +559,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasefire"
-version = "0.5.1-git"
+version = "0.6.0-git"
 dependencies = [
  "bytemuck",
  "const-default",

--- a/examples/rust/echo/Cargo.lock
+++ b/examples/rust/echo/Cargo.lock
@@ -283,7 +283,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasefire"
-version = "0.5.1-git"
+version = "0.6.0-git"
 dependencies = [
  "bytemuck",
  "const-default",

--- a/examples/rust/exercises/client/Cargo.lock
+++ b/examples/rust/exercises/client/Cargo.lock
@@ -867,7 +867,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasefire"
-version = "0.5.1-git"
+version = "0.6.0-git"
 dependencies = [
  "bytemuck",
  "const-default",

--- a/examples/rust/exercises/interface/Cargo.lock
+++ b/examples/rust/exercises/interface/Cargo.lock
@@ -328,7 +328,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasefire"
-version = "0.5.1-git"
+version = "0.6.0-git"
 dependencies = [
  "bytemuck",
  "const-default",

--- a/examples/rust/exercises/part-1-sol/Cargo.lock
+++ b/examples/rust/exercises/part-1-sol/Cargo.lock
@@ -283,7 +283,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasefire"
-version = "0.5.1-git"
+version = "0.6.0-git"
 dependencies = [
  "bytemuck",
  "const-default",

--- a/examples/rust/exercises/part-1/Cargo.lock
+++ b/examples/rust/exercises/part-1/Cargo.lock
@@ -283,7 +283,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasefire"
-version = "0.5.1-git"
+version = "0.6.0-git"
 dependencies = [
  "bytemuck",
  "const-default",

--- a/examples/rust/exercises/part-2-sol/Cargo.lock
+++ b/examples/rust/exercises/part-2-sol/Cargo.lock
@@ -336,7 +336,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasefire"
-version = "0.5.1-git"
+version = "0.6.0-git"
 dependencies = [
  "bytemuck",
  "const-default",

--- a/examples/rust/exercises/part-2/Cargo.lock
+++ b/examples/rust/exercises/part-2/Cargo.lock
@@ -336,7 +336,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasefire"
-version = "0.5.1-git"
+version = "0.6.0-git"
 dependencies = [
  "bytemuck",
  "const-default",

--- a/examples/rust/exercises/part-3-sol/Cargo.lock
+++ b/examples/rust/exercises/part-3-sol/Cargo.lock
@@ -336,7 +336,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasefire"
-version = "0.5.1-git"
+version = "0.6.0-git"
 dependencies = [
  "bytemuck",
  "const-default",

--- a/examples/rust/exercises/part-3/Cargo.lock
+++ b/examples/rust/exercises/part-3/Cargo.lock
@@ -336,7 +336,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasefire"
-version = "0.5.1-git"
+version = "0.6.0-git"
 dependencies = [
  "bytemuck",
  "const-default",

--- a/examples/rust/exercises/part-4-sol/Cargo.lock
+++ b/examples/rust/exercises/part-4-sol/Cargo.lock
@@ -336,7 +336,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasefire"
-version = "0.5.1-git"
+version = "0.6.0-git"
 dependencies = [
  "bytemuck",
  "const-default",

--- a/examples/rust/exercises/part-4/Cargo.lock
+++ b/examples/rust/exercises/part-4/Cargo.lock
@@ -336,7 +336,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasefire"
-version = "0.5.1-git"
+version = "0.6.0-git"
 dependencies = [
  "bytemuck",
  "const-default",

--- a/examples/rust/exercises/part-5-sol/Cargo.lock
+++ b/examples/rust/exercises/part-5-sol/Cargo.lock
@@ -336,7 +336,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasefire"
-version = "0.5.1-git"
+version = "0.6.0-git"
 dependencies = [
  "bytemuck",
  "const-default",

--- a/examples/rust/exercises/part-5-sol/src/touch.rs
+++ b/examples/rust/exercises/part-5-sol/src/touch.rs
@@ -36,7 +36,8 @@ impl Touch {
                     pressed.set(true);
                 }
             }
-        });
+        })
+        .unwrap();
         scheduling::wait_until(|| pressed.get());
         led::set(0, led::Off);
         Ok(())

--- a/examples/rust/exercises/part-5/Cargo.lock
+++ b/examples/rust/exercises/part-5/Cargo.lock
@@ -336,7 +336,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasefire"
-version = "0.5.1-git"
+version = "0.6.0-git"
 dependencies = [
  "bytemuck",
  "const-default",

--- a/examples/rust/exercises/part-6-sol/Cargo.lock
+++ b/examples/rust/exercises/part-6-sol/Cargo.lock
@@ -336,7 +336,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasefire"
-version = "0.5.1-git"
+version = "0.6.0-git"
 dependencies = [
  "bytemuck",
  "const-default",

--- a/examples/rust/exercises/part-6-sol/src/touch.rs
+++ b/examples/rust/exercises/part-6-sol/src/touch.rs
@@ -37,7 +37,8 @@ impl Touch {
                     pressed.set(true);
                 }
             }
-        });
+        })
+        .unwrap();
         let timed_out = Rc::new(Cell::new(false));
         let timer = timer::Timer::new({
             let timed_out = timed_out.clone();

--- a/examples/rust/exercises/part-6/Cargo.lock
+++ b/examples/rust/exercises/part-6/Cargo.lock
@@ -336,7 +336,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasefire"
-version = "0.5.1-git"
+version = "0.6.0-git"
 dependencies = [
  "bytemuck",
  "const-default",

--- a/examples/rust/exercises/part-6/src/touch.rs
+++ b/examples/rust/exercises/part-6/src/touch.rs
@@ -37,7 +37,8 @@ impl Touch {
                     pressed.set(true);
                 }
             }
-        });
+        })
+        .unwrap();
         // TODO: Create a timed_out variable similar to pressed.
         // TODO: Use timer::Timer to allocate a new timer.
         // TODO: Unconditionally set the timed_out variable in its callback (similar to pressed).

--- a/examples/rust/exercises/part-7-sol/Cargo.lock
+++ b/examples/rust/exercises/part-7-sol/Cargo.lock
@@ -336,7 +336,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasefire"
-version = "0.5.1-git"
+version = "0.6.0-git"
 dependencies = [
  "bytemuck",
  "const-default",

--- a/examples/rust/exercises/part-7-sol/src/touch.rs
+++ b/examples/rust/exercises/part-7-sol/src/touch.rs
@@ -34,7 +34,7 @@ struct Blink;
 impl Touch {
     pub fn new() -> Self {
         let touch = Touch::default();
-        let _button = button::Listener::new(0, touch.clone());
+        let _button = button::Listener::new(0, touch.clone()).unwrap();
         let blink = timer::Timer::new(Blink);
         let timeout = timer::Timer::new(touch.clone());
         let touch_impl = TouchImpl { touched: false, _button, blink, timeout };

--- a/examples/rust/exercises/part-7/Cargo.lock
+++ b/examples/rust/exercises/part-7/Cargo.lock
@@ -336,7 +336,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasefire"
-version = "0.5.1-git"
+version = "0.6.0-git"
 dependencies = [
  "bytemuck",
  "const-default",

--- a/examples/rust/gcm_test/Cargo.lock
+++ b/examples/rust/gcm_test/Cargo.lock
@@ -320,7 +320,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasefire"
-version = "0.5.1-git"
+version = "0.6.0-git"
 dependencies = [
  "aead",
  "bytemuck",

--- a/examples/rust/gpio_test/Cargo.lock
+++ b/examples/rust/gpio_test/Cargo.lock
@@ -283,7 +283,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasefire"
-version = "0.5.1-git"
+version = "0.6.0-git"
 dependencies = [
  "bytemuck",
  "const-default",

--- a/examples/rust/hash_test/Cargo.lock
+++ b/examples/rust/hash_test/Cargo.lock
@@ -570,7 +570,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasefire"
-version = "0.5.1-git"
+version = "0.6.0-git"
 dependencies = [
  "aead",
  "bytemuck",

--- a/examples/rust/hello/Cargo.lock
+++ b/examples/rust/hello/Cargo.lock
@@ -283,7 +283,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasefire"
-version = "0.5.1-git"
+version = "0.6.0-git"
 dependencies = [
  "bytemuck",
  "const-default",

--- a/examples/rust/hsm/Cargo.lock
+++ b/examples/rust/hsm/Cargo.lock
@@ -291,7 +291,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasefire"
-version = "0.5.1-git"
+version = "0.6.0-git"
 dependencies = [
  "bytemuck",
  "const-default",

--- a/examples/rust/hsm/common/Cargo.lock
+++ b/examples/rust/hsm/common/Cargo.lock
@@ -304,7 +304,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasefire"
-version = "0.5.1-git"
+version = "0.6.0-git"
 dependencies = [
  "bytemuck",
  "const-default",

--- a/examples/rust/led/Cargo.lock
+++ b/examples/rust/led/Cargo.lock
@@ -283,7 +283,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasefire"
-version = "0.5.1-git"
+version = "0.6.0-git"
 dependencies = [
  "bytemuck",
  "const-default",

--- a/examples/rust/led/src/lib.rs
+++ b/examples/rust/led/src/lib.rs
@@ -57,6 +57,6 @@ fn main() {
         };
 
         // We indefinitely listen by creating and leaking a listener.
-        button::Listener::new(button_index, handler).leak();
+        button::Listener::new(button_index, handler).unwrap().leak();
     }
 }

--- a/examples/rust/link_test/Cargo.lock
+++ b/examples/rust/link_test/Cargo.lock
@@ -284,7 +284,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasefire"
-version = "0.5.1-git"
+version = "0.6.0-git"
 dependencies = [
  "bytemuck",
  "const-default",

--- a/examples/rust/memory_game/Cargo.lock
+++ b/examples/rust/memory_game/Cargo.lock
@@ -283,7 +283,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasefire"
-version = "0.5.1-git"
+version = "0.6.0-git"
 dependencies = [
  "bytemuck",
  "const-default",

--- a/examples/rust/oom/Cargo.lock
+++ b/examples/rust/oom/Cargo.lock
@@ -283,7 +283,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasefire"
-version = "0.5.1-git"
+version = "0.6.0-git"
 dependencies = [
  "bytemuck",
  "const-default",

--- a/examples/rust/panic/Cargo.lock
+++ b/examples/rust/panic/Cargo.lock
@@ -283,7 +283,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasefire"
-version = "0.5.1-git"
+version = "0.6.0-git"
 dependencies = [
  "bytemuck",
  "const-default",

--- a/examples/rust/perf/Cargo.lock
+++ b/examples/rust/perf/Cargo.lock
@@ -283,7 +283,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasefire"
-version = "0.5.1-git"
+version = "0.6.0-git"
 dependencies = [
  "bytemuck",
  "const-default",

--- a/examples/rust/rand/Cargo.lock
+++ b/examples/rust/rand/Cargo.lock
@@ -283,7 +283,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasefire"
-version = "0.5.1-git"
+version = "0.6.0-git"
 dependencies = [
  "bytemuck",
  "const-default",

--- a/examples/rust/reboot/Cargo.lock
+++ b/examples/rust/reboot/Cargo.lock
@@ -283,7 +283,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasefire"
-version = "0.5.1-git"
+version = "0.6.0-git"
 dependencies = [
  "bytemuck",
  "const-default",

--- a/examples/rust/reboot/src/lib.rs
+++ b/examples/rust/reboot/src/lib.rs
@@ -38,7 +38,8 @@ fn press() {
     let button = button::Listener::new(0, |event| match event {
         button::Pressed => PRESSED.store(true, Relaxed),
         button::Released => (),
-    });
+    })
+    .unwrap();
     scheduling::wait_until(|| PRESSED.load(Relaxed));
     drop(button);
 }

--- a/examples/rust/rng_test/Cargo.lock
+++ b/examples/rust/rng_test/Cargo.lock
@@ -283,7 +283,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasefire"
-version = "0.5.1-git"
+version = "0.6.0-git"
 dependencies = [
  "bytemuck",
  "const-default",

--- a/examples/rust/store/Cargo.lock
+++ b/examples/rust/store/Cargo.lock
@@ -283,7 +283,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasefire"
-version = "0.5.1-git"
+version = "0.6.0-git"
 dependencies = [
  "bytemuck",
  "const-default",

--- a/examples/rust/store_test/Cargo.lock
+++ b/examples/rust/store_test/Cargo.lock
@@ -283,7 +283,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasefire"
-version = "0.5.1-git"
+version = "0.6.0-git"
 dependencies = [
  "bytemuck",
  "const-default",

--- a/examples/rust/sync_test/Cargo.lock
+++ b/examples/rust/sync_test/Cargo.lock
@@ -283,7 +283,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasefire"
-version = "0.5.1-git"
+version = "0.6.0-git"
 dependencies = [
  "bytemuck",
  "const-default",

--- a/examples/rust/syscall_test/Cargo.lock
+++ b/examples/rust/syscall_test/Cargo.lock
@@ -283,7 +283,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasefire"
-version = "0.5.1-git"
+version = "0.6.0-git"
 dependencies = [
  "bytemuck",
  "const-default",

--- a/examples/rust/timer/Cargo.lock
+++ b/examples/rust/timer/Cargo.lock
@@ -283,7 +283,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasefire"
-version = "0.5.1-git"
+version = "0.6.0-git"
 dependencies = [
  "bytemuck",
  "const-default",

--- a/examples/rust/timer_test/Cargo.lock
+++ b/examples/rust/timer_test/Cargo.lock
@@ -283,7 +283,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasefire"
-version = "0.5.1-git"
+version = "0.6.0-git"
 dependencies = [
  "bytemuck",
  "const-default",

--- a/examples/rust/uart-usb/Cargo.lock
+++ b/examples/rust/uart-usb/Cargo.lock
@@ -283,7 +283,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasefire"
-version = "0.5.1-git"
+version = "0.6.0-git"
 dependencies = [
  "bytemuck",
  "const-default",

--- a/examples/rust/update/Cargo.lock
+++ b/examples/rust/update/Cargo.lock
@@ -283,7 +283,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasefire"
-version = "0.5.1-git"
+version = "0.6.0-git"
 dependencies = [
  "bytemuck",
  "const-default",

--- a/examples/rust/version/Cargo.lock
+++ b/examples/rust/version/Cargo.lock
@@ -283,7 +283,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasefire"
-version = "0.5.1-git"
+version = "0.6.0-git"
 dependencies = [
  "bytemuck",
  "const-default",


### PR DESCRIPTION
This PR changes `scheduler::call::button::new` to never trap and return a `Result<(), Error>` instead.