### PR TITLE
Do not use trim-paths in Cargo.toml

### DIFF
--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.1.2-git
+
+### Patch
+
+- Restore release builds to the default
+
 ## 0.1.1
 
 ### Minor

--- a/crates/cli/Cargo.lock
+++ b/crates/cli/Cargo.lock
@@ -464,7 +464,7 @@ dependencies = [
 
 [[package]]
 name = "wasefire-cli"
-version = "0.1.1"
+version = "0.1.2-git"
 dependencies = [
  "anyhow",
  "clap",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,8 +1,6 @@
-cargo-features = ["trim-paths"]
-
 [package]
 name = "wasefire-cli"
-version = "0.1.1"
+version = "0.1.2-git"
 authors = ["Julien Cretin <cretin@google.com>"]
 license = "Apache-2.0"
 publish = true
@@ -27,11 +25,6 @@ rusb = { version = "0.9.4", default-features = false }
 wasefire-cli-tools = { version = "0.1.0", path = "../cli-tools" }
 wasefire-protocol = { version = "0.1.0", path = "../protocol", features = ["host"] }
 wasefire-protocol-usb = { version = "0.1.0", path = "../protocol-usb", features = ["host"] }
-
-# Try to make the build as reproducible as possible in release mode.
-[profile.release]
-codegen-units = 1
-trim-paths = true
 
 [lints]
 clippy.unit-arg = "allow"


### PR DESCRIPTION
This breaks `cargo publish`. Also don't try to make the build reproducible now that we release and attest from Github. Also users installing from `cargo install` may still want debug paths.