### PR TITLE
Use ubuntu repository for markdownlint

### DIFF
--- a/.github/actions/ci-checks/action.yml
+++ b/.github/actions/ci-checks/action.yml
@@ -36,14 +36,7 @@ runs:
       run: ./scripts/publish.sh --dry-run
       shell: bash
     - if: ${{ contains(fromJSON(inputs.checks), 'markdown') }}
-      # TODO: Keep only the last command once ubuntu-latest is 24.04.
-      run: |
-        set -x
-        curl -Os http://ftp.de.debian.org/debian/pool/main/r/ruby-mdl/markdownlint_0.13.0-4_all.deb
-        sudo apt install ruby-kramdown-parser-gfm ruby-mixlib-{cli,config,shellout}
-        sudo dpkg -i markdownlint_0.13.0-4_all.deb
-        rm markdownlint_0.13.0-4_all.deb
-        ./scripts/wrapper.sh mdl -g -s markdownlint.rb .
+      run: ./scripts/wrapper.sh mdl -g -s markdownlint.rb .
       shell: bash
     - if: ${{ contains(fromJSON(inputs.checks), 'taplo') }}
       run: ./scripts/ci-taplo.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ permissions: {}
 
 jobs:
   checks:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Compute the checks for ${{ github.event_name }}
@@ -54,7 +54,7 @@ jobs:
     outputs:
       checks: ${{ steps.checks.outputs.checks }}
   cache:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: checks
     steps:
       - uses: actions/checkout@v4
@@ -74,7 +74,7 @@ jobs:
       - if: steps.cache.outputs.cache-hit != 'true'
         run: rm -rf target && cargo xtask help
   matrix:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [checks, cache] # The cache is used by the checks.
     strategy:
       fail-fast: false
@@ -89,7 +89,7 @@ jobs:
           checks: "[\"${{ matrix.check }}\"]"
           token: ${{ secrets.GITHUB_TOKEN }}
   ubuntu:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: matrix
     steps:
       - run: true


### PR DESCRIPTION
Now that `ubuntu-latest` is Ubuntu 24.04, see https://github.com/actions/runner-images/issues/9691