### PR TITLE
Change prelude main to return a Result

### DIFF
--- a/book/src/applet/prelude/button1.rs
+++ b/book/src/applet/prelude/button1.rs
@@ -20,7 +20,7 @@
 #![no_std]
 wasefire::applet!();
 
-fn main() {
+fn main() -> Result<(), Error> {
     //{ ANCHOR: count
     // Make sure there is at least one button.
     let count = button::count();
@@ -38,7 +38,7 @@ fn main() {
 
         //{ ANCHOR: listener
         // We start listening for state changes with the handler.
-        let listener = button::Listener::new(index, handler).unwrap();
+        let listener = button::Listener::new(index, handler)?;
         //} ANCHOR_END: listener
 
         //{ ANCHOR: leak

--- a/book/src/applet/prelude/button2.rs
+++ b/book/src/applet/prelude/button2.rs
@@ -27,7 +27,7 @@ wasefire::applet!();
 use alloc::boxed::Box;
 use core::cell::Cell;
 
-fn main() {
+fn main() -> Result<(), Error> {
     //{ ANCHOR: setup
     // Make sure there is at least one button.
     let num_buttons = button::count();
@@ -65,8 +65,10 @@ fn main() {
 
         //{ ANCHOR: listener
         // We indefinitely listen by creating and leaking a listener.
-        button::Listener::new(button_index, handler).unwrap().leak();
+        button::Listener::new(button_index, handler)?.leak();
         //} ANCHOR_END: listener
     }
+
+    Ok(())
 }
 //} ANCHOR_END: all

--- a/book/src/applet/prelude/timer.rs
+++ b/book/src/applet/prelude/timer.rs
@@ -28,7 +28,7 @@ use alloc::rc::Rc;
 use core::cell::Cell;
 use core::time::Duration;
 
-fn main() {
+fn main() -> Result<(), Error> {
     assert!(button::count() > 0, "Board has no buttons.");
     assert!(led::count() > 0, "Board has no LEDs.");
 
@@ -66,8 +66,7 @@ fn main() {
                 button::Released if pressed.get() => released.set(true),
                 button::Released => (),
             }
-        })
-        .unwrap();
+        })?;
         //} ANCHOR_END: button
 
         //{ ANCHOR: pressed

--- a/crates/prelude/CHANGELOG.md
+++ b/crates/prelude/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Minor
 
+- Allow main to return an error
 - Change `led::{get,set}()` to never trap and return an error instead
 - Document all public API
 - Remove deprecated `println!` macro

--- a/crates/prelude/src/_internal.rs
+++ b/crates/prelude/src/_internal.rs
@@ -1,0 +1,31 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub trait MaybeUnwrap {
+    fn maybe_unwrap(self);
+}
+
+impl MaybeUnwrap for () {
+    fn maybe_unwrap(self) {}
+}
+
+impl MaybeUnwrap for ! {
+    fn maybe_unwrap(self) {}
+}
+
+impl MaybeUnwrap for Result<(), crate::Error> {
+    fn maybe_unwrap(self) {
+        self.unwrap();
+    }
+}

--- a/crates/prelude/src/lib.rs
+++ b/crates/prelude/src/lib.rs
@@ -40,6 +40,10 @@ extern crate alloc;
 use wasefire_applet_api as api;
 pub use wasefire_error::Error;
 
+// This internal module is made public because it's used by exported macros called from user code.
+#[doc(hidden)]
+pub mod _internal;
+
 mod allocator;
 #[cfg(feature = "api-button")]
 pub mod button;
@@ -104,8 +108,11 @@ macro_rules! applet {
         use wasefire::*;
 
         #[export_name = "main"]
+        #[allow(unreachable_code)]
+        #[allow(clippy::diverging_sub_expression)]
         extern "C" fn _main() {
-            main();
+            use $crate::_internal::MaybeUnwrap as _;
+            main().maybe_unwrap();
         }
     };
 }
@@ -119,8 +126,11 @@ macro_rules! applet {
         use wasefire::*;
 
         #[no_mangle]
+        #[allow(unreachable_code)]
+        #[allow(clippy::diverging_sub_expression)]
         extern "C" fn applet_main() {
-            main();
+            use $crate::_internal::MaybeUnwrap as _;
+            main().maybe_unwrap();
         }
     };
 }

--- a/examples/rust/button/src/lib.rs
+++ b/examples/rust/button/src/lib.rs
@@ -23,7 +23,7 @@
 #![no_std]
 wasefire::applet!();
 
-fn main() {
+fn main() -> Result<(), Error> {
     // Make sure there is at least one button.
     let count = button::count();
     assert!(count > 0, "Board has no buttons.");
@@ -34,7 +34,7 @@ fn main() {
         let handler = move |state| debug!("Button {index} has been {state:?}.");
 
         // We start listening for state changes with the handler.
-        let listener = button::Listener::new(index, handler).unwrap();
+        let listener = button::Listener::new(index, handler)?;
 
         // We leak the listener to continue listening for events.
         listener.leak();

--- a/examples/rust/button_abort/src/lib.rs
+++ b/examples/rust/button_abort/src/lib.rs
@@ -31,7 +31,7 @@ use alloc::rc::Rc;
 use core::cell::Cell;
 use core::time::Duration;
 
-fn main() {
+fn main() -> Result<(), Error> {
     assert!(button::count() > 0, "Board has no buttons.");
     assert!(led::count() > 0, "Board has no LEDs.");
 
@@ -62,8 +62,7 @@ fn main() {
                 button::Released if pressed.get() => released.set(true),
                 button::Released => (),
             }
-        })
-        .unwrap();
+        })?;
 
         // Wait for the button to be pressed.
         scheduling::wait_until(|| pressed.get());

--- a/examples/rust/led/src/lib.rs
+++ b/examples/rust/led/src/lib.rs
@@ -30,7 +30,7 @@ wasefire::applet!();
 use alloc::boxed::Box;
 use core::cell::Cell;
 
-fn main() {
+fn main() -> Result<(), Error> {
     // Make sure there is at least one button.
     let num_buttons = button::count();
     assert!(num_buttons > 0, "Board has no buttons.");
@@ -57,6 +57,8 @@ fn main() {
         };
 
         // We indefinitely listen by creating and leaking a listener.
-        button::Listener::new(button_index, handler).unwrap().leak();
+        button::Listener::new(button_index, handler)?.leak();
     }
+
+    Ok(())
 }


### PR DESCRIPTION
In #441 we changed `button::Listener::new` to never trap and never return an error, allowing users to use an early return of `?` if they don't care about the error. That PR `unwrap` ed the result instead of handling the error or propagating the error to its caller (sometimes ` main()`). 

This PR makes sure we properly handle the errors that we get from ` button::Listener::new` . 