### PR TITLE
Enable mutable globals in wasm-opt.

### DIFF
--- a/crates/cli-tools/CHANGELOG.md
+++ b/crates/cli-tools/CHANGELOG.md
@@ -2,4 +2,4 @@
 
 ## 0.1.0-git
 
-<!-- Increment to skip CHANGELOG.md test: 5 -->
+<!-- Increment to skip CHANGELOG.md test: 6 -->

--- a/crates/cli-tools/src/action.rs
+++ b/crates/cli-tools/src/action.rs
@@ -203,7 +203,7 @@ pub fn optimize_wasm(applet: impl AsRef<Path>, opt_level: Option<OptLevel>) -> R
     strip.arg(applet.as_ref());
     cmd::execute(&mut strip)?;
     let mut opt = Command::new("wasm-opt");
-    opt.args(["--enable-bulk-memory", "--enable-sign-ext"]);
+    opt.args(["--enable-bulk-memory", "--enable-sign-ext", "--enable-mutable-globals"]);
     match opt_level {
         Some(level) => drop(opt.arg(format!("-O{level}"))),
         None => drop(opt.arg("-O")),


### PR DESCRIPTION
For the target `wasm32-unknown-unknown` the mutable globals are activated by default. There seems to be a mismatch with wasm-opt, where it is not (yet?) the case.

Here is what is activatd by default for rustc (1.77.0):
```
~/wasefire % rustc --print=cfg  --target=wasm32-unknown-unknown  
debug_assertions
overflow_checks
panic="abort"
relocation_model="static"
target_abi=""
target_arch="wasm32"
target_endian="little"
target_env=""
target_family="wasm"
target_feature="mutable-globals"
target_feature="sign-ext"
target_has_atomic
target_has_atomic="16"
target_has_atomic="32"
target_has_atomic="64"
target_has_atomic="8"
target_has_atomic="ptr"
target_has_atomic_equal_alignment="16"
target_has_atomic_equal_alignment="32"
target_has_atomic_equal_alignment="64"
target_has_atomic_equal_alignment="8"
target_has_atomic_equal_alignment="ptr"
target_has_atomic_load_store
target_has_atomic_load_store="16"
target_has_atomic_load_store="32"
target_has_atomic_load_store="64"
target_has_atomic_load_store="8"
target_has_atomic_load_store="ptr"
target_os="unknown"
target_pointer_width="32"
target_thread_local
target_vendor="unknown"
```