### PR TITLE
Revert "Add TODO to remove println timestamp"

### DIFF
--- a/crates/board/CHANGELOG.md
+++ b/crates/board/CHANGELOG.md
@@ -133,4 +133,4 @@
 
 ## 0.1.0
 
-<!-- Increment to skip CHANGELOG.md test: 22 -->
+<!-- Increment to skip CHANGELOG.md test: 21 -->

--- a/crates/board/src/debug.rs
+++ b/crates/board/src/debug.rs
@@ -23,7 +23,6 @@ pub trait Api: Send {
 
     /// Prints a line with timestamp.
     fn println(line: &str) {
-        // TODO(probe-rs-tools > 0.24.0): Call println! without timestamp.
         let time = Self::time();
         log::println!("{}.{:06}: {}", time / 1000000, time % 1000000, line);
     }


### PR DESCRIPTION
Reverts google/wasefire#502

The conclusion from https://github.com/knurling-rs/defmt/issues/844#issuecomment-2143064192 is that `println` should just print its input (no timestamp, no location).