### PR TITLE
Add contiguous access to Nordic flash

### DIFF
--- a/crates/runner-nordic/src/main.rs
+++ b/crates/runner-nordic/src/main.rs
@@ -15,6 +15,8 @@
 #![no_std]
 #![no_main]
 #![feature(never_type)]
+#![feature(ptr_metadata)]
+#![feature(slice_ptr_get)]
 #![feature(try_blocks)]
 
 extern crate alloc;

--- a/crates/runner-nordic/src/main.rs
+++ b/crates/runner-nordic/src/main.rs
@@ -16,7 +16,6 @@
 #![no_main]
 #![feature(never_type)]
 #![feature(ptr_metadata)]
-#![feature(slice_ptr_get)]
 #![feature(try_blocks)]
 
 extern crate alloc;


### PR DESCRIPTION
This follows #562 towards dynamic loading and unloading of applets. The applet will be stored in a contiguous part of the flash.