### PR TITLE
Implement From<interpreter::Error> for wasefire_error::Error

### DIFF
--- a/crates/interpreter/CHANGELOG.md
+++ b/crates/interpreter/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.3.1-git
+
+### Major
+
+- Implement `From<Error>` for `wasefire_error::Error`
+
 ## 0.3.0
 
 ### Major

--- a/crates/interpreter/CHANGELOG.md
+++ b/crates/interpreter/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.3.1-git
 
-### Major
+### Minor
 
 - Implement `From<Error>` for `wasefire_error::Error`
 

--- a/crates/interpreter/Cargo.lock
+++ b/crates/interpreter/Cargo.lock
@@ -112,8 +112,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68f5e5f3158ecfd4b8ff6fe086db7c8467a2dfdac97fe420f2b7c4aa97af66d6"
 
 [[package]]
+name = "wasefire-error"
+version = "0.1.2-git"
+dependencies = [
+ "num_enum",
+]
+
+[[package]]
 name = "wasefire-interpreter"
-version = "0.3.0"
+version = "0.3.1-git"
 dependencies = [
  "lazy_static",
  "libm",
@@ -121,6 +128,7 @@ dependencies = [
  "num_enum",
  "paste",
  "portable-atomic",
+ "wasefire-error",
  "wast",
 ]
 

--- a/crates/interpreter/Cargo.toml
+++ b/crates/interpreter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasefire-interpreter"
-version = "0.3.0"
+version = "0.3.1-git"
 authors = ["Julien Cretin <cretin@google.com>"]
 license = "Apache-2.0"
 publish = true
@@ -17,6 +17,7 @@ lru = { version = "0.12.3", default-features = false, optional = true }
 num_enum = { version = "0.7.2", default-features = false }
 paste = { version = "1.0.15", default-features = false }
 portable-atomic = { version = "1.6.0", default-features = false }
+wasefire-error = { version = "0.1.2-git", path = "../error" }
 
 [dev-dependencies]
 lazy_static = "1.4.0"

--- a/crates/interpreter/src/error.rs
+++ b/crates/interpreter/src/error.rs
@@ -29,6 +29,20 @@ pub enum Error {
     Trap,
 }
 
+pub const TRAP_CODE: u16 = 0xffff;
+
+impl From<Error> for wasefire_error::Error {
+    fn from(value: Error) -> Self {
+        use wasefire_error::{Code, Error as WError};
+        match value {
+            Error::Invalid => WError::user(Code::InvalidArgument),
+            Error::NotFound => WError::user(Code::NotFound),
+            Error::Unsupported(_) => WError::internal(Code::NotImplemented),
+            Error::Trap => WError::user(TRAP_CODE),
+        }
+    }
+}
+
 #[cfg(not(feature = "debug"))]
 pub type Unsupported = ();
 

--- a/crates/interpreter/src/lib.rs
+++ b/crates/interpreter/src/lib.rs
@@ -149,7 +149,7 @@ mod syntax;
 mod toctou;
 mod valid;
 
-pub use error::{Error, Unsupported};
+pub use error::{Error, Unsupported, TRAP_CODE};
 pub use exec::{Call, InstId, RunAnswer, RunResult, Store, StoreId, Val, MEMORY_ALIGN};
 pub use module::Module;
 pub use syntax::{

--- a/crates/runner-host/Cargo.lock
+++ b/crates/runner-host/Cargo.lock
@@ -1953,11 +1953,12 @@ dependencies = [
 
 [[package]]
 name = "wasefire-interpreter"
-version = "0.3.0"
+version = "0.3.1-git"
 dependencies = [
  "num_enum",
  "paste",
  "portable-atomic",
+ "wasefire-error",
 ]
 
 [[package]]

--- a/crates/runner-nordic/Cargo.lock
+++ b/crates/runner-nordic/Cargo.lock
@@ -1159,11 +1159,12 @@ dependencies = [
 
 [[package]]
 name = "wasefire-interpreter"
-version = "0.3.0"
+version = "0.3.1-git"
 dependencies = [
  "num_enum",
  "paste",
  "portable-atomic",
+ "wasefire-error",
 ]
 
 [[package]]

--- a/crates/runner-nordic/src/board/uart.rs
+++ b/crates/runner-nordic/src/board/uart.rs
@@ -258,7 +258,7 @@ impl Api for Impl {
         if EASY_DMA_SIZE < input.len() || !in_ram(input) {
             return Err(Error::user(Code::InvalidArgument));
         }
-        with_state(|state| {
+        with_state::<Result<_, Error>>(|state| {
             let Uart { regs, state } = state.uarts.get(uart);
             Error::user(Code::InvalidState).check(state.running)?;
             regs.txd.ptr.write(|w| unsafe { w.ptr().bits(input.as_ptr() as u32) });

--- a/crates/scheduler/CHANGELOG.md
+++ b/crates/scheduler/CHANGELOG.md
@@ -150,4 +150,4 @@
 
 ## 0.1.0
 
-<!-- Increment to skip CHANGELOG.md test: 3 -->
+<!-- Increment to skip CHANGELOG.md test: 4 -->

--- a/crates/scheduler/Cargo.lock
+++ b/crates/scheduler/Cargo.lock
@@ -781,11 +781,12 @@ dependencies = [
 
 [[package]]
 name = "wasefire-interpreter"
-version = "0.3.0"
+version = "0.3.1-git"
 dependencies = [
  "num_enum",
  "paste",
  "portable-atomic",
+ "wasefire-error",
 ]
 
 [[package]]

--- a/crates/scheduler/Cargo.toml
+++ b/crates/scheduler/Cargo.toml
@@ -30,7 +30,7 @@ wasefire-store = { version = "0.3.0-git", path = "../store", optional = true }
 wasefire-sync = { version = "0.1.1", path = "../sync", optional = true }
 
 [dependencies.wasefire-interpreter]
-version = "0.3.0"
+version = "0.3.1-git"
 path = "../interpreter"
 features = ["toctou"]
 optional = true

--- a/crates/wasm-bench/Cargo.lock
+++ b/crates/wasm-bench/Cargo.lock
@@ -1265,13 +1265,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasefire-error"
+version = "0.1.2-git"
+dependencies = [
+ "num_enum",
+]
+
+[[package]]
 name = "wasefire-interpreter"
-version = "0.3.0"
+version = "0.3.1-git"
 dependencies = [
  "libm",
  "num_enum",
  "paste",
  "portable-atomic",
+ "wasefire-error",
 ]
 
 [[package]]


### PR DESCRIPTION
Part of #577 because starting an applet (dynamically) should not crash the platform in case of errors but instead propagate the error to the host.