### PR TITLE
Add a --force flag to the sync script

### DIFF
--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -18,6 +18,8 @@ set -e
 
 # This script synchronizes generated content.
 
+[ "$1" = --force ] && FORCE=y
+
 cargo xtask update-apis
 
 book_example() {
@@ -25,7 +27,7 @@ book_example() {
   local dst=examples/rust/$2/src/lib.rs
   # We only check that the destination is newer by more than one second, because when cloning the
   # repository or switching branches, it may happen that the destination is slightly newer.
-  if [ $(stat -c%Y $dst) -gt $(($(stat -c%Y $src) + 1)) ]; then
+  if [ -z "$FORCE" -a $(stat -c%Y $dst) -gt $(($(stat -c%Y $src) + 1)) ]; then
     t "Update $src instead of $dst"
     e "$dst seems to have been manually modified"
   fi

--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -29,6 +29,7 @@ book_example() {
   # repository or switching branches, it may happen that the destination is slightly newer.
   if [ -z "$FORCE" -a $(stat -c%Y $dst) -gt $(($(stat -c%Y $src) + 1)) ]; then
     t "Update $src instead of $dst"
+    i "If you switched branch and did not modify those files, rerun with --force"
     e "$dst seems to have been manually modified"
   fi
   # Besides removing all anchors, we insert a warning before the #![no_std] line, which all examples


### PR DESCRIPTION
This is useful to bypass the check for the book examples, which over-triggers when moving between before and after #445.