### PR TITLE
Implement Error from core instead of std

### DIFF
--- a/crates/error/CHANGELOG.md
+++ b/crates/error/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 ### Minor
 
+- Implement `core::error::Error` for `Error`
 - Add `Error::new_const()` and make `Error::{space,code}()` const
-- Add `std` feature to implement `std::error::Error`
 - Add an `OutOfBounds` error
 
 ### Patch

--- a/crates/error/Cargo.toml
+++ b/crates/error/Cargo.toml
@@ -17,7 +17,6 @@ num_enum = { version = "0.7.2", default-features = false }
 
 [features]
 defmt = ["dep:defmt"]
-std = []
 
 [lints]
 clippy.unit-arg = "allow"

--- a/crates/error/src/lib.rs
+++ b/crates/error/src/lib.rs
@@ -15,11 +15,10 @@
 //! Applet and board API errors.
 
 #![no_std]
+#![feature(error_in_core)]
 
 // TODO(https://github.com/rust-lang/rust/issues/122105): Remove when fixed.
 extern crate alloc;
-#[cfg(feature = "std")]
-extern crate std;
 
 use num_enum::{IntoPrimitive, TryFromPrimitive, TryFromPrimitiveError};
 
@@ -223,8 +222,7 @@ impl defmt::Format for Error {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for Error {}
+impl core::error::Error for Error {}
 
 #[cfg(test)]
 mod tests {

--- a/crates/protocol-usb/CHANGELOG.md
+++ b/crates/protocol-usb/CHANGELOG.md
@@ -2,4 +2,4 @@
 
 ## 0.1.0-git
 
-<!-- Increment to skip CHANGELOG.md test: 4 -->
+<!-- Increment to skip CHANGELOG.md test: 5 -->

--- a/crates/protocol-usb/Cargo.toml
+++ b/crates/protocol-usb/Cargo.toml
@@ -28,7 +28,7 @@ optional = true
 [features]
 defmt = ["dep:defmt", "wasefire-board-api?/defmt", "wasefire-error?/defmt", "wasefire-logger/defmt"]
 log = ["wasefire-board-api?/log", "wasefire-logger/log"]
-std = ["wasefire-board-api?/std", "wasefire-error?/std"]
+std = ["wasefire-board-api?/std"]
 # Exactly one of host or device must be selected.
 device = ["dep:usb-device", "dep:wasefire-board-api", "dep:wasefire-error"]
 host = ["dep:anyhow", "dep:rusb", "std"]

--- a/crates/protocol/CHANGELOG.md
+++ b/crates/protocol/CHANGELOG.md
@@ -2,4 +2,4 @@
 
 ## 0.1.0-git
 
-<!-- Increment to skip CHANGELOG.md test: 6 -->
+<!-- Increment to skip CHANGELOG.md test: 7 -->

--- a/crates/protocol/Cargo.toml
+++ b/crates/protocol/Cargo.toml
@@ -20,7 +20,7 @@ wasefire-wire = { version = "0.1.0-git", path = "../wire" }
 
 [features]
 full = []
-std = ["wasefire-error/std", "wasefire-wire/std"]
+std = ["wasefire-wire/std"]
 
 [lints]
 clippy.unit-arg = "allow"

--- a/crates/wire/CHANGELOG.md
+++ b/crates/wire/CHANGELOG.md
@@ -2,4 +2,4 @@
 
 ## 0.1.0-git
 
-<!-- Increment to skip CHANGELOG.md test: 2 -->
+<!-- Increment to skip CHANGELOG.md test: 3 -->

--- a/crates/wire/Cargo.toml
+++ b/crates/wire/Cargo.toml
@@ -20,7 +20,7 @@ wasefire-wire-derive = { version = "0.1.0-git", path = "../wire-derive" }
 
 [features]
 schema = ["std", "wasefire-wire-derive/schema"]
-std = ["wasefire-error/std"]
+std = []
 
 [lints]
 clippy.unit-arg = "allow"

--- a/examples/rust/protocol/host/Cargo.lock
+++ b/examples/rust/protocol/host/Cargo.lock
@@ -380,7 +380,6 @@ dependencies = [
  "anyhow",
  "rusb",
  "wasefire-board-api",
- "wasefire-error",
  "wasefire-logger",
 ]
 


### PR DESCRIPTION
This is not a breaking change because 0.1.1-git was not published yet.