### PR TITLE
Depend on official nrf-usbd repository

### DIFF
--- a/crates/runner-nordic/Cargo.lock
+++ b/crates/runner-nordic/Cargo.lock
@@ -654,7 +654,7 @@ dependencies = [
 [[package]]
 name = "nrf-usbd"
 version = "0.2.0"
-source = "git+https://github.com/ia0/nrf-usbd.git?branch=bump#b1db2c14f5c1a2c9c38415ff996e02046777d33b"
+source = "git+https://github.com/nrf-rs/nrf-usbd.git?rev=c736b03214e740d06251266b56d36c648a6c7f1b#c736b03214e740d06251266b56d36c648a6c7f1b"
 dependencies = [
  "cortex-m",
  "critical-section",

--- a/crates/runner-nordic/Cargo.toml
+++ b/crates/runner-nordic/Cargo.toml
@@ -73,5 +73,7 @@ release = ["dep:panic-abort"]
 native = ["wasefire-scheduler/native"]
 wasm = ["dep:wasefire-interpreter", "wasefire-scheduler/wasm"]
 
-[patch.crates-io]
-nrf-usbd = { git = "https://github.com/ia0/nrf-usbd.git", branch = "bump" }
+# TODO(nrf-usbd > 0.2): Remove once the update makes it to nrf-hal-common and nrf52840-hal.
+[patch.crates-io.nrf-usbd]
+git = "https://github.com/nrf-rs/nrf-usbd.git"
+rev = "c736b03214e740d06251266b56d36c648a6c7f1b"


### PR DESCRIPTION
Now that https://github.com/nrf-rs/nrf-usbd/pull/17 has been merged.