### PR TITLE
Execution of wasm atomic ops with portable_atomics in the interpreter.

### DIFF
--- a/crates/interpreter/src/exec.rs
+++ b/crates/interpreter/src/exec.rs
@@ -1421,7 +1421,7 @@ impl<'m> Thread<'m> {
             return Err(trap());
         }
         self.push_value(count);
-        return Ok(());
+        Ok(())
     }
 
     #[cfg(feature = "threads")]
@@ -1438,7 +1438,7 @@ impl<'m> Thread<'m> {
         if read != expected {
             self.push_value(Val::I32(1));
         }
-        return Ok(());
+        Ok(())
     }
 
     #[cfg(feature = "threads")]
@@ -1532,21 +1532,17 @@ impl<'m> Thread<'m> {
                 c.unwrap_i64() as i64,
                 c2.unwrap_i64() as i64,
             ) as u64),
-            (NumType::I32, 8) => Val::I32(op.u32_u8(
-                mem.as_mut_ptr() as *mut u8,
-                c.unwrap_i32() as u8,
-                c2.unwrap_i32() as u8,
-            )),
+            (NumType::I32, 8) => {
+                Val::I32(op.u32_u8(mem.as_mut_ptr(), c.unwrap_i32() as u8, c2.unwrap_i32() as u8))
+            }
             (NumType::I32, 16) => Val::I32(op.u32_u16(
                 mem.as_mut_ptr() as *mut u16,
                 c.unwrap_i32() as u16,
                 c2.unwrap_i32() as u16,
             )),
-            (NumType::I64, 8) => Val::I64(op.u64_u8(
-                mem.as_mut_ptr() as *mut u8,
-                c.unwrap_i64() as u8,
-                c2.unwrap_i64() as u8,
-            )),
+            (NumType::I64, 8) => {
+                Val::I64(op.u64_u8(mem.as_mut_ptr(), c.unwrap_i64() as u8, c2.unwrap_i64() as u8))
+            }
             (NumType::I64, 16) => Val::I64(op.u64_u16(
                 mem.as_mut_ptr() as *mut u16,
                 c.unwrap_i64() as u16,

--- a/crates/interpreter/src/exec.rs
+++ b/crates/interpreter/src/exec.rs
@@ -16,6 +16,9 @@
 use alloc::vec;
 use alloc::vec::Vec;
 
+#[cfg(feature = "threads")]
+use portable_atomic::*;
+
 use crate::error::*;
 use crate::module::*;
 use crate::syntax::*;
@@ -965,58 +968,38 @@ impl<'m> Thread<'m> {
                 table.elems[i ..][.. n].fill(val);
             }
             #[cfg(feature = "threads")]
-            AtomicNotify(_) => {
-                #[cfg(feature = "debug")]
-                println!("Atomic notify");
-                return Err(trap());
+            AtomicNotify(m) => {
+                self.atomic_notify(store.mem(inst_id, 0), m)?;
             }
             #[cfg(feature = "threads")]
-            AtomicWait(_, _) => {
-                #[cfg(feature = "debug")]
-                println!("Atomic wait");
-                return Err(trap());
+            AtomicWait(n, m) => {
+                self.atomic_wait(store.mem(inst_id, 0), NumType::i(n), n.into(), m)?;
             }
             #[cfg(feature = "threads")]
-            AtomicFence => {
-                #[cfg(feature = "debug")]
-                println!("Atomic fence");
-                return Err(trap());
+            AtomicFence => {}
+            #[cfg(feature = "threads")]
+            AtomicLoad(n, m) => {
+                self.atomic_load(store.mem(inst_id, 0), NumType::i(n), n.into(), m)?;
             }
             #[cfg(feature = "threads")]
-            AtomicLoad(_, _) => {
-                #[cfg(feature = "debug")]
-                println!("Atomic load");
-                return Err(trap());
+            AtomicLoad_(b, m) => {
+                self.atomic_load(store.mem(inst_id, 0), NumType::i(b.into()), b.into(), m)?;
             }
             #[cfg(feature = "threads")]
-            AtomicLoad_(_, _) => {
-                #[cfg(feature = "debug")]
-                println!("Atomic load");
-                return Err(trap());
+            AtomicStore(n, m) => {
+                self.atomic_store(store.mem(inst_id, 0), NumType::i(n), n.into(), m)?;
             }
             #[cfg(feature = "threads")]
-            AtomicStore(_, _) => {
-                #[cfg(feature = "debug")]
-                println!("Atomic store");
-                return Err(trap());
+            AtomicStore_(b, m) => {
+                self.atomic_store(store.mem(inst_id, 0), NumType::i(b.into()), b.into(), m)?;
             }
             #[cfg(feature = "threads")]
-            AtomicStore_(_, _) => {
-                #[cfg(feature = "debug")]
-                println!("Atomic store");
-                return Err(trap());
+            AtomicOp(n, op, m) => {
+                self.atomic_binop(op, store.mem(inst_id, 0), NumType::i(n), n.into(), m)?;
             }
             #[cfg(feature = "threads")]
-            AtomicOp(_op, _, _) => {
-                #[cfg(feature = "debug")]
-                println!("Atomic binop {:?} ", _op);
-                return Err(trap());
-            }
-            #[cfg(feature = "threads")]
-            AtomicOp_(_op, _, _) => {
-                #[cfg(feature = "debug")]
-                println!("Atomic binopP {:?} ", _op);
-                return Err(trap());
+            AtomicOp_(b, op, m) => {
+                self.atomic_binop(op, store.mem(inst_id, 0), NumType::i(b.into()), b.into(), m)?;
             }
         }
         Ok(ThreadResult::Continue(self))
@@ -1423,6 +1406,162 @@ impl<'m> Thread<'m> {
         self.frames.push(Frame::new(inst_id, t.results.len(), ret, locals));
         Ok(ThreadResult::Continue(self))
     }
+
+    #[cfg(feature = "threads")]
+    fn atomic_notify(&mut self, _mem: &mut Memory<'m>, _m: MemArg) -> Result<(), Error> {
+        let count = self.pop_value();
+        let i = self.pop_value().unwrap_i32();
+
+        // Trap if memory access is OOB.
+        let _mem = match self.mem_slice(_mem, _m, i, 4) {
+            None => return Err(trap()),
+            Some(x) => x,
+        };
+        if i % 4 != 0 {
+            return Err(trap());
+        }
+        self.push_value(count);
+        return Ok(());
+    }
+
+    #[cfg(feature = "threads")]
+    fn atomic_wait(
+        &mut self, mem: &mut Memory<'m>, t: NumType, n: usize, m: MemArg,
+    ) -> Result<(), Error> {
+        if !mem.share {
+            return Err(trap());
+        }
+        let _timeout = self.pop_value().unwrap_i64();
+        let expected = self.pop_value();
+        self.atomic_load(mem, t, n, m)?;
+        let read = self.pop_value();
+        if read != expected {
+            self.push_value(Val::I32(1));
+        }
+        return Ok(());
+    }
+
+    #[cfg(feature = "threads")]
+    fn atomic_load(
+        &mut self, mem: &mut Memory<'m>, t: NumType, n: usize, m: MemArg,
+    ) -> Result<(), Error> {
+        let i = self.pop_value().unwrap_i32();
+        if i % (n as u32 / 8) != 0 {
+            return Err(trap());
+        }
+        let mem = match self.mem_slice(mem, m, i, n / 8) {
+            None => return Err(trap()),
+            Some(x) => x,
+        };
+        macro_rules! convert {
+            ($T:ident, $t:ident, $s:ident) => {
+               unsafe {
+                    paste::paste! { Val::$T([< Atomic $s:upper >]::from_ptr(mem.as_mut_ptr() as *mut $s).load(portable_atomic::Ordering::SeqCst) as $t)}
+                }
+            };
+        }
+        let c = match (t, n) {
+            (NumType::I32, 32) => convert!(I32, u32, u32),
+            (NumType::I64, 64) => convert!(I64, u64, u64),
+            (NumType::I32, 8) => convert!(I32, u32, u8),
+            (NumType::I32, 16) => convert!(I32, u32, u16),
+            (NumType::I64, 8) => convert!(I64, u64, u8),
+            (NumType::I64, 16) => convert!(I64, u64, u16),
+            (NumType::I64, 32) => convert!(I64, u64, u32),
+            _ => unreachable!(),
+        };
+        self.push_value(c);
+        Ok(())
+    }
+
+    #[cfg(feature = "threads")]
+    fn atomic_store(
+        &mut self, mem: &mut Memory<'m>, t: NumType, n: usize, m: MemArg,
+    ) -> Result<(), Error> {
+        let c = self.pop_value();
+        let i = self.pop_value().unwrap_i32();
+        if i % (n as u32 / 8) != 0 {
+            return Err(trap());
+        }
+        let mem = match self.mem_slice(mem, m, i, n / 8) {
+            None => return Err(trap()),
+            Some(x) => x,
+        };
+        macro_rules! convert {
+            ($s:ident, $t:ident) => {
+                unsafe {
+                    paste::paste! { [< Atomic $t:upper >]::from_ptr(mem.as_mut_ptr() as *mut $t).store((c.[<unwrap_ $s>]() as $t),portable_atomic::Ordering::SeqCst) }
+                }
+            };
+        }
+        match (t, n) {
+            (NumType::I32, 32) => convert!(i32, i32),
+            (NumType::I64, 64) => convert!(i64, i64),
+            (NumType::I32, 8) => convert!(i32, i8),
+            (NumType::I32, 16) => convert!(i32, i16),
+            (NumType::I64, 8) => convert!(i64, i8),
+            (NumType::I64, 16) => convert!(i64, i16),
+            (NumType::I64, 32) => convert!(i64, i32),
+            _ => unreachable!(),
+        }
+        Ok(())
+    }
+
+    #[cfg(feature = "threads")]
+    fn atomic_binop(
+        &mut self, op: AtomicOp, mem: &mut Memory<'m>, t: NumType, n: usize, m: MemArg,
+    ) -> Result<(), Error> {
+        let c = self.pop_value();
+        let c2 = if op == AtomicOp::Cmpxchg { self.pop_value() } else { c };
+        let i = self.pop_value().unwrap_i32();
+        if i % (n as u32 / 8) != 0 {
+            return Err(trap());
+        }
+        let mem = match self.mem_slice(mem, m, i, n / 8) {
+            None => return Err(trap()),
+            Some(x) => x,
+        };
+        let c = match (t, n) {
+            (NumType::I32, 32) => Val::I32(op.i32_i32(
+                mem.as_mut_ptr() as *mut i32,
+                c.unwrap_i32() as i32,
+                c2.unwrap_i32() as i32,
+            ) as u32),
+            (NumType::I64, 64) => Val::I64(op.i64_i64(
+                mem.as_mut_ptr() as *mut i64,
+                c.unwrap_i64() as i64,
+                c2.unwrap_i64() as i64,
+            ) as u64),
+            (NumType::I32, 8) => Val::I32(op.u32_u8(
+                mem.as_mut_ptr() as *mut u8,
+                c.unwrap_i32() as u8,
+                c2.unwrap_i32() as u8,
+            )),
+            (NumType::I32, 16) => Val::I32(op.u32_u16(
+                mem.as_mut_ptr() as *mut u16,
+                c.unwrap_i32() as u16,
+                c2.unwrap_i32() as u16,
+            )),
+            (NumType::I64, 8) => Val::I64(op.u64_u8(
+                mem.as_mut_ptr() as *mut u8,
+                c.unwrap_i64() as u8,
+                c2.unwrap_i64() as u8,
+            )),
+            (NumType::I64, 16) => Val::I64(op.u64_u16(
+                mem.as_mut_ptr() as *mut u16,
+                c.unwrap_i64() as u16,
+                c2.unwrap_i64() as u16,
+            )),
+            (NumType::I64, 32) => Val::I64(op.u64_u32(
+                mem.as_mut_ptr() as *mut u32,
+                c.unwrap_i64() as u32,
+                c2.unwrap_i64() as u32,
+            )),
+            _ => unreachable!(),
+        };
+        self.push_value(c);
+        Ok(())
+    }
 }
 
 fn table_init(d: usize, s: usize, n: usize, table: &mut Table, elems: &[Val]) -> Result<(), Error> {
@@ -1498,6 +1637,8 @@ struct Memory<'m> {
     // The size currently available to the module. May be larger than the actual data.
     size: u32,
     max: u32,
+    #[cfg(feature = "threads")]
+    share: bool,
 }
 
 impl<'m> Memory<'m> {
@@ -1515,6 +1656,8 @@ impl<'m> Memory<'m> {
         self.data.fill(0);
         self.size = limits.min;
         self.max = limits.max;
+        #[cfg(feature = "threads")]
+        (self.share = limits.share == Share::Shared);
         Ok(())
     }
 

--- a/crates/interpreter/src/parser.rs
+++ b/crates/interpreter/src/parser.rs
@@ -337,12 +337,18 @@ impl<'m, M: Mode> Parser<'m, M> {
             x @ 18 ..= 22 => Instr::AtomicLoad_((x - 18).into(), self.parse_memarg()?),
             x @ 23 ..= 24 => Instr::AtomicStore((x - 23).into(), self.parse_memarg()?),
             x @ 25 ..= 29 => Instr::AtomicStore_((x - 25).into(), self.parse_memarg()?),
-            x @ 30 ..= 78 => {
-                let op: AtomicOp = ((x - 30) / 7).into();
+            x @ 30 ..= 71 => {
+                let op: AtomicUnOp = ((x - 30) / 7).into();
                 match (x - 30) % 7 {
-                    x @ 0 ..= 1 => Instr::AtomicOp(x.into(), op, self.parse_memarg()?),
-                    x => Instr::AtomicOp_((x - 2).into(), op, self.parse_memarg()?),
+                    x @ 0 ..= 1 => Instr::AtomicUnOp(x.into(), op, self.parse_memarg()?),
+                    x => Instr::AtomicUnOp_((x - 2).into(), op, self.parse_memarg()?),
                 }
+            }
+            x @ 72 ..= 73 => {
+                Instr::AtomicBinOp((x - 72).into(), AtomicBinOp::Cmpxchg, self.parse_memarg()?)
+            }
+            x @ 74 ..= 78 => {
+                Instr::AtomicBinOp_((x - 74).into(), AtomicBinOp::Cmpxchg, self.parse_memarg()?)
             }
             _ => M::invalid()?,
         })

--- a/crates/interpreter/src/syntax.rs
+++ b/crates/interpreter/src/syntax.rs
@@ -560,27 +560,25 @@ impl CvtOp {
 #[cfg(feature = "threads")]
 macro_rules! impl_atomic_op {
     ($u:ident) => {
-        paste::paste! {
-            impl AtomicUnOp {
-                pub fn $u(&self, ptr: *mut $u, c: $u) -> $u {
-                    let x = unsafe { [< Atomic $u:upper >]::from_ptr(ptr) };
-                    match self {
-                        AtomicUnOp::Add => x.fetch_add(c, Ordering::SeqCst),
-                        AtomicUnOp::Sub => x.fetch_sub(c, Ordering::SeqCst),
-                        AtomicUnOp::And => x.fetch_and(c, Ordering::SeqCst),
-                        AtomicUnOp::Or => x.fetch_or(c, Ordering::SeqCst),
-                        AtomicUnOp::Xor => x.fetch_xor(c, Ordering::SeqCst),
-                        AtomicUnOp::Xchg => x.swap(c, Ordering::SeqCst),
-                    }
+        impl AtomicUnOp {
+            pub fn $u(&self, ptr: *mut $u, val: $u) -> $u {
+                let x = unsafe { paste::paste!([<Atomic $u:upper>]::from_ptr(ptr)) };
+                match self {
+                    AtomicUnOp::Add => x.fetch_add(val, Ordering::SeqCst),
+                    AtomicUnOp::Sub => x.fetch_sub(val, Ordering::SeqCst),
+                    AtomicUnOp::And => x.fetch_and(val, Ordering::SeqCst),
+                    AtomicUnOp::Or => x.fetch_or(val, Ordering::SeqCst),
+                    AtomicUnOp::Xor => x.fetch_xor(val, Ordering::SeqCst),
+                    AtomicUnOp::Xchg => x.swap(val, Ordering::SeqCst),
                 }
             }
-            impl AtomicBinOp {
-                pub fn $u(&self, ptr: *mut $u, c: $u, c2: $u) -> $u {
-                    let x = unsafe { [< Atomic $u:upper >]::from_ptr(ptr) };
-                    match x.compare_exchange(c2, c, Ordering::SeqCst, Ordering::SeqCst) {
-                                Err(v) => v,
-                                Ok(v) => v
-                    }
+        }
+        impl AtomicBinOp {
+            pub fn $u(&self, ptr: *mut $u, val1: $u, val2: $u) -> $u {
+                let x = unsafe { paste::paste!([<Atomic $u:upper>]::from_ptr(ptr)) };
+                match x.compare_exchange(val1, val2, Ordering::SeqCst, Ordering::SeqCst) {
+                    Err(v) => v,
+                    Ok(v) => v
                 }
             }
         }

--- a/crates/interpreter/src/syntax.rs
+++ b/crates/interpreter/src/syntax.rs
@@ -548,6 +548,7 @@ impl CvtOp {
     }
 }
 
+#[cfg(feature = "threads")]
 macro_rules! impl_atomic_op {
     ($n:ident, $u:ident) => {
         paste::paste! {

--- a/crates/interpreter/src/syntax.rs
+++ b/crates/interpreter/src/syntax.rs
@@ -17,7 +17,7 @@ use core::ops::Deref;
 
 use num_enum::{TryFromPrimitive, UnsafeFromPrimitive};
 #[cfg(feature = "threads")]
-use portable_atomic::{AtomicI32, AtomicI64, AtomicU16, AtomicU32, AtomicU8, Ordering};
+use portable_atomic::{AtomicU16, AtomicU32, AtomicU64, AtomicU8, Ordering};
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, TryFromPrimitive, UnsafeFromPrimitive)]
 #[repr(u8)]
@@ -562,22 +562,22 @@ macro_rules! impl_atomic_op {
     ($u:ident) => {
         paste::paste! {
             impl AtomicUnOp {
-                pub fn $u(&self, mem: *mut $u, c: $u) -> $u {
-                    let atomic_val = unsafe { [< Atomic $u:upper >]::from_ptr(mem) };
+                pub fn $u(&self, ptr: *mut $u, c: $u) -> $u {
+                    let x = unsafe { [< Atomic $u:upper >]::from_ptr(ptr) };
                     match self {
-                        AtomicUnOp::Add => atomic_val.fetch_add(c, Ordering::SeqCst),
-                        AtomicUnOp::Sub => atomic_val.fetch_sub(c, Ordering::SeqCst),
-                        AtomicUnOp::And => atomic_val.fetch_and(c, Ordering::SeqCst),
-                        AtomicUnOp::Or => atomic_val.fetch_or(c, Ordering::SeqCst),
-                        AtomicUnOp::Xor => atomic_val.fetch_xor(c, Ordering::SeqCst),
-                        AtomicUnOp::Xchg => atomic_val.swap(c, Ordering::SeqCst),
+                        AtomicUnOp::Add => x.fetch_add(c, Ordering::SeqCst),
+                        AtomicUnOp::Sub => x.fetch_sub(c, Ordering::SeqCst),
+                        AtomicUnOp::And => x.fetch_and(c, Ordering::SeqCst),
+                        AtomicUnOp::Or => x.fetch_or(c, Ordering::SeqCst),
+                        AtomicUnOp::Xor => x.fetch_xor(c, Ordering::SeqCst),
+                        AtomicUnOp::Xchg => x.swap(c, Ordering::SeqCst),
                     }
                 }
             }
             impl AtomicBinOp {
-                pub fn $u(&self, mem: *mut $u, c: $u, c2: $u) -> $u {
-                    let atomic_val = unsafe { [< Atomic $u:upper >]::from_ptr(mem) };
-                    match atomic_val.compare_exchange(c2, c, Ordering::SeqCst, Ordering::SeqCst) {
+                pub fn $u(&self, ptr: *mut $u, c: $u, c2: $u) -> $u {
+                    let x = unsafe { [< Atomic $u:upper >]::from_ptr(ptr) };
+                    match x.compare_exchange(c2, c, Ordering::SeqCst, Ordering::SeqCst) {
                                 Err(v) => v,
                                 Ok(v) => v
                     }
@@ -588,9 +588,7 @@ macro_rules! impl_atomic_op {
 }
 
 #[cfg(feature = "threads")]
-impl_atomic_op!(i64);
-#[cfg(feature = "threads")]
-impl_atomic_op!(i32);
+impl_atomic_op!(u64);
 #[cfg(feature = "threads")]
 impl_atomic_op!(u32);
 #[cfg(feature = "threads")]

--- a/crates/interpreter/src/valid.rs
+++ b/crates/interpreter/src/valid.rs
@@ -669,20 +669,6 @@ impl<'a, 'm> Expr<'a, 'm> {
             #[cfg(feature = "threads")]
             AtomicStore_(b, m) => self.store(true, NumType::i(b.into()), b.into(), m)?,
             #[cfg(feature = "threads")]
-            AtomicBinOp(n, _, m) => {
-                self.check_mem(true, n.into(), m)?;
-                let num = NumType::i(n);
-                self.pops([ValType::I32, num.into(), num.into()][..].into())?;
-                self.push(num.into());
-            }
-            #[cfg(feature = "threads")]
-            AtomicBinOp_(b, _, m) => {
-                self.check_mem(true, b.into(), m)?;
-                let num = NumType::i(b.into());
-                self.pops([ValType::I32, num.into(), num.into()][..].into())?;
-                self.push(num.into())
-            }
-            #[cfg(feature = "threads")]
             AtomicUnOp(n, _, m) => {
                 self.check_mem(true, n.into(), m)?;
                 let num = NumType::i(n);
@@ -694,6 +680,20 @@ impl<'a, 'm> Expr<'a, 'm> {
                 self.check_mem(true, b.into(), m)?;
                 let num = NumType::i(b.into());
                 self.pops([ValType::I32, num.into()][..].into())?;
+                self.push(num.into())
+            }
+            #[cfg(feature = "threads")]
+            AtomicBinOp(n, _, m) => {
+                self.check_mem(true, n.into(), m)?;
+                let num = NumType::i(n);
+                self.pops([ValType::I32, num.into(), num.into()][..].into())?;
+                self.push(num.into());
+            }
+            #[cfg(feature = "threads")]
+            AtomicBinOp_(b, _, m) => {
+                self.check_mem(true, b.into(), m)?;
+                let num = NumType::i(b.into());
+                self.pops([ValType::I32, num.into(), num.into()][..].into())?;
                 self.push(num.into())
             }
         }

--- a/crates/interpreter/src/valid.rs
+++ b/crates/interpreter/src/valid.rs
@@ -669,28 +669,28 @@ impl<'a, 'm> Expr<'a, 'm> {
             #[cfg(feature = "threads")]
             AtomicStore_(b, m) => self.store(true, NumType::i(b.into()), b.into(), m)?,
             #[cfg(feature = "threads")]
-            AtomicOp(n, syntax::AtomicOp::Cmpxchg, m) => {
+            AtomicBinOp(n, _, m) => {
                 self.check_mem(true, n.into(), m)?;
                 let num = NumType::i(n);
                 self.pops([ValType::I32, num.into(), num.into()][..].into())?;
                 self.push(num.into());
             }
             #[cfg(feature = "threads")]
-            AtomicOp_(b, syntax::AtomicOp::Cmpxchg, m) => {
+            AtomicBinOp_(b, _, m) => {
                 self.check_mem(true, b.into(), m)?;
                 let num = NumType::i(b.into());
                 self.pops([ValType::I32, num.into(), num.into()][..].into())?;
                 self.push(num.into())
             }
             #[cfg(feature = "threads")]
-            AtomicOp(n, _, m) => {
+            AtomicUnOp(n, _, m) => {
                 self.check_mem(true, n.into(), m)?;
                 let num = NumType::i(n);
                 self.pops([ValType::I32, num.into()][..].into())?;
                 self.push(num.into());
             }
             #[cfg(feature = "threads")]
-            AtomicOp_(b, _, m) => {
+            AtomicUnOp_(b, _, m) => {
                 self.check_mem(true, b.into(), m)?;
                 let num = NumType::i(b.into());
                 self.pops([ValType::I32, num.into()][..].into())?;

--- a/crates/interpreter/tests/spec.rs
+++ b/crates/interpreter/tests/spec.rs
@@ -488,9 +488,4 @@ test!(utf8_import_field, "utf8-import-field");
 test!(utf8_import_module, "utf8-import-module");
 test!(utf8_invalid_encoding, "utf8-invalid-encoding");
 
-test!(
-    // Not fully implemented yet, ignoring.
-    #[ignore]
-    "threads",
-    atomic
-);
+test!("threads", atomic);


### PR DESCRIPTION
Execution up to the point that `atomic.wast` test passes. Notably that means notify, wait and fence are nor properly implemented yet, but everything else is. For the last three some basic checks are implemented though, like out of bounds and memory alignment.

Also changed the submodule to the feature branch with the fixed tests.