### PR TITLE
Enable +bulk-memory for wasm by default.

### DIFF
--- a/crates/cli-tools/src/action.rs
+++ b/crates/cli-tools/src/action.rs
@@ -107,6 +107,7 @@ impl RustAppletBuild {
         match &self.native {
             None => {
                 rustflags.push(format!("-C link-arg=-zstack-size={}", self.stack_size));
+                rustflags.push("-C target-feature=+bulk-memory".to_string());
                 cargo.args(["--crate-type=cdylib", "--target=wasm32-unknown-unknown"]);
             }
             Some(target) => {


### PR DESCRIPTION
As discussed in #466 , let's enable bulk-memory operations by default.