### PR TITLE
Rename MaybeUnwrap to Termination like std

### DIFF
--- a/crates/prelude/CHANGELOG.md
+++ b/crates/prelude/CHANGELOG.md
@@ -149,4 +149,4 @@
 
 ## 0.1.0
 
-<!-- Increment to skip CHANGELOG.md test: 25 -->
+<!-- Increment to skip CHANGELOG.md test: 26 -->

--- a/crates/prelude/src/internal.rs
+++ b/crates/prelude/src/internal.rs
@@ -12,20 +12,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub trait MaybeUnwrap {
-    fn maybe_unwrap(self);
+/// Wasefire version of `std::process::Termination`.
+pub trait Termination {
+    /// Reports the termination at the applet level.
+    ///
+    /// There is nothing to report to the platform, which is why the function doesn't return
+    /// anything, compared to the `std` version.
+    fn report(self);
 }
 
-impl MaybeUnwrap for () {
-    fn maybe_unwrap(self) {}
+impl Termination for () {
+    fn report(self) {}
 }
 
-impl MaybeUnwrap for ! {
-    fn maybe_unwrap(self) {}
+impl Termination for ! {
+    fn report(self) {}
 }
 
-impl MaybeUnwrap for Result<(), crate::Error> {
-    fn maybe_unwrap(self) {
+impl Termination for Result<(), crate::Error> {
+    fn report(self) {
         self.unwrap();
     }
 }

--- a/crates/prelude/src/lib.rs
+++ b/crates/prelude/src/lib.rs
@@ -42,7 +42,7 @@ pub use wasefire_error::Error;
 
 // This internal module is made public because it's used by exported macros called from user code.
 #[doc(hidden)]
-pub mod _internal;
+pub mod internal;
 
 mod allocator;
 #[cfg(feature = "api-button")]
@@ -111,8 +111,8 @@ macro_rules! applet {
         #[allow(unreachable_code)]
         #[allow(clippy::diverging_sub_expression)]
         extern "C" fn _main() {
-            use $crate::_internal::MaybeUnwrap as _;
-            main().maybe_unwrap();
+            use $crate::internal::Termination as _;
+            main().report();
         }
     };
 }
@@ -129,8 +129,8 @@ macro_rules! applet {
         #[allow(unreachable_code)]
         #[allow(clippy::diverging_sub_expression)]
         extern "C" fn applet_main() {
-            use $crate::_internal::MaybeUnwrap as _;
-            main().maybe_unwrap();
+            use $crate::internal::Termination as _;
+            main().report();
         }
     };
 }


### PR DESCRIPTION
FYI @lukeyeh : I discovered that Rust has a [`Termination`](https://doc.rust-lang.org/std/process/trait.Termination.html) trait in `std` for the exact purpose we added `MaybeUnwrap`. So I'm just renaming to be consistent with `std`. If the trait was in `core`, we could have used it, and just discarded the `ExitCode`. Applets in Wasefire are not really meant to exit, so a notion of exit code is not really useful.