### PR TITLE
Do not strip debuginfo in debug build

### DIFF
--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -419,6 +419,7 @@ impl RunnerOptions {
             } else {
                 rustflags.push("-C link-arg=-Tdefmt.x".to_string());
                 rustflags.push("-C debuginfo=2".to_string());
+                rustflags.push("-C strip=none".to_string());
             }
         }
         if let Some(level) = self.opt_level {

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -56,7 +56,6 @@ fi
 # Transitive dependencies of xtask.
 ensure bin cc
 ensure lib libudev
-ensure lib libusb-1.0
 
 # Transitive dependencies of runner-host. This should ideally be installed on
 # demand by xtask.

--- a/scripts/system.sh
+++ b/scripts/system.sh
@@ -49,7 +49,6 @@ install() {
       lib)
         case "$2" in
           libudev) set libudev-dev ;;
-          libusb-1.0) set libusb-1.0-0-dev ;;
           openssl) set libssl-dev ;;
           *) e "Internal error: apt-get install unimplemented for $*" ;;
         esac ;;


### PR DESCRIPTION
This seems to have changed in https://github.com/rust-lang/cargo/pull/13257.

Also do not install libusb-1.0 during setup. This doesn't seem necessary anymore.