### PR TITLE
Change gpio functions to never trap

### DIFF
--- a/crates/prelude/CHANGELOG.md
+++ b/crates/prelude/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Major
 
+- Change `Gpio` to never panic and return an error instead
 - Change `button::Listener::new()` to never panic and return an error instead
 
 ### Minor

--- a/crates/prelude/CHANGELOG.md
+++ b/crates/prelude/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Major
 
-- Change `Gpio` to never panic and return an error instead
+- Change `gpio` module to never panic and return an error instead
 - Change `button::Listener::new()` to never panic and return an error instead
 
 ### Minor

--- a/crates/scheduler/CHANGELOG.md
+++ b/crates/scheduler/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Minor
 
+- Change gpio functions to never trap and return an error instead
 - Change `button::{register, unregister}()` to never trap and return an error instead
 - Migrate to `Id::new` returning `Result` instead of `Option`
 - Migrate to `crypto::{Hash,Hmac}` depending on `crypto::WithError`

--- a/crates/scheduler/CHANGELOG.md
+++ b/crates/scheduler/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Minor
 
-- Change gpio functions to never trap and return an error instead
+- Change `gpio` module to never trap and return an error instead
 - Change `button::{register, unregister}()` to never trap and return an error instead
 - Migrate to `Id::new` returning `Result` instead of `Option`
 - Migrate to `crypto::{Hash,Hmac}` depending on `crypto::WithError`

--- a/crates/scheduler/src/call/gpio.rs
+++ b/crates/scheduler/src/call/gpio.rs
@@ -18,9 +18,9 @@ use wasefire_board_api::gpio::Api as _;
 use wasefire_board_api::Api as Board;
 #[cfg(feature = "board-api-gpio")]
 use wasefire_board_api::{self as board, Id, Support};
-
 #[cfg(feature = "board-api-gpio")]
-use crate::Trap;
+use wasefire_error::{Code, Error};
+
 use crate::{DispatchSchedulerCall, SchedulerCall};
 
 pub fn process<B: Board>(call: Api<DispatchSchedulerCall<B>>) {
@@ -46,44 +46,45 @@ fn count<B: Board>(call: SchedulerCall<B, api::count::Sig>) {
 fn configure<B: Board>(call: SchedulerCall<B, api::configure::Sig>) {
     let api::configure::Params { gpio, mode } = call.read();
     let result = try {
-        let gpio = Id::new(*gpio as usize).map_err(|_| Trap)?;
-        let config = *bytemuck::checked::try_from_bytes(&mode.to_le_bytes()).map_err(|_| Trap)?;
-        board::Gpio::<B>::configure(gpio, config)
+        let gpio = Id::new(*gpio as usize)?;
+        let config = *bytemuck::checked::try_from_bytes(&mode.to_le_bytes())
+            .map_err(|_| Error::user(Code::InvalidArgument))?;
+        board::Gpio::<B>::configure(gpio, config)?
     };
-    call.reply(result);
+    call.reply(Ok(result));
 }
 
 #[cfg(feature = "board-api-gpio")]
 fn read<B: Board>(call: SchedulerCall<B, api::read::Sig>) {
     let api::read::Params { gpio } = call.read();
     let result = try {
-        let gpio = Id::new(*gpio as usize).map_err(|_| Trap)?;
-        board::Gpio::<B>::read(gpio)
+        let gpio = Id::new(*gpio as usize)?;
+        board::Gpio::<B>::read(gpio)?
     };
-    call.reply(result);
+    call.reply(Ok(result));
 }
 
 #[cfg(feature = "board-api-gpio")]
 fn write<B: Board>(call: SchedulerCall<B, api::write::Sig>) {
     let api::write::Params { gpio, val } = call.read();
     let result = try {
-        let gpio = Id::new(*gpio as usize).map_err(|_| Trap)?;
+        let gpio = Id::new(*gpio as usize)?;
         let value = match *val {
             0 => false,
             1 => true,
-            _ => Err(Trap)?,
+            _ => Err(Error::user(Code::InvalidArgument))?,
         };
-        board::Gpio::<B>::write(gpio, value)
+        board::Gpio::<B>::write(gpio, value)?
     };
-    call.reply(result);
+    call.reply(Ok(result));
 }
 
 #[cfg(feature = "board-api-gpio")]
 fn last_write<B: Board>(call: SchedulerCall<B, api::last_write::Sig>) {
     let api::last_write::Params { gpio } = call.read();
     let result = try {
-        let gpio = Id::new(*gpio as usize).map_err(|_| Trap)?;
-        board::Gpio::<B>::last_write(gpio)
+        let gpio = Id::new(*gpio as usize)?;
+        board::Gpio::<B>::last_write(gpio)?
     };
-    call.reply(result);
+    call.reply(Ok(result));
 }

--- a/examples/rust/gpio_test/src/lib.rs
+++ b/examples/rust/gpio_test/src/lib.rs
@@ -25,7 +25,7 @@ use wasefire::gpio::InputConfig::*;
 use wasefire::gpio::OutputConfig::*;
 use wasefire::gpio::{Config, Gpio, InputConfig, OutputConfig};
 
-fn main() {
+fn main() -> Result<(), Error> {
     if gpio::count() < 3 {
         debug!("This test needs at least 3 GPIOs (connected together).");
         debug::exit(true);
@@ -54,15 +54,15 @@ fn main() {
                 None => continue,
             };
             debug!("{} + {} = {expected:?}", Pretty(src), Pretty(dst));
-            let _src = Gpio::new(0, src);
-            let dst = Gpio::new(1, dst);
+            let _src = Gpio::new(0, src)?;
+            let dst = Gpio::new(1, dst)?;
             match expected {
-                Some(expected) => debug::assert_eq(&dst.read(), &expected),
+                Some(expected) => debug::assert_eq(&dst.read()?, &expected),
                 None => {
-                    let bus = Gpio::new(2, &Config::output(PushPull, false));
-                    debug::assert_eq(&dst.read(), &false);
-                    bus.write(true);
-                    debug::assert_eq(&dst.read(), &true);
+                    let bus = Gpio::new(2, &Config::output(PushPull, false))?;
+                    debug::assert_eq(&dst.read()?, &false);
+                    bus.write(true)?;
+                    debug::assert_eq(&dst.read()?, &true);
                 }
             }
         }


### PR DESCRIPTION
* Changes `scheduler/call/gpio.rs` to not trap and always return errors.
* Changes `prelude/gpio` to never panic and always return errors.