### PR TITLE
Fix copy_if_changed with multiple sources

### DIFF
--- a/crates/cli-tools/CHANGELOG.md
+++ b/crates/cli-tools/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.1.1-git
+
+### Minor
+
+- Change the behavior of `fs::copy_if_changed()` to keep an original source
+
 ## 0.1.0
 
 <!-- Increment to skip CHANGELOG.md test: 0 -->

--- a/crates/cli-tools/Cargo.lock
+++ b/crates/cli-tools/Cargo.lock
@@ -374,7 +374,7 @@ dependencies = [
 
 [[package]]
 name = "wasefire-cli-tools"
-version = "0.1.0"
+version = "0.1.1-git"
 dependencies = [
  "anyhow",
  "cargo_metadata",

--- a/crates/cli-tools/Cargo.toml
+++ b/crates/cli-tools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasefire-cli-tools"
-version = "0.1.0"
+version = "0.1.1-git"
 authors = ["Julien Cretin <cretin@google.com>"]
 license = "Apache-2.0"
 publish = true

--- a/crates/cli-tools/src/lib.rs
+++ b/crates/cli-tools/src/lib.rs
@@ -16,6 +16,8 @@
 //!
 //! This library is also used for the internal maintenance CLI of Wasefire called xtask.
 
+#![feature(path_add_extension)]
+
 macro_rules! debug {
     ($($x:tt)*) => {
         print!("\x1b[1;36m");

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Patch
 
+- Update dependencies
 - Restore release builds to the default
 
 ## 0.1.1

--- a/crates/cli/Cargo.lock
+++ b/crates/cli/Cargo.lock
@@ -479,7 +479,7 @@ dependencies = [
 
 [[package]]
 name = "wasefire-cli-tools"
-version = "0.1.0"
+version = "0.1.1-git"
 dependencies = [
  "anyhow",
  "cargo_metadata",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -22,7 +22,7 @@ clap_complete = { version = "4.5.2", default-features = false }
 data-encoding = { version = "2.6.0", default-features = false, features = ["std"] }
 humantime = { version = "2.1.0", default-features = false }
 rusb = { version = "0.9.4", default-features = false }
-wasefire-cli-tools = { version = "0.1.0", path = "../cli-tools" }
+wasefire-cli-tools = { version = "0.1.1-git", path = "../cli-tools" }
 wasefire-protocol = { version = "0.1.0", path = "../protocol", features = ["host"] }
 wasefire-protocol-usb = { version = "0.1.0", path = "../protocol-usb", features = ["host"] }
 

--- a/crates/protocol/crates/schema/Cargo.lock
+++ b/crates/protocol/crates/schema/Cargo.lock
@@ -385,7 +385,7 @@ dependencies = [
 
 [[package]]
 name = "wasefire-cli-tools"
-version = "0.1.0"
+version = "0.1.1-git"
 dependencies = [
  "anyhow",
  "cargo_metadata",

--- a/crates/xtask/Cargo.lock
+++ b/crates/xtask/Cargo.lock
@@ -1686,7 +1686,7 @@ dependencies = [
 
 [[package]]
 name = "wasefire-cli-tools"
-version = "0.1.0"
+version = "0.1.1-git"
 dependencies = [
  "anyhow",
  "cargo_metadata",

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -16,7 +16,7 @@ probe-rs = "0.24.0"
 rustc-demangle = "0.1.24"
 serde = { version = "1.0.202", features = ["derive"] }
 stack-sizes = "0.5.0"
-wasefire-cli-tools = { version = "0.1.0", path = "../cli-tools" }
+wasefire-cli-tools = { path = "../cli-tools" }
 
 [lints]
 clippy.unit-arg = "allow"


### PR DESCRIPTION
When using `copy_if_changed()` from 2 different sources `a.src` and `b.src` to `x.dst` in an ABA scenario, it is possible that the modification timestamp of `a.src` is not updated on the last run, and will thus not be copied. We introduce a copy of the source file next to the destination file to fix this issue.