### PR TITLE
Introduce Failure type for scheduler replies

### DIFF
--- a/crates/scheduler/CHANGELOG.md
+++ b/crates/scheduler/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Patch
 
+- Add `Failure` type to simplify try-blocks for `Scheduler::reply()` arguments
 - Update `store` errors mapping
 - Use explicit conversion from `Error` to `Trap`
 - Simplify `#[cfg(all)]` attributes between board and applet features

--- a/crates/scheduler/src/call.rs
+++ b/crates/scheduler/src/call.rs
@@ -23,7 +23,7 @@ macro_rules! or_trap {
         #[cfg(feature = $feature)]
         $name($call);
         #[cfg(not(feature = $feature))]
-        $call.reply_(Err(crate::Trap));
+        $call.reply_(Err(crate::Trap.into()));
     }};
 }
 
@@ -33,7 +33,9 @@ macro_rules! or_fail {
         #[cfg(feature = $feature)]
         $name($call);
         #[cfg(not(feature = $feature))]
-        $call.reply_(Ok(Err(wasefire_error::Error::world(wasefire_error::Code::NotImplemented))));
+        $call.reply_(Err(crate::Failure::Error(wasefire_error::Error::world(
+            wasefire_error::Code::NotImplemented,
+        ))));
     }};
 }
 
@@ -113,5 +115,5 @@ pub fn process<B: Board>(call: Api<DispatchSchedulerCall<B>>) {
 
 fn syscall<B: Board>(call: SchedulerCall<B, api::syscall::Sig>) {
     let api::syscall::Params { x1, x2, x3, x4 } = call.read();
-    call.reply(B::syscall(*x1, *x2, *x3, *x4).ok_or(Trap));
+    call.reply(try { B::syscall(*x1, *x2, *x3, *x4).ok_or(Trap)?? });
 }

--- a/crates/scheduler/src/call/button.rs
+++ b/crates/scheduler/src/call/button.rs
@@ -37,7 +37,7 @@ fn count<B: Board>(call: SchedulerCall<B, api::count::Sig>) {
     let count = board::Button::<B>::SUPPORT as u32;
     #[cfg(not(feature = "board-api-button"))]
     let count = 0;
-    call.reply(Ok(Ok(count)));
+    call.reply(Ok(count));
 }
 
 #[cfg(feature = "board-api-button")]
@@ -57,7 +57,7 @@ fn register<B: Board>(mut call: SchedulerCall<B, api::register::Sig>) {
             .map_err(|_| Error::user(Code::InvalidState))?;
         board::Button::<B>::enable(button)?;
     };
-    call.reply(Ok(result));
+    call.reply(result);
 }
 
 #[cfg(feature = "board-api-button")]
@@ -70,5 +70,5 @@ fn unregister<B: Board>(mut call: SchedulerCall<B, api::unregister::Sig>) {
             .disable_event(Key { button }.into())
             .map_err(|_| Error::user(Code::InvalidState))?;
     };
-    call.reply(Ok(result));
+    call.reply(result);
 }

--- a/crates/scheduler/src/call/crypto/ccm.rs
+++ b/crates/scheduler/src/call/crypto/ccm.rs
@@ -39,7 +39,7 @@ fn is_supported<B: Board>(call: SchedulerCall<B, api::is_supported::Sig>) {
     let supported = bool::from(board::crypto::Aes128Ccm::<B>::SUPPORT) as u32;
     #[cfg(not(feature = "board-api-crypto-aes128-ccm"))]
     let supported = 0;
-    call.reply(Ok(Ok(supported)))
+    call.reply(Ok(supported))
 }
 
 #[cfg(feature = "board-api-crypto-aes128-ccm")]
@@ -55,7 +55,7 @@ fn encrypt<B: Board>(mut call: SchedulerCall<B, api::encrypt::Sig>) {
         let clear = Some(memory.get(*clear, *len)?);
         let (cipher, tag) = memory.get_mut(*cipher, *len + 4)?.split_at_mut(*len as usize);
         let tag = tag.into();
-        board::crypto::Aes128Ccm::<B>::encrypt(key, &iv, aad, clear, cipher, tag)
+        board::crypto::Aes128Ccm::<B>::encrypt(key, &iv, aad, clear, cipher, tag)?
     };
     call.reply(result);
 }
@@ -74,7 +74,7 @@ fn decrypt<B: Board>(mut call: SchedulerCall<B, api::decrypt::Sig>) {
         let cipher = Some(cipher);
         let tag = tag.into();
         let clear = memory.get_mut(*clear, *len)?;
-        board::crypto::Aes128Ccm::<B>::decrypt(key, &iv, aad, cipher, tag, clear)
+        board::crypto::Aes128Ccm::<B>::decrypt(key, &iv, aad, cipher, tag, clear)?
     };
     call.reply(result);
 }

--- a/crates/scheduler/src/call/crypto/ec.rs
+++ b/crates/scheduler/src/call/crypto/ec.rs
@@ -39,7 +39,7 @@ pub fn process<B: Board>(call: Api<DispatchSchedulerCall<B>>) {
 
 fn is_supported<B: Board>(call: SchedulerCall<B, api::is_supported::Sig>) {
     let api::is_supported::Params { curve } = call.read();
-    call.reply(convert_curve::<B>(*curve).map(|x| Ok(x.is_ok())))
+    call.reply(try { convert_curve::<B>(*curve)?.is_ok() })
 }
 
 #[cfg(feature = "internal-board-api-crypto-ecc")]
@@ -48,7 +48,7 @@ fn is_valid_scalar<B: Board>(mut call: SchedulerCall<B, api::is_valid_scalar::Si
     let scheduler = call.scheduler();
     let memory = scheduler.applet.memory();
     let result = try {
-        Ok(match convert_curve::<B>(*curve)?? {
+        match convert_curve::<B>(*curve)?? {
             #[cfg(feature = "board-api-crypto-p256")]
             Curve::P256 => {
                 let n = memory.get_array::<32>(*n)?.into();
@@ -61,7 +61,7 @@ fn is_valid_scalar<B: Board>(mut call: SchedulerCall<B, api::is_valid_scalar::Si
             }
             #[allow(unreachable_patterns)]
             _ => trap_use!(),
-        })
+        }
     };
     call.reply(result)
 }
@@ -72,7 +72,7 @@ fn is_valid_point<B: Board>(mut call: SchedulerCall<B, api::is_valid_point::Sig>
     let scheduler = call.scheduler();
     let memory = scheduler.applet.memory();
     let result = try {
-        Ok(match convert_curve::<B>(*curve)?? {
+        match convert_curve::<B>(*curve)?? {
             #[cfg(feature = "board-api-crypto-p256")]
             Curve::P256 => {
                 let x = memory.get_array::<32>(*x)?.into();
@@ -87,7 +87,7 @@ fn is_valid_point<B: Board>(mut call: SchedulerCall<B, api::is_valid_point::Sig>
             }
             #[allow(unreachable_patterns)]
             _ => trap_use!(),
-        })
+        }
     };
     call.reply(result)
 }
@@ -104,14 +104,14 @@ fn base_point_mul<B: Board>(mut call: SchedulerCall<B, api::base_point_mul::Sig>
                 let n = memory.get_array::<32>(*n)?.into();
                 let x = memory.get_array_mut::<32>(*x)?.into();
                 let y = memory.get_array_mut::<32>(*y)?.into();
-                board::crypto::P256::<B>::base_point_mul(n, x, y)
+                board::crypto::P256::<B>::base_point_mul(n, x, y)?
             }
             #[cfg(feature = "board-api-crypto-p384")]
             Curve::P384 => {
                 let n = memory.get_array::<48>(*n)?.into();
                 let x = memory.get_array_mut::<48>(*x)?.into();
                 let y = memory.get_array_mut::<48>(*y)?.into();
-                board::crypto::P384::<B>::base_point_mul(n, x, y)
+                board::crypto::P384::<B>::base_point_mul(n, x, y)?
             }
             #[allow(unreachable_patterns)]
             _ => trap_use!(),
@@ -134,7 +134,7 @@ fn point_mul<B: Board>(mut call: SchedulerCall<B, api::point_mul::Sig>) {
                 let in_y = memory.get_array::<32>(*in_y)?.into();
                 let out_x = memory.get_array_mut::<32>(*out_x)?.into();
                 let out_y = memory.get_array_mut::<32>(*out_y)?.into();
-                board::crypto::P256::<B>::point_mul(n, in_x, in_y, out_x, out_y)
+                board::crypto::P256::<B>::point_mul(n, in_x, in_y, out_x, out_y)?
             }
             #[cfg(feature = "board-api-crypto-p384")]
             Curve::P384 => {
@@ -143,7 +143,7 @@ fn point_mul<B: Board>(mut call: SchedulerCall<B, api::point_mul::Sig>) {
                 let in_y = memory.get_array::<48>(*in_y)?.into();
                 let out_x = memory.get_array_mut::<48>(*out_x)?.into();
                 let out_y = memory.get_array_mut::<48>(*out_y)?.into();
-                board::crypto::P384::<B>::point_mul(n, in_x, in_y, out_x, out_y)
+                board::crypto::P384::<B>::point_mul(n, in_x, in_y, out_x, out_y)?
             }
             #[allow(unreachable_patterns)]
             _ => trap_use!(),
@@ -165,7 +165,7 @@ fn ecdsa_sign<B: Board>(mut call: SchedulerCall<B, api::ecdsa_sign::Sig>) {
                 let message = memory.get_array::<32>(*message)?.into();
                 let r = memory.get_array_mut::<32>(*r)?.into();
                 let s = memory.get_array_mut::<32>(*s)?.into();
-                board::crypto::P256::<B>::ecdsa_sign(key, message, r, s)
+                board::crypto::P256::<B>::ecdsa_sign(key, message, r, s)?
             }
             #[cfg(feature = "board-api-crypto-p384")]
             Curve::P384 => {
@@ -173,7 +173,7 @@ fn ecdsa_sign<B: Board>(mut call: SchedulerCall<B, api::ecdsa_sign::Sig>) {
                 let message = memory.get_array::<48>(*message)?.into();
                 let r = memory.get_array_mut::<48>(*r)?.into();
                 let s = memory.get_array_mut::<48>(*s)?.into();
-                board::crypto::P384::<B>::ecdsa_sign(key, message, r, s)
+                board::crypto::P384::<B>::ecdsa_sign(key, message, r, s)?
             }
             #[allow(unreachable_patterns)]
             _ => trap_use!(),
@@ -196,7 +196,7 @@ fn ecdsa_verify<B: Board>(mut call: SchedulerCall<B, api::ecdsa_verify::Sig>) {
                 let y = memory.get_array::<32>(*y)?.into();
                 let r = memory.get_array::<32>(*r)?.into();
                 let s = memory.get_array::<32>(*s)?.into();
-                board::crypto::P256::<B>::ecdsa_verify(message, x, y, r, s)
+                board::crypto::P256::<B>::ecdsa_verify(message, x, y, r, s)?
             }
             #[cfg(feature = "board-api-crypto-p384")]
             Curve::P384 => {
@@ -205,7 +205,7 @@ fn ecdsa_verify<B: Board>(mut call: SchedulerCall<B, api::ecdsa_verify::Sig>) {
                 let y = memory.get_array::<48>(*y)?.into();
                 let r = memory.get_array::<48>(*r)?.into();
                 let s = memory.get_array::<48>(*s)?.into();
-                board::crypto::P384::<B>::ecdsa_verify(message, x, y, r, s)
+                board::crypto::P384::<B>::ecdsa_verify(message, x, y, r, s)?
             }
             #[allow(unreachable_patterns)]
             _ => trap_use!(),

--- a/crates/scheduler/src/call/crypto/gcm.rs
+++ b/crates/scheduler/src/call/crypto/gcm.rs
@@ -45,13 +45,13 @@ fn support<B: Board>(call: SchedulerCall<B, api::support::Sig>) {
     };
     #[cfg(not(feature = "board-api-crypto-aes256-gcm"))]
     let support = 0;
-    call.reply(Ok(Ok(support)))
+    call.reply(Ok(support))
 }
 
 #[cfg(feature = "board-api-crypto-aes256-gcm")]
 fn tag_length<B: Board>(call: SchedulerCall<B, api::tag_length::Sig>) {
     let api::tag_length::Params {} = call.read();
-    call.reply(Ok(Ok(tag_len::<B>() as u32)))
+    call.reply(Ok(tag_len::<B>() as u32))
 }
 
 #[cfg(feature = "board-api-crypto-aes256-gcm")]
@@ -68,7 +68,7 @@ fn encrypt<B: Board>(mut call: SchedulerCall<B, api::encrypt::Sig>) {
         let cipher = memory.get_mut(*cipher, *length)?;
         let tag_len = tag_len::<B>() as u32;
         let tag = memory.get_mut(*tag, tag_len)?.into();
-        board::crypto::Aes256Gcm::<B>::encrypt(key, iv, aad, clear, cipher, tag)
+        board::crypto::Aes256Gcm::<B>::encrypt(key, iv, aad, clear, cipher, tag)?
     };
     call.reply(result);
 }
@@ -87,7 +87,7 @@ fn decrypt<B: Board>(mut call: SchedulerCall<B, api::decrypt::Sig>) {
         let tag = memory.get(*tag, tag_len)?.into();
         let cipher = memory.get_opt(*cipher, *length)?;
         let clear = memory.get_mut(*clear, *length)?;
-        board::crypto::Aes256Gcm::<B>::decrypt(key, iv, aad, cipher, tag, clear)
+        board::crypto::Aes256Gcm::<B>::decrypt(key, iv, aad, cipher, tag, clear)?
     };
     call.reply(result);
 }

--- a/crates/scheduler/src/call/debug.rs
+++ b/crates/scheduler/src/call/debug.rs
@@ -34,7 +34,6 @@ fn println<B: Board>(mut call: SchedulerCall<B, api::println::Sig>) {
     let result = try {
         let line = core::str::from_utf8(memory.get(*ptr, *len)?).map_err(|_| Trap)?;
         board::Debug::<B>::println(line);
-        Ok(())
     };
     call.reply(result)
 }
@@ -47,7 +46,7 @@ fn time<B: Board>(mut call: SchedulerCall<B, api::time::Sig>) {
         if *ptr != 0 {
             memory.get_mut(*ptr, 8)?.copy_from_slice(&time.to_le_bytes());
         }
-        Ok(time as u32 & 0x7fffffff)
+        time as u32 & 0x7fffffff
     };
     call.reply(result)
 }
@@ -61,7 +60,6 @@ fn perf<B: Board>(mut call: SchedulerCall<B, api::perf::Sig>) {
     let memory = call.memory();
     let result = try {
         *memory.from_bytes_mut::<Perf>(*ptr)? = perf;
-        Ok(())
     };
     call.reply(result)
 }

--- a/crates/scheduler/src/call/gpio.rs
+++ b/crates/scheduler/src/call/gpio.rs
@@ -39,7 +39,7 @@ fn count<B: Board>(call: SchedulerCall<B, api::count::Sig>) {
     let count = board::Gpio::<B>::SUPPORT as u32;
     #[cfg(not(feature = "board-api-gpio"))]
     let count = 0;
-    call.reply(Ok(Ok(count)));
+    call.reply(Ok(count));
 }
 
 #[cfg(feature = "board-api-gpio")]
@@ -51,7 +51,7 @@ fn configure<B: Board>(call: SchedulerCall<B, api::configure::Sig>) {
             .map_err(|_| Error::user(Code::InvalidArgument))?;
         board::Gpio::<B>::configure(gpio, config)?
     };
-    call.reply(Ok(result));
+    call.reply(result);
 }
 
 #[cfg(feature = "board-api-gpio")]
@@ -61,7 +61,7 @@ fn read<B: Board>(call: SchedulerCall<B, api::read::Sig>) {
         let gpio = Id::new(*gpio as usize)?;
         board::Gpio::<B>::read(gpio)?
     };
-    call.reply(Ok(result));
+    call.reply(result);
 }
 
 #[cfg(feature = "board-api-gpio")]
@@ -76,7 +76,7 @@ fn write<B: Board>(call: SchedulerCall<B, api::write::Sig>) {
         };
         board::Gpio::<B>::write(gpio, value)?
     };
-    call.reply(Ok(result));
+    call.reply(result);
 }
 
 #[cfg(feature = "board-api-gpio")]
@@ -86,5 +86,5 @@ fn last_write<B: Board>(call: SchedulerCall<B, api::last_write::Sig>) {
         let gpio = Id::new(*gpio as usize)?;
         board::Gpio::<B>::last_write(gpio)?
     };
-    call.reply(Ok(result));
+    call.reply(result);
 }

--- a/crates/scheduler/src/call/led.rs
+++ b/crates/scheduler/src/call/led.rs
@@ -35,7 +35,7 @@ fn count<B: Board>(call: SchedulerCall<B, api::count::Sig>) {
     let count = board::Led::<B>::SUPPORT as u32;
     #[cfg(not(feature = "board-api-led"))]
     let count = 0;
-    call.reply(Ok(Ok(count)));
+    call.reply(Ok(count));
 }
 
 #[cfg(feature = "board-api-led")]
@@ -45,7 +45,7 @@ fn get<B: Board>(call: SchedulerCall<B, api::get::Sig>) {
         let id = Id::new(*led as usize)?;
         board::Led::<B>::get(id)?
     };
-    call.reply(Ok(result));
+    call.reply(result);
 }
 
 #[cfg(feature = "board-api-led")]
@@ -56,5 +56,5 @@ fn set<B: Board>(call: SchedulerCall<B, api::set::Sig>) {
         let on = matches!(api::Status::try_from(*status)?, api::Status::On);
         board::Led::<B>::set(id, on)?
     };
-    call.reply(Ok(result));
+    call.reply(result);
 }

--- a/crates/scheduler/src/call/platform.rs
+++ b/crates/scheduler/src/call/platform.rs
@@ -52,7 +52,7 @@ fn version<B: Board>(mut call: SchedulerCall<B, api::version::Sig>) {
     let memory = scheduler.applet.memory();
     let result = try {
         let output = memory.get_mut(*ptr, *len)?;
-        Ok(board::Platform::<B>::version(output) as u32)
+        board::Platform::<B>::version(output) as u32
     };
     call.reply(result);
 }
@@ -60,5 +60,5 @@ fn version<B: Board>(mut call: SchedulerCall<B, api::version::Sig>) {
 #[cfg(feature = "board-api-platform")]
 fn reboot<B: Board>(call: SchedulerCall<B, api::reboot::Sig>) {
     let api::reboot::Params {} = call.read();
-    call.reply(Ok(board::Platform::<B>::reboot()));
+    call.reply(board::Platform::<B>::reboot().map_err(|x| x.into()));
 }

--- a/crates/scheduler/src/call/platform/protocol.rs
+++ b/crates/scheduler/src/call/platform/protocol.rs
@@ -39,18 +39,17 @@ fn read<B: Board>(mut call: SchedulerCall<B, api::read::Sig>) {
     let api::read::Params { ptr: ptr_ptr, len: len_ptr } = call.read();
     let scheduler = call.scheduler();
     let result = try {
-        match scheduler.applet.get_request() {
-            Ok(None) => Ok(false),
-            Ok(Some(value)) => {
+        match scheduler.applet.get_request()? {
+            None => false,
+            Some(value) => {
                 let mut memory = scheduler.applet.memory();
                 let len = value.len() as u32;
                 let ptr = memory.alloc(len, 1)?;
                 memory.get_mut(ptr, len)?.copy_from_slice(&value);
                 memory.get_mut(*ptr_ptr, 4)?.copy_from_slice(&ptr.to_le_bytes());
                 memory.get_mut(*len_ptr, 4)?.copy_from_slice(&len.to_le_bytes());
-                Ok(true)
+                true
             }
-            Err(e) => Err(e),
         }
     };
     call.reply(result);
@@ -63,7 +62,7 @@ fn write<B: Board>(mut call: SchedulerCall<B, api::write::Sig>) {
     let result = try {
         let memory = scheduler.applet.memory();
         let input = memory.get(*ptr, *len)?.into();
-        crate::protocol::put_response(scheduler, input)
+        crate::protocol::put_response(scheduler, input)?
     };
     call.reply(result);
 }
@@ -80,8 +79,7 @@ fn register<B: Board>(mut call: SchedulerCall<B, api::register::Sig>) {
             inst,
             func: *handler_func,
             data: *handler_data,
-        })?;
-        Ok(())
+        })?
     };
     call.reply(result);
 }
@@ -92,8 +90,7 @@ fn unregister<B: Board>(mut call: SchedulerCall<B, api::unregister::Sig>) {
     let scheduler = call.scheduler();
     let result = try {
         // We only disable the applet handler because we still need to process non-applet requests.
-        scheduler.disable_event(Key::Request.into())?;
-        Ok(())
+        scheduler.disable_event(Key::Request.into())?
     };
     call.reply(result);
 }

--- a/crates/scheduler/src/call/platform/update.rs
+++ b/crates/scheduler/src/call/platform/update.rs
@@ -41,7 +41,7 @@ fn is_supported<B: Board>(call: SchedulerCall<B, api::is_supported::Sig>) {
     let supported = board::platform::Update::<B>::SUPPORT as u32;
     #[cfg(not(feature = "board-api-platform-update"))]
     let supported = 0;
-    call.reply(Ok(Ok(supported)))
+    call.reply(Ok(supported))
 }
 
 #[cfg(feature = "board-api-platform-update")]
@@ -50,17 +50,12 @@ fn metadata<B: Board>(mut call: SchedulerCall<B, api::metadata::Sig>) {
     let scheduler = call.scheduler();
     let mut memory = scheduler.applet.memory();
     let result = try {
-        match board::platform::Update::<B>::metadata() {
-            Ok(metadata) => {
-                let len = metadata.len() as u32;
-                let ptr = memory.alloc(len, 1)?;
-                memory.get_mut(ptr, len)?.copy_from_slice(&metadata);
-                memory.get_mut(*ptr_ptr, 4)?.copy_from_slice(&ptr.to_le_bytes());
-                memory.get_mut(*len_ptr, 4)?.copy_from_slice(&len.to_le_bytes());
-                Ok(())
-            }
-            Err(error) => Err(error),
-        }
+        let metadata = board::platform::Update::<B>::metadata()?;
+        let len = metadata.len() as u32;
+        let ptr = memory.alloc(len, 1)?;
+        memory.get_mut(ptr, len)?.copy_from_slice(&metadata);
+        memory.get_mut(*ptr_ptr, 4)?.copy_from_slice(&ptr.to_le_bytes());
+        memory.get_mut(*len_ptr, 4)?.copy_from_slice(&len.to_le_bytes());
     };
     call.reply(result);
 }
@@ -74,7 +69,7 @@ fn initialize<B: Board>(call: SchedulerCall<B, api::initialize::Sig>) {
             1 => true,
             _ => Err(Trap)?,
         };
-        board::platform::Update::<B>::initialize(dry_run)
+        board::platform::Update::<B>::initialize(dry_run)?
     };
     call.reply(result);
 }
@@ -86,7 +81,7 @@ fn process_<B: Board>(mut call: SchedulerCall<B, api::process::Sig>) {
     let memory = scheduler.applet.memory();
     let result = try {
         let chunk = memory.get(*ptr, *len)?;
-        board::platform::Update::<B>::process(chunk)
+        board::platform::Update::<B>::process(chunk)?
     };
     call.reply(result);
 }
@@ -94,6 +89,5 @@ fn process_<B: Board>(mut call: SchedulerCall<B, api::process::Sig>) {
 #[cfg(feature = "board-api-platform-update")]
 fn finalize<B: Board>(call: SchedulerCall<B, api::finalize::Sig>) {
     let api::finalize::Params {} = call.read();
-    let result = try { board::platform::Update::<B>::finalize() };
-    call.reply(result);
+    call.reply(try { board::platform::Update::<B>::finalize()? });
 }

--- a/crates/scheduler/src/call/radio/ble.rs
+++ b/crates/scheduler/src/call/radio/ble.rs
@@ -50,7 +50,7 @@ fn register<B: Board>(mut call: SchedulerCall<B, api::register::Sig>) {
             func: *handler_func,
             data: *handler_data,
         })?;
-        board::radio::Ble::<B>::enable(&event)
+        board::radio::Ble::<B>::enable(&event)?
     };
     call.reply(result);
 }
@@ -63,7 +63,6 @@ fn unregister<B: Board>(mut call: SchedulerCall<B, api::unregister::Sig>) {
         let event = convert_event(event)?;
         board::radio::Ble::<B>::disable(&event).map_err(|_| Trap)?;
         scheduler.disable_event(Key::from(&event).into())?;
-        Ok(())
     };
     call.reply(result);
 }
@@ -75,7 +74,7 @@ fn read_advertisement<B: Board>(mut call: SchedulerCall<B, api::read_advertiseme
     let memory = scheduler.applet.memory();
     let result = try {
         let packet = memory.from_bytes_mut::<Advertisement>(*ptr)?;
-        board::radio::Ble::<B>::read_advertisement(packet)
+        board::radio::Ble::<B>::read_advertisement(packet)?
     };
     call.reply(result);
 }

--- a/crates/scheduler/src/call/rng.rs
+++ b/crates/scheduler/src/call/rng.rs
@@ -40,7 +40,7 @@ fn fill_bytes<B: Board>(mut call: SchedulerCall<B, api::fill_bytes::Sig>) {
     let memory = scheduler.applet.memory();
     let result = try {
         let output = memory.get_mut(*ptr, *len)?;
-        board::Rng::<B>::fill_bytes(output)
+        board::Rng::<B>::fill_bytes(output)?
     };
     call.reply(result);
 }

--- a/crates/scheduler/src/call/scheduling.rs
+++ b/crates/scheduler/src/call/scheduling.rs
@@ -28,17 +28,17 @@ pub fn process<B: Board>(call: Api<DispatchSchedulerCall<B>>) {
 fn wait_for_callback<B: Board>(mut call: SchedulerCall<B, api::wait_for_callback::Sig>) {
     let api::wait_for_callback::Params {} = call.read();
     if call.scheduler().process_event() {
-        call.reply(Ok(Ok(())));
+        call.reply(Ok(()));
     }
 }
 
 fn num_pending_callbacks<B: Board>(mut call: SchedulerCall<B, api::num_pending_callbacks::Sig>) {
     let api::num_pending_callbacks::Params {} = call.read();
     let count = call.applet().len() as u32;
-    call.reply(Ok(Ok(count)));
+    call.reply(Ok(count));
 }
 
 fn abort<B: Board>(call: SchedulerCall<B, api::abort::Sig>) {
     let api::abort::Params {} = call.read();
-    call.reply_(Err(crate::Trap));
+    call.reply_(Err(crate::Trap.into()));
 }

--- a/crates/scheduler/src/call/store.rs
+++ b/crates/scheduler/src/call/store.rs
@@ -57,7 +57,7 @@ fn insert<B: Board>(mut call: SchedulerCall<B, api::insert::Sig>) {
     let memory = scheduler.applet.memory();
     let result = try {
         let value = memory.get(*ptr, *len)?;
-        scheduler.store.insert(*key as usize, value).map_err(convert)
+        scheduler.store.insert(*key as usize, value).map_err(convert)?
     };
     call.reply(result);
 }
@@ -65,8 +65,8 @@ fn insert<B: Board>(mut call: SchedulerCall<B, api::insert::Sig>) {
 #[cfg(feature = "board-api-storage")]
 fn remove<B: Board>(mut call: SchedulerCall<B, api::remove::Sig>) {
     let api::remove::Params { key } = call.read();
-    let res = call.scheduler().store.remove(*key as usize).map_err(convert);
-    call.reply(Ok(res));
+    let res = try { call.scheduler().store.remove(*key as usize).map_err(convert)? };
+    call.reply(res);
 }
 
 #[cfg(feature = "board-api-storage")]
@@ -75,17 +75,16 @@ fn find<B: Board>(mut call: SchedulerCall<B, api::find::Sig>) {
     let scheduler = call.scheduler();
     let mut memory = scheduler.applet.memory();
     let result = try {
-        match scheduler.store.find(*key as usize) {
-            Ok(None) => Ok(false),
-            Ok(Some(value)) => {
+        match scheduler.store.find(*key as usize).map_err(convert)? {
+            None => false,
+            Some(value) => {
                 let len = value.len() as u32;
                 let ptr = memory.alloc(len, 1)?;
                 memory.get_mut(ptr, len)?.copy_from_slice(&value);
                 memory.get_mut(*ptr_ptr, 4)?.copy_from_slice(&ptr.to_le_bytes());
                 memory.get_mut(*len_ptr, 4)?.copy_from_slice(&len.to_le_bytes());
-                Ok(true)
+                true
             }
-            Err(e) => Err(convert(e)),
         }
     };
     call.reply(result);
@@ -97,23 +96,19 @@ fn keys<B: Board>(mut call: SchedulerCall<B, api::keys::Sig>) {
     let scheduler = call.scheduler();
     let mut memory = scheduler.applet.memory();
     let result = try {
-        let keys = try {
-            let mut keys = Vec::new();
-            for handle in scheduler.store.iter()? {
-                keys.push(handle?.get_key() as u16);
-            }
-            keys
-        };
+        let mut keys = Vec::new();
+        for handle in scheduler.store.iter().map_err(convert)? {
+            keys.push(handle.map_err(convert)?.get_key() as u16);
+        }
         match keys {
-            Ok(keys) if keys.is_empty() => Ok(0),
-            Ok(keys) => {
+            keys if keys.is_empty() => 0,
+            keys => {
                 let len = keys.len() as u32;
                 let ptr = memory.alloc(2 * len, 2)?;
                 memory.get_mut(ptr, 2 * len)?.copy_from_slice(bytemuck::cast_slice(&keys));
                 memory.get_mut(*ptr_ptr, 4)?.copy_from_slice(&ptr.to_le_bytes());
-                Ok(len)
+                len
             }
-            Err(e) => Err(convert(e)),
         }
     };
     call.reply(result);
@@ -123,8 +118,8 @@ fn keys<B: Board>(mut call: SchedulerCall<B, api::keys::Sig>) {
 fn clear<B: Board>(mut call: SchedulerCall<B, api::clear::Sig>) {
     let api::clear::Params {} = call.read();
     let scheduler = call.scheduler();
-    let result = scheduler.store.clear(0).map_err(convert);
-    call.reply(Ok(result));
+    let result = try { scheduler.store.clear(0).map_err(convert)? };
+    call.reply(result);
 }
 
 #[cfg(feature = "board-api-storage")]

--- a/crates/scheduler/src/call/uart.rs
+++ b/crates/scheduler/src/call/uart.rs
@@ -46,7 +46,7 @@ fn count<B: Board>(call: SchedulerCall<B, api::count::Sig>) {
     let count = board::Uart::<B>::SUPPORT as u32;
     #[cfg(not(feature = "board-api-uart"))]
     let count = 0;
-    call.reply(Ok(Ok(count)));
+    call.reply(Ok(count));
 }
 
 #[cfg(feature = "board-api-uart")]
@@ -54,7 +54,7 @@ fn set_baudrate<B: Board>(call: SchedulerCall<B, api::set_baudrate::Sig>) {
     let api::set_baudrate::Params { uart, baudrate } = call.read();
     let result = try {
         let uart = Id::new(*uart as usize).map_err(|_| Trap)?;
-        board::Uart::<B>::set_baudrate(uart, *baudrate as usize)
+        board::Uart::<B>::set_baudrate(uart, *baudrate as usize)?
     };
     call.reply(result);
 }
@@ -64,7 +64,7 @@ fn start<B: Board>(call: SchedulerCall<B, api::start::Sig>) {
     let api::start::Params { uart } = call.read();
     let result = try {
         let uart = Id::new(*uart as usize).map_err(|_| Trap)?;
-        board::Uart::<B>::start(uart)
+        board::Uart::<B>::start(uart)?
     };
     call.reply(result);
 }
@@ -74,7 +74,7 @@ fn stop<B: Board>(call: SchedulerCall<B, api::stop::Sig>) {
     let api::stop::Params { uart } = call.read();
     let result = try {
         let uart = Id::new(*uart as usize).map_err(|_| Trap)?;
-        board::Uart::<B>::stop(uart)
+        board::Uart::<B>::stop(uart)?
     };
     call.reply(result);
 }
@@ -87,7 +87,7 @@ fn read<B: Board>(mut call: SchedulerCall<B, api::read::Sig>) {
     let result = try {
         let uart = Id::new(*uart as usize).map_err(|_| Trap)?;
         let output = memory.get_mut(*ptr, *len)?;
-        board::Uart::<B>::read(uart, output).map(|x| x as u32)
+        board::Uart::<B>::read(uart, output)? as u32
     };
     call.reply(result);
 }
@@ -100,7 +100,7 @@ fn write<B: Board>(mut call: SchedulerCall<B, api::write::Sig>) {
     let result = try {
         let uart = Id::new(*uart as usize).map_err(|_| Trap)?;
         let input = memory.get(*ptr, *len)?;
-        board::Uart::<B>::write(uart, input).map(|x| x as u32)
+        board::Uart::<B>::write(uart, input)? as u32
     };
     call.reply(result);
 }
@@ -119,7 +119,7 @@ fn register<B: Board>(mut call: SchedulerCall<B, api::register::Sig>) {
             func: *handler_func,
             data: *handler_data,
         })?;
-        board::Uart::<B>::enable(uart, event.direction)
+        board::Uart::<B>::enable(uart, event.direction)?
     };
     call.reply(result);
 }
@@ -133,7 +133,6 @@ fn unregister<B: Board>(mut call: SchedulerCall<B, api::unregister::Sig>) {
         let event = convert_event(uart, *event)?;
         board::Uart::<B>::disable(uart, event.direction).map_err(|_| Trap)?;
         scheduler.disable_event(Key::from(&event).into())?;
-        Ok(())
     };
     call.reply(result);
 }

--- a/crates/scheduler/src/call/usb/serial.rs
+++ b/crates/scheduler/src/call/usb/serial.rs
@@ -46,7 +46,7 @@ fn read<B: Board>(mut call: SchedulerCall<B, api::read::Sig>) {
     let memory = scheduler.applet.memory();
     let result = try {
         let output = memory.get_mut(*ptr, *len)?;
-        board::usb::Serial::<B>::read(output).map(|x| x as u32)
+        board::usb::Serial::<B>::read(output)? as u32
     };
     call.reply(result);
 }
@@ -58,7 +58,7 @@ fn write<B: Board>(mut call: SchedulerCall<B, api::write::Sig>) {
     let memory = scheduler.applet.memory();
     let result = try {
         let input = memory.get(*ptr, *len)?;
-        board::usb::Serial::<B>::write(input).map(|x| x as u32)
+        board::usb::Serial::<B>::write(input)? as u32
     };
     call.reply(result);
 }
@@ -76,7 +76,7 @@ fn register<B: Board>(mut call: SchedulerCall<B, api::register::Sig>) {
             func: *handler_func,
             data: *handler_data,
         })?;
-        board::usb::Serial::<B>::enable(&event)
+        board::usb::Serial::<B>::enable(&event)?
     };
     call.reply(result);
 }
@@ -89,7 +89,6 @@ fn unregister<B: Board>(mut call: SchedulerCall<B, api::unregister::Sig>) {
         let event = convert_event(*event)?;
         board::usb::Serial::<B>::disable(&event).map_err(|_| Trap)?;
         scheduler.disable_event(Key::from(&event).into())?;
-        Ok(())
     };
     call.reply(result);
 }
@@ -97,7 +96,7 @@ fn unregister<B: Board>(mut call: SchedulerCall<B, api::unregister::Sig>) {
 #[cfg(feature = "board-api-usb-serial")]
 fn flush<B: Board>(call: SchedulerCall<B, api::flush::Sig>) {
     let api::flush::Params {} = call.read();
-    let result = try { board::usb::Serial::<B>::flush() };
+    let result = try { board::usb::Serial::<B>::flush()? };
     call.reply(result);
 }
 

--- a/crates/scheduler/src/lib.rs
+++ b/crates/scheduler/src/lib.rs
@@ -182,16 +182,16 @@ impl<'a, B: Board, T: Signature> SchedulerCall<'a, B, T> {
         self.erased.scheduler
     }
 
-    fn reply(self, result: Result<Result<impl Into<U32<T::Result>>, Error>, Trap>) {
-        self.reply_(result.map(|x| x.map(|x| x.into())))
+    fn reply(self, result: Result<impl Into<U32<T::Result>>, Failure>) {
+        self.reply_(result.map(|x| x.into()))
     }
 
-    fn reply_(self, result: Result<Result<U32<T::Result>, Error>, Trap>) {
-        let result = match result {
-            Ok(x) => x,
-            Err(Trap) => applet_trapped::<B>(Some(T::NAME)),
-        };
-        let result = Error::encode(result.map(|x| *x));
+    fn reply_(self, result: Result<U32<T::Result>, Failure>) {
+        let result = Error::encode(match result {
+            Ok(x) => Ok(*x),
+            Err(Failure::Error(e)) => Err(e),
+            Err(Failure::Trap(Trap)) => applet_trapped::<B>(Some(T::NAME)),
+        });
         #[cfg(feature = "wasm")]
         {
             let mut this = self;
@@ -453,6 +453,23 @@ fn applet_trapped<B: Board>(reason: Option<&'static str>) -> ! {
 }
 
 struct Trap;
+
+enum Failure {
+    Trap(Trap),
+    Error(Error),
+}
+
+impl From<Trap> for Failure {
+    fn from(value: Trap) -> Self {
+        Self::Trap(value)
+    }
+}
+
+impl From<Error> for Failure {
+    fn from(value: Error) -> Self {
+        Self::Error(value)
+    }
+}
 
 #[cfg(feature = "wasm")]
 const fn memory_size() -> usize {


### PR DESCRIPTION
This PR addresses the issue of handling both Trap and Error within the same try-block in the scheduler reply, resolving #463. Currently, the scheduler reply has the signature Result<Result<T, Error>, Trap>, which does not work well with try-blocks that only support one level of Result.

To resolve this, we introduce a new Failure enum that can represent either a Trap or an Error. The Failure type is defined in failure.rs, along with the Trap function. We also implement From traits for both Trap and Error to allow seamless conversion into the Failure type.

By updating the scheduler reply signature to Result<T, Failure>, we can now use the ? operator for both Trap and Error within the same try-block, making the code more concise and easier to read.