### PR TITLE
Make applet optional in scheduler

### DIFF
--- a/crates/scheduler/CHANGELOG.md
+++ b/crates/scheduler/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Patch
 
+- Make applet optional
 - Update dependencies
 - Fix missing `build.rs` in cargo package
 

--- a/crates/scheduler/src/call/button.rs
+++ b/crates/scheduler/src/call/button.rs
@@ -46,8 +46,7 @@ fn register<B: Board>(mut call: SchedulerCall<B, api::register::Sig>) {
     let inst = call.inst();
     let result = try {
         let button = Id::new(*button as usize)?;
-        call.scheduler()
-            .applet
+        call.applet()
             .enable(Handler {
                 key: Key { button }.into(),
                 inst,

--- a/crates/scheduler/src/call/crypto/ccm.rs
+++ b/crates/scheduler/src/call/crypto/ccm.rs
@@ -45,8 +45,8 @@ fn is_supported<B: Board>(call: SchedulerCall<B, api::is_supported::Sig>) {
 #[cfg(feature = "board-api-crypto-aes128-ccm")]
 fn encrypt<B: Board>(mut call: SchedulerCall<B, api::encrypt::Sig>) {
     let api::encrypt::Params { key, iv, len, clear, cipher } = call.read();
-    let scheduler = call.scheduler();
-    let memory = scheduler.applet.memory();
+    let applet = call.applet();
+    let memory = applet.memory();
     let result = try {
         ensure_support::<B>()?;
         let key = memory.get(*key, 16)?.into();
@@ -63,8 +63,8 @@ fn encrypt<B: Board>(mut call: SchedulerCall<B, api::encrypt::Sig>) {
 #[cfg(feature = "board-api-crypto-aes128-ccm")]
 fn decrypt<B: Board>(mut call: SchedulerCall<B, api::decrypt::Sig>) {
     let api::decrypt::Params { key, iv, len, cipher, clear } = call.read();
-    let scheduler = call.scheduler();
-    let memory = scheduler.applet.memory();
+    let applet = call.applet();
+    let memory = applet.memory();
     let result = try {
         ensure_support::<B>()?;
         let key = memory.get(*key, 16)?.into();

--- a/crates/scheduler/src/call/crypto/ec.rs
+++ b/crates/scheduler/src/call/crypto/ec.rs
@@ -47,8 +47,8 @@ fn is_supported<B: Board>(call: SchedulerCall<B, api::is_supported::Sig>) {
 #[cfg(feature = "internal-board-api-crypto-ecc")]
 fn is_valid_scalar<B: Board>(mut call: SchedulerCall<B, api::is_valid_scalar::Sig>) {
     let api::is_valid_scalar::Params { curve, n } = call.read();
-    let scheduler = call.scheduler();
-    let memory = scheduler.applet.memory();
+    let applet = call.applet();
+    let memory = applet.memory();
     let result = try {
         match convert_curve::<B>(*curve)?? {
             #[cfg(feature = "board-api-crypto-p256")]
@@ -71,8 +71,8 @@ fn is_valid_scalar<B: Board>(mut call: SchedulerCall<B, api::is_valid_scalar::Si
 #[cfg(feature = "internal-board-api-crypto-ecc")]
 fn is_valid_point<B: Board>(mut call: SchedulerCall<B, api::is_valid_point::Sig>) {
     let api::is_valid_point::Params { curve, x, y } = call.read();
-    let scheduler = call.scheduler();
-    let memory = scheduler.applet.memory();
+    let applet = call.applet();
+    let memory = applet.memory();
     let result = try {
         match convert_curve::<B>(*curve)?? {
             #[cfg(feature = "board-api-crypto-p256")]
@@ -97,8 +97,8 @@ fn is_valid_point<B: Board>(mut call: SchedulerCall<B, api::is_valid_point::Sig>
 #[cfg(feature = "internal-board-api-crypto-ecc")]
 fn base_point_mul<B: Board>(mut call: SchedulerCall<B, api::base_point_mul::Sig>) {
     let api::base_point_mul::Params { curve, n, x, y } = call.read();
-    let scheduler = call.scheduler();
-    let memory = scheduler.applet.memory();
+    let applet = call.applet();
+    let memory = applet.memory();
     let result = try {
         match convert_curve::<B>(*curve)?? {
             #[cfg(feature = "board-api-crypto-p256")]
@@ -125,8 +125,8 @@ fn base_point_mul<B: Board>(mut call: SchedulerCall<B, api::base_point_mul::Sig>
 #[cfg(feature = "internal-board-api-crypto-ecc")]
 fn point_mul<B: Board>(mut call: SchedulerCall<B, api::point_mul::Sig>) {
     let api::point_mul::Params { curve, n, in_x, in_y, out_x, out_y } = call.read();
-    let scheduler = call.scheduler();
-    let memory = scheduler.applet.memory();
+    let applet = call.applet();
+    let memory = applet.memory();
     let result = try {
         match convert_curve::<B>(*curve)?? {
             #[cfg(feature = "board-api-crypto-p256")]
@@ -157,8 +157,8 @@ fn point_mul<B: Board>(mut call: SchedulerCall<B, api::point_mul::Sig>) {
 #[cfg(feature = "internal-board-api-crypto-ecc")]
 fn ecdsa_sign<B: Board>(mut call: SchedulerCall<B, api::ecdsa_sign::Sig>) {
     let api::ecdsa_sign::Params { curve, key, message, r, s } = call.read();
-    let scheduler = call.scheduler();
-    let memory = scheduler.applet.memory();
+    let applet = call.applet();
+    let memory = applet.memory();
     let result = try {
         match convert_curve::<B>(*curve)?? {
             #[cfg(feature = "board-api-crypto-p256")]
@@ -187,8 +187,8 @@ fn ecdsa_sign<B: Board>(mut call: SchedulerCall<B, api::ecdsa_sign::Sig>) {
 #[cfg(feature = "internal-board-api-crypto-ecc")]
 fn ecdsa_verify<B: Board>(mut call: SchedulerCall<B, api::ecdsa_verify::Sig>) {
     let api::ecdsa_verify::Params { curve, message, x, y, r, s } = call.read();
-    let scheduler = call.scheduler();
-    let memory = scheduler.applet.memory();
+    let applet = call.applet();
+    let memory = applet.memory();
     let result = try {
         match convert_curve::<B>(*curve)?? {
             #[cfg(feature = "board-api-crypto-p256")]

--- a/crates/scheduler/src/call/crypto/gcm.rs
+++ b/crates/scheduler/src/call/crypto/gcm.rs
@@ -57,8 +57,8 @@ fn tag_length<B: Board>(call: SchedulerCall<B, api::tag_length::Sig>) {
 #[cfg(feature = "board-api-crypto-aes256-gcm")]
 fn encrypt<B: Board>(mut call: SchedulerCall<B, api::encrypt::Sig>) {
     let api::encrypt::Params { key, iv, aad, aad_len, length, clear, cipher, tag } = call.read();
-    let scheduler = call.scheduler();
-    let memory = scheduler.applet.memory();
+    let applet = call.applet();
+    let memory = applet.memory();
     let result = try {
         ensure_support::<B>()?;
         let key = memory.get_array::<32>(*key)?.into();
@@ -76,8 +76,8 @@ fn encrypt<B: Board>(mut call: SchedulerCall<B, api::encrypt::Sig>) {
 #[cfg(feature = "board-api-crypto-aes256-gcm")]
 fn decrypt<B: Board>(mut call: SchedulerCall<B, api::decrypt::Sig>) {
     let api::decrypt::Params { key, iv, aad, aad_len, tag, length, cipher, clear } = call.read();
-    let scheduler = call.scheduler();
-    let memory = scheduler.applet.memory();
+    let applet = call.applet();
+    let memory = applet.memory();
     let result = try {
         ensure_support::<B>()?;
         let key = memory.get_array::<32>(*key)?.into();

--- a/crates/scheduler/src/call/crypto/hash.rs
+++ b/crates/scheduler/src/call/crypto/hash.rs
@@ -65,7 +65,6 @@ fn is_supported<B: Board>(call: SchedulerCall<B, api::is_supported::Sig>) {
 #[cfg(feature = "applet-api-crypto-hash")]
 fn initialize<B: Board>(mut call: SchedulerCall<B, api::initialize::Sig>) {
     let api::initialize::Params { algorithm } = call.read();
-    let scheduler = call.scheduler();
     let result = try {
         let context = match convert_hash_algorithm::<B>(*algorithm)?? {
             #[cfg(feature = "board-api-crypto-sha256")]
@@ -75,7 +74,7 @@ fn initialize<B: Board>(mut call: SchedulerCall<B, api::initialize::Sig>) {
             #[allow(unreachable_patterns)]
             _ => Err(Trap)?,
         };
-        scheduler.applet.hashes.insert(context)? as u32
+        call.applet().hashes.insert(context)? as u32
     };
     call.reply(result);
 }
@@ -83,11 +82,11 @@ fn initialize<B: Board>(mut call: SchedulerCall<B, api::initialize::Sig>) {
 #[cfg(feature = "applet-api-crypto-hash")]
 fn update<B: Board>(mut call: SchedulerCall<B, api::update::Sig>) {
     let api::update::Params { id, data, length } = call.read();
-    let scheduler = call.scheduler();
-    let memory = scheduler.applet.store.memory();
+    let applet = call.applet();
+    let memory = applet.store.memory();
     let result: Result<(), _> = try {
         let data = memory.get(*data, *length)?;
-        match scheduler.applet.hashes.get_mut(*id as usize)? {
+        match applet.hashes.get_mut(*id as usize)? {
             #[cfg(feature = "board-api-crypto-sha256")]
             HashContext::Sha256(context) => context.update(data)?,
             #[cfg(feature = "board-api-crypto-sha384")]
@@ -101,10 +100,10 @@ fn update<B: Board>(mut call: SchedulerCall<B, api::update::Sig>) {
 #[cfg(feature = "applet-api-crypto-hash")]
 fn finalize<B: Board>(mut call: SchedulerCall<B, api::finalize::Sig>) {
     let api::finalize::Params { id, digest } = call.read();
-    let scheduler = call.scheduler();
-    let memory = scheduler.applet.store.memory();
+    let applet = call.applet();
+    let memory = applet.store.memory();
     let result = try {
-        let context = scheduler.applet.hashes.take(*id as usize)?;
+        let context = applet.hashes.take(*id as usize)?;
         match context {
             _ if *digest == 0 => (),
             #[cfg(feature = "board-api-crypto-sha256")]
@@ -132,8 +131,8 @@ fn is_hmac_supported<B: Board>(call: SchedulerCall<B, api::is_hmac_supported::Si
 #[cfg(feature = "applet-api-crypto-hmac")]
 fn hmac_initialize<B: Board>(mut call: SchedulerCall<B, api::hmac_initialize::Sig>) {
     let api::hmac_initialize::Params { algorithm, key, key_len } = call.read();
-    let scheduler = call.scheduler();
-    let memory = scheduler.applet.memory();
+    let applet = call.applet();
+    let memory = applet.memory();
     let result = try {
         let key = memory.get(*key, *key_len)?;
         let context = match convert_hmac_algorithm::<B>(*algorithm)?? {
@@ -144,7 +143,7 @@ fn hmac_initialize<B: Board>(mut call: SchedulerCall<B, api::hmac_initialize::Si
             #[allow(unreachable_patterns)]
             _ => trap_use!(key),
         };
-        scheduler.applet.hashes.insert(context)? as u32
+        applet.hashes.insert(context)? as u32
     };
     call.reply(result);
 }
@@ -152,11 +151,11 @@ fn hmac_initialize<B: Board>(mut call: SchedulerCall<B, api::hmac_initialize::Si
 #[cfg(feature = "applet-api-crypto-hmac")]
 fn hmac_update<B: Board>(mut call: SchedulerCall<B, api::hmac_update::Sig>) {
     let api::hmac_update::Params { id, data, length } = call.read();
-    let scheduler = call.scheduler();
-    let memory = scheduler.applet.store.memory();
+    let applet = call.applet();
+    let memory = applet.store.memory();
     let result: Result<(), _> = try {
         let data = memory.get(*data, *length)?;
-        match scheduler.applet.hashes.get_mut(*id as usize)? {
+        match applet.hashes.get_mut(*id as usize)? {
             #[cfg(feature = "board-api-crypto-hmac-sha256")]
             HashContext::HmacSha256(context) => context.update(data)?,
             #[cfg(feature = "board-api-crypto-hmac-sha384")]
@@ -170,10 +169,10 @@ fn hmac_update<B: Board>(mut call: SchedulerCall<B, api::hmac_update::Sig>) {
 #[cfg(feature = "applet-api-crypto-hmac")]
 fn hmac_finalize<B: Board>(mut call: SchedulerCall<B, api::hmac_finalize::Sig>) {
     let api::hmac_finalize::Params { id, hmac } = call.read();
-    let scheduler = call.scheduler();
-    let memory = scheduler.applet.store.memory();
+    let applet = call.applet();
+    let memory = applet.store.memory();
     let result = try {
-        let context = scheduler.applet.hashes.take(*id as usize)?;
+        let context = applet.hashes.take(*id as usize)?;
         match context {
             _ if *hmac == 0 => (),
             #[cfg(feature = "board-api-crypto-hmac-sha256")]
@@ -202,8 +201,8 @@ fn is_hkdf_supported<B: Board>(call: SchedulerCall<B, api::is_hkdf_supported::Si
 fn hkdf_expand<B: Board>(mut call: SchedulerCall<B, api::hkdf_expand::Sig>) {
     let api::hkdf_expand::Params { algorithm, prk, prk_len, info, info_len, okm, okm_len } =
         call.read();
-    let scheduler = call.scheduler();
-    let memory = scheduler.applet.memory();
+    let applet = call.applet();
+    let memory = applet.memory();
     let result: Result<(), _> = try {
         let prk = memory.get(*prk, *prk_len)?;
         let info = memory.get(*info, *info_len)?;

--- a/crates/scheduler/src/call/platform.rs
+++ b/crates/scheduler/src/call/platform.rs
@@ -25,7 +25,7 @@ use wasefire_board_api::Api as Board;
 use crate::applet::store::MemoryApi;
 use crate::DispatchSchedulerCall;
 #[cfg(feature = "board-api-platform")]
-use crate::{Failure, Scheduler, SchedulerCall};
+use crate::{Applet, Failure, SchedulerCall};
 
 #[cfg(feature = "applet-api-platform-protocol")]
 mod protocol;
@@ -50,14 +50,14 @@ pub fn process<B: Board>(call: Api<DispatchSchedulerCall<B>>) {
 #[cfg(feature = "board-api-platform")]
 fn serial<B: Board>(mut call: SchedulerCall<B, api::serial::Sig>) {
     let api::serial::Params { ptr } = call.read();
-    let result = alloc_bytes(call.scheduler(), *ptr, &board::Platform::<B>::serial());
+    let result = alloc_bytes(call.applet(), *ptr, &board::Platform::<B>::serial());
     call.reply(result);
 }
 
 #[cfg(feature = "board-api-platform")]
 fn version<B: Board>(mut call: SchedulerCall<B, api::version::Sig>) {
     let api::version::Params { ptr } = call.read();
-    let result = alloc_bytes(call.scheduler(), *ptr, &board::Platform::<B>::version());
+    let result = alloc_bytes(call.applet(), *ptr, &board::Platform::<B>::version());
     call.reply(result);
 }
 
@@ -69,12 +69,12 @@ fn reboot<B: Board>(call: SchedulerCall<B, api::reboot::Sig>) {
 
 #[cfg(feature = "board-api-platform")]
 fn alloc_bytes<B: Board>(
-    scheduler: &mut Scheduler<B>, ptr_ptr: u32, data: &[u8],
+    applet: &mut Applet<B>, ptr_ptr: u32, data: &[u8],
 ) -> Result<u32, Failure> {
     if data.is_empty() {
         return Ok(0);
     }
-    let mut memory = scheduler.applet.memory();
+    let mut memory = applet.memory();
     memory.alloc_copy(ptr_ptr, None, data)?;
     Ok(data.len() as u32)
 }

--- a/crates/scheduler/src/call/platform/update.rs
+++ b/crates/scheduler/src/call/platform/update.rs
@@ -47,8 +47,8 @@ fn is_supported<B: Board>(call: SchedulerCall<B, api::is_supported::Sig>) {
 #[cfg(feature = "board-api-platform-update")]
 fn metadata<B: Board>(mut call: SchedulerCall<B, api::metadata::Sig>) {
     let api::metadata::Params { ptr: ptr_ptr, len: len_ptr } = call.read();
-    let scheduler = call.scheduler();
-    let mut memory = scheduler.applet.memory();
+    let applet = call.applet();
+    let mut memory = applet.memory();
     let result = try {
         let metadata = board::platform::Update::<B>::metadata()?;
         memory.alloc_copy(*ptr_ptr, Some(*len_ptr), &metadata)?;
@@ -73,8 +73,8 @@ fn initialize<B: Board>(call: SchedulerCall<B, api::initialize::Sig>) {
 #[cfg(feature = "board-api-platform-update")]
 fn process_<B: Board>(mut call: SchedulerCall<B, api::process::Sig>) {
     let api::process::Params { ptr, len } = call.read();
-    let scheduler = call.scheduler();
-    let memory = scheduler.applet.memory();
+    let applet = call.applet();
+    let memory = applet.memory();
     let result = try {
         let chunk = memory.get(*ptr, *len)?;
         board::platform::Update::<B>::process(chunk)?

--- a/crates/scheduler/src/call/rng.rs
+++ b/crates/scheduler/src/call/rng.rs
@@ -36,8 +36,8 @@ pub fn process<B: Board>(call: Api<DispatchSchedulerCall<B>>) {
 #[cfg(feature = "board-api-rng")]
 fn fill_bytes<B: Board>(mut call: SchedulerCall<B, api::fill_bytes::Sig>) {
     let api::fill_bytes::Params { ptr, len } = call.read();
-    let scheduler = call.scheduler();
-    let memory = scheduler.applet.memory();
+    let applet = call.applet();
+    let memory = applet.memory();
     let result = try {
         let output = memory.get_mut(*ptr, *len)?;
         board::Rng::<B>::fill_bytes(output)?

--- a/crates/scheduler/src/call/store.rs
+++ b/crates/scheduler/src/call/store.rs
@@ -54,7 +54,7 @@ pub fn process<B: Board>(call: Api<DispatchSchedulerCall<B>>) {
 fn insert<B: Board>(mut call: SchedulerCall<B, api::insert::Sig>) {
     let api::insert::Params { key, ptr, len } = call.read();
     let scheduler = call.scheduler();
-    let memory = scheduler.applet.memory();
+    let memory = scheduler.applet.as_mut().unwrap().memory();
     let result = try {
         let value = memory.get(*ptr, *len)?;
         scheduler.store.insert(*key as usize, value).map_err(convert)?
@@ -73,7 +73,7 @@ fn remove<B: Board>(mut call: SchedulerCall<B, api::remove::Sig>) {
 fn find<B: Board>(mut call: SchedulerCall<B, api::find::Sig>) {
     let api::find::Params { key, ptr: ptr_ptr, len: len_ptr } = call.read();
     let scheduler = call.scheduler();
-    let mut memory = scheduler.applet.memory();
+    let mut memory = scheduler.applet.as_mut().unwrap().memory();
     let result = try {
         match scheduler.store.find(*key as usize).map_err(convert)? {
             None => false,
@@ -90,7 +90,7 @@ fn find<B: Board>(mut call: SchedulerCall<B, api::find::Sig>) {
 fn keys<B: Board>(mut call: SchedulerCall<B, api::keys::Sig>) {
     let api::keys::Params { ptr: ptr_ptr } = call.read();
     let scheduler = call.scheduler();
-    let mut memory = scheduler.applet.memory();
+    let mut memory = scheduler.applet.as_mut().unwrap().memory();
     let result = try {
         let mut keys = Vec::new();
         for handle in scheduler.store.iter().map_err(convert)? {
@@ -113,8 +113,7 @@ fn keys<B: Board>(mut call: SchedulerCall<B, api::keys::Sig>) {
 #[cfg(feature = "board-api-storage")]
 fn clear<B: Board>(mut call: SchedulerCall<B, api::clear::Sig>) {
     let api::clear::Params {} = call.read();
-    let scheduler = call.scheduler();
-    let result = try { scheduler.store.clear(0).map_err(convert)? };
+    let result = try { call.scheduler().store.clear(0).map_err(convert)? };
     call.reply(result);
 }
 

--- a/crates/scheduler/src/call/store/fragment.rs
+++ b/crates/scheduler/src/call/store/fragment.rs
@@ -39,7 +39,7 @@ pub fn process<B: Board>(call: Api<DispatchSchedulerCall<B>>) {
 fn insert<B: Board>(mut call: SchedulerCall<B, api::insert::Sig>) {
     let api::insert::Params { keys, ptr, len } = call.read();
     let scheduler = call.scheduler();
-    let memory = scheduler.applet.memory();
+    let memory = scheduler.applet.as_mut().unwrap().memory();
     let result = try {
         let keys = decode_keys(keys)?;
         let value = memory.get(*ptr, *len)?;
@@ -61,7 +61,7 @@ fn remove<B: Board>(mut call: SchedulerCall<B, api::remove::Sig>) {
 fn find<B: Board>(mut call: SchedulerCall<B, api::find::Sig>) {
     let api::find::Params { keys, ptr: ptr_ptr, len: len_ptr } = call.read();
     let scheduler = call.scheduler();
-    let mut memory = scheduler.applet.memory();
+    let mut memory = scheduler.applet.as_mut().unwrap().memory();
     let result = try {
         match fragment::read(&scheduler.store, &decode_keys(keys)?).map_err(convert)? {
             None => false,

--- a/crates/scheduler/src/call/timer.rs
+++ b/crates/scheduler/src/call/timer.rs
@@ -50,7 +50,7 @@ fn allocate<B: Board>(mut call: SchedulerCall<B, api::allocate::Sig>) {
         let timers = &mut call.scheduler().timers;
         let timer = timers.iter().position(|x| x.is_none()).ok_or(Trap)?;
         timers[timer] = Some(Timer {});
-        call.scheduler().applet.enable(Handler {
+        call.applet().enable(Handler {
             key: Key { timer: Id::new(timer).unwrap() }.into(),
             inst,
             func: *handler_func,

--- a/crates/scheduler/src/call/uart.rs
+++ b/crates/scheduler/src/call/uart.rs
@@ -82,8 +82,8 @@ fn stop<B: Board>(call: SchedulerCall<B, api::stop::Sig>) {
 #[cfg(feature = "board-api-uart")]
 fn read<B: Board>(mut call: SchedulerCall<B, api::read::Sig>) {
     let api::read::Params { uart, ptr, len } = call.read();
-    let scheduler = call.scheduler();
-    let memory = scheduler.applet.memory();
+    let applet = call.applet();
+    let memory = applet.memory();
     let result = try {
         let uart = Id::new(*uart as usize).map_err(|_| Trap)?;
         let output = memory.get_mut(*ptr, *len)?;
@@ -95,8 +95,8 @@ fn read<B: Board>(mut call: SchedulerCall<B, api::read::Sig>) {
 #[cfg(feature = "board-api-uart")]
 fn write<B: Board>(mut call: SchedulerCall<B, api::write::Sig>) {
     let api::write::Params { uart, ptr, len } = call.read();
-    let scheduler = call.scheduler();
-    let memory = scheduler.applet.memory();
+    let applet = call.applet();
+    let memory = applet.memory();
     let result = try {
         let uart = Id::new(*uart as usize).map_err(|_| Trap)?;
         let input = memory.get(*ptr, *len)?;
@@ -109,11 +109,11 @@ fn write<B: Board>(mut call: SchedulerCall<B, api::write::Sig>) {
 fn register<B: Board>(mut call: SchedulerCall<B, api::register::Sig>) {
     let api::register::Params { uart, event, handler_func, handler_data } = call.read();
     let inst = call.inst();
-    let scheduler = call.scheduler();
+    let applet = call.applet();
     let result = try {
         let uart = Id::new(*uart as usize).map_err(|_| Trap)?;
         let event = convert_event(uart, *event)?;
-        scheduler.applet.enable(Handler {
+        applet.enable(Handler {
             key: Key::from(&event).into(),
             inst,
             func: *handler_func,
@@ -127,12 +127,11 @@ fn register<B: Board>(mut call: SchedulerCall<B, api::register::Sig>) {
 #[cfg(feature = "board-api-uart")]
 fn unregister<B: Board>(mut call: SchedulerCall<B, api::unregister::Sig>) {
     let api::unregister::Params { uart, event } = call.read();
-    let scheduler = call.scheduler();
     let result = try {
         let uart = Id::new(*uart as usize).map_err(|_| Trap)?;
         let event = convert_event(uart, *event)?;
         board::Uart::<B>::disable(uart, event.direction).map_err(|_| Trap)?;
-        scheduler.disable_event(Key::from(&event).into())?;
+        call.scheduler().disable_event(Key::from(&event).into())?;
     };
     call.reply(result);
 }

--- a/crates/scheduler/src/call/usb/serial.rs
+++ b/crates/scheduler/src/call/usb/serial.rs
@@ -42,8 +42,8 @@ pub fn process<B: Board>(call: Api<DispatchSchedulerCall<B>>) {
 #[cfg(feature = "board-api-usb-serial")]
 fn read<B: Board>(mut call: SchedulerCall<B, api::read::Sig>) {
     let api::read::Params { ptr, len } = call.read();
-    let scheduler = call.scheduler();
-    let memory = scheduler.applet.memory();
+    let applet = call.applet();
+    let memory = applet.memory();
     let result = try {
         let output = memory.get_mut(*ptr, *len)?;
         board::usb::Serial::<B>::read(output)? as u32
@@ -54,8 +54,8 @@ fn read<B: Board>(mut call: SchedulerCall<B, api::read::Sig>) {
 #[cfg(feature = "board-api-usb-serial")]
 fn write<B: Board>(mut call: SchedulerCall<B, api::write::Sig>) {
     let api::write::Params { ptr, len } = call.read();
-    let scheduler = call.scheduler();
-    let memory = scheduler.applet.memory();
+    let applet = call.applet();
+    let memory = applet.memory();
     let result = try {
         let input = memory.get(*ptr, *len)?;
         board::usb::Serial::<B>::write(input)? as u32
@@ -67,10 +67,10 @@ fn write<B: Board>(mut call: SchedulerCall<B, api::write::Sig>) {
 fn register<B: Board>(mut call: SchedulerCall<B, api::register::Sig>) {
     let api::register::Params { event, handler_func, handler_data } = call.read();
     let inst = call.inst();
-    let scheduler = call.scheduler();
+    let applet = call.applet();
     let result = try {
         let event = convert_event(*event)?;
-        scheduler.applet.enable(Handler {
+        applet.enable(Handler {
             key: Key::from(&event).into(),
             inst,
             func: *handler_func,
@@ -84,11 +84,10 @@ fn register<B: Board>(mut call: SchedulerCall<B, api::register::Sig>) {
 #[cfg(feature = "board-api-usb-serial")]
 fn unregister<B: Board>(mut call: SchedulerCall<B, api::unregister::Sig>) {
     let api::unregister::Params { event } = call.read();
-    let scheduler = call.scheduler();
     let result = try {
         let event = convert_event(*event)?;
         board::usb::Serial::<B>::disable(&event).map_err(|_| Trap)?;
-        scheduler.disable_event(Key::from(&event).into())?;
+        call.scheduler().disable_event(Key::from(&event).into())?;
     };
     call.reply(result);
 }

--- a/crates/scheduler/src/lib.rs
+++ b/crates/scheduler/src/lib.rs
@@ -92,7 +92,7 @@ pub struct Scheduler<B: Board> {
     #[cfg(feature = "board-api-storage")]
     store: store::Store<B::Storage>,
     host_funcs: Vec<Api<Id>>,
-    applet: Applet<B>,
+    applet: Option<Applet<B>>,
     #[cfg(feature = "board-api-timer")]
     timers: Vec<Option<Timer>>,
     #[cfg(feature = "internal-debug")]
@@ -211,7 +211,7 @@ impl<'a, B: Board, T: Signature> SchedulerCall<'a, B, T> {
     }
 
     fn applet(&mut self) -> &mut Applet<B> {
-        &mut self.erased.scheduler.applet
+        self.erased.scheduler.applet.as_mut().unwrap()
     }
 
     fn store(&mut self) -> &mut Store {
@@ -239,6 +239,7 @@ impl<B: Board> Scheduler<B> {
     #[cfg(feature = "native")]
     pub fn run() -> ! {
         native::set_scheduler(Self::new());
+        native::with_scheduler(|x| x.new_applet());
         extern "C" {
             fn applet_init();
             fn applet_main();
@@ -287,26 +288,13 @@ impl<B: Board> Scheduler<B> {
         Api::<Id>::iter(&mut host_funcs, |x| x);
         host_funcs.sort_by_key(|x| x.descriptor().name);
         assert!(host_funcs.windows(2).all(|x| x[0].descriptor().name != x[1].descriptor().name));
-        #[cfg(feature = "wasm")]
-        let applet = {
-            let mut applet = Applet::default();
-            let store = applet.store_mut();
-            for f in &host_funcs {
-                let d = f.descriptor();
-                store.link_func("env", d.name, d.params, 1).unwrap();
-            }
-            store.link_func_default("env").unwrap();
-            applet
-        };
         #[cfg(feature = "board-api-platform-protocol")]
         protocol::enable::<B>();
-        #[cfg(feature = "native")]
-        let applet = Applet::default();
         Self {
             #[cfg(feature = "board-api-storage")]
             store: store::Store::new(board::Storage::<B>::take().unwrap()).ok().unwrap(),
             host_funcs,
-            applet,
+            applet: None,
             #[cfg(feature = "board-api-timer")]
             timers: alloc::vec![None; board::Timer::<B>::SUPPORT],
             #[cfg(feature = "internal-debug")]
@@ -316,31 +304,44 @@ impl<B: Board> Scheduler<B> {
         }
     }
 
+    fn new_applet(&mut self) {
+        assert!(self.applet.is_none());
+        self.applet = Some(Applet::default());
+    }
+
     #[cfg(feature = "wasm")]
     fn load(&mut self, wasm: &'static [u8]) {
         const MEMORY_SIZE: usize = memory_size();
         #[repr(align(16))]
         struct Memory([u8; MEMORY_SIZE]);
         static mut MEMORY: Memory = Memory([0; MEMORY_SIZE]);
+
         #[cfg(not(feature = "unsafe-skip-validation"))]
         let module = Module::new(wasm).unwrap();
         // SAFETY: The module is valid by the feature invariant.
         #[cfg(feature = "unsafe-skip-validation")]
         let module = unsafe { Module::new_unchecked(wasm) };
-        let store = self.applet.store_mut();
+        self.new_applet();
+        let applet = self.applet.as_mut().unwrap();
+        let store = applet.store_mut();
+        for f in &self.host_funcs {
+            let d = f.descriptor();
+            store.link_func("env", d.name, d.params, 1).unwrap();
+        }
+        store.link_func_default("env").unwrap();
         // SAFETY: This function is called once in `run()`.
         let inst = store.instantiate(module, unsafe { &mut MEMORY.0 }).unwrap();
         #[cfg(feature = "internal-debug")]
         self.perf.record(perf::Slot::Platform);
         self.call(inst, "init", &[]);
-        while let Some(call) = self.applet.store_mut().last_call() {
+        while let Some(call) = self.applet.as_mut().unwrap().store_mut().last_call() {
             match self.host_funcs[call.index()].descriptor().name {
                 "dp" => (),
                 x => log::panic!("init called {} into host", log::Debug2Format(&x)),
             }
             self.process_applet();
         }
-        assert!(matches!(self.applet.pop(), EventAction::Reply));
+        assert!(matches!(self.applet.as_mut().unwrap().pop(), EventAction::Reply));
         #[cfg(feature = "internal-debug")]
         self.perf.record(perf::Slot::Applets);
         self.call(inst, "main", &[]);
@@ -355,16 +356,18 @@ impl<B: Board> Scheduler<B> {
     fn triage_event(&mut self, event: board::Event<B>) {
         #[cfg(feature = "board-api-platform-protocol")]
         if protocol::should_process_event(&event) {
-            protocol::process_event(self, event);
-            return;
+            return protocol::process_event(self, event);
         }
-        self.applet.push(event);
+        match &mut self.applet {
+            None => log::warn!("{} matches no applet", log::Debug2Format(&event)),
+            Some(applet) => applet.push(event),
+        }
     }
 
     /// Returns whether execution should resume.
     fn process_event(&mut self) -> bool {
         let event = loop {
-            match self.applet.pop() {
+            match self.applet.as_mut().map_or(EventAction::Wait, |x| x.pop()) {
                 EventAction::Handle(event) => break event,
                 EventAction::Wait => {
                     #[cfg(feature = "internal-debug")]
@@ -384,7 +387,11 @@ impl<B: Board> Scheduler<B> {
 
     #[cfg(feature = "wasm")]
     fn process_applet(&mut self) {
-        let call = match self.applet.store_mut().last_call() {
+        let applet = match &mut self.applet {
+            Some(x) => x,
+            None => return,
+        };
+        let call = match applet.store_mut().last_call() {
             Some(x) => x,
             None => {
                 self.process_event();
@@ -411,7 +418,9 @@ impl<B: Board> Scheduler<B> {
 
     #[allow(dead_code)] // in case there are no events
     fn disable_event(&mut self, key: Key<B>) -> Result<(), Trap> {
-        self.applet.disable(key)?;
+        if let Some(applet) = &mut self.applet {
+            applet.disable(key)?;
+        }
         self.flush_events();
         Ok(())
     }
@@ -422,7 +431,8 @@ impl<B: Board> Scheduler<B> {
         let args = args.iter().map(|&x| Val::I32(x)).collect();
         #[cfg(feature = "internal-debug")]
         self.perf.record(perf::Slot::Platform);
-        let answer = self.applet.store_mut().invoke(inst, name, args).map(|x| x.forget());
+        let applet = self.applet.as_mut().unwrap();
+        let answer = applet.store_mut().invoke(inst, name, args).map(|x| x.forget());
         #[cfg(feature = "internal-debug")]
         self.perf.record(perf::Slot::Applets);
         self.process_answer(answer);
@@ -434,7 +444,7 @@ impl<B: Board> Scheduler<B> {
             Ok(RunAnswer::Done(x)) => {
                 log::debug!("Thread is done.");
                 debug_assert!(x.is_empty());
-                self.applet.done();
+                self.applet.as_mut().unwrap().done();
             }
             Ok(RunAnswer::Host) => (),
             Err(interpreter::Error::Trap) => applet_trapped::<B>(None),

--- a/crates/scheduler/src/native.rs
+++ b/crates/scheduler/src/native.rs
@@ -24,6 +24,7 @@ use crate::perf::Slot;
 use crate::Scheduler;
 
 pub(crate) trait ErasedScheduler: Send {
+    fn new_applet(&mut self);
     fn dispatch(&mut self, link: &CStr, params: *const u32) -> isize;
     fn flush_events(&mut self);
     fn process_event(&mut self);
@@ -32,6 +33,10 @@ pub(crate) trait ErasedScheduler: Send {
 }
 
 impl<B: Board> ErasedScheduler for Scheduler<B> {
+    fn new_applet(&mut self) {
+        self.new_applet();
+    }
+
     fn dispatch(&mut self, link: &CStr, params: *const u32) -> isize {
         self.dispatch(link, params)
     }


### PR DESCRIPTION
This is a first step towards dynamic loading and unloading of applets. For now, at most one applet may be loaded at a time.