### PR TITLE
Add "xtask changelog ci" to validate CHANGELOG.md files

### DIFF
--- a/crates/api-macro/CHANGELOG.md
+++ b/crates/api-macro/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.6.2-git
 
-## Patch
+### Patch
 
 - Update dependencies
 

--- a/crates/cli-tools/src/fs.rs
+++ b/crates/cli-tools/src/fs.rs
@@ -117,8 +117,8 @@ pub fn read(path: impl AsRef<Path>) -> Result<Vec<u8>> {
 
 pub fn read_dir(path: impl AsRef<Path>) -> Result<ReadDir> {
     let dir = path.as_ref().display();
-    debug!("read_dir < {dir:?}");
-    std::fs::read_dir(path.as_ref()).with_context(|| format!("reading directory {dir}"))
+    debug!("walk < {dir:?}");
+    std::fs::read_dir(path.as_ref()).with_context(|| format!("walking {dir}"))
 }
 
 pub fn read_toml<T: DeserializeOwned>(path: impl AsRef<Path>) -> Result<T> {

--- a/crates/cli-tools/src/fs.rs
+++ b/crates/cli-tools/src/fs.rs
@@ -14,7 +14,7 @@
 
 //! Wrappers around `std::fs` with descriptive errors.
 
-use std::fs::Metadata;
+use std::fs::{Metadata, ReadDir};
 use std::io::{ErrorKind, Read, Write};
 use std::path::{Component, Path, PathBuf};
 
@@ -113,6 +113,12 @@ pub fn read(path: impl AsRef<Path>) -> Result<Vec<u8>> {
     let name = path.as_ref().display();
     debug!("read < {name:?}");
     std::fs::read(path.as_ref()).with_context(|| format!("reading {name}"))
+}
+
+pub fn read_dir(path: impl AsRef<Path>) -> Result<ReadDir> {
+    let dir = path.as_ref().display();
+    debug!("read_dir < {dir:?}");
+    std::fs::read_dir(path.as_ref()).with_context(|| format!("reading directory {dir}"))
 }
 
 pub fn read_toml<T: DeserializeOwned>(path: impl AsRef<Path>) -> Result<T> {

--- a/crates/cli-tools/src/fs.rs
+++ b/crates/cli-tools/src/fs.rs
@@ -117,7 +117,7 @@ pub fn read(path: impl AsRef<Path>) -> Result<Vec<u8>> {
 
 pub fn read_dir(path: impl AsRef<Path>) -> Result<ReadDir> {
     let dir = path.as_ref().display();
-    debug!("walk < {dir:?}");
+    debug!("walk {dir:?}");
     std::fs::read_dir(path.as_ref()).with_context(|| format!("walking {dir}"))
 }
 

--- a/crates/xtask/Cargo.lock
+++ b/crates/xtask/Cargo.lock
@@ -1959,6 +1959,7 @@ dependencies = [
  "log",
  "probe-rs",
  "rustc-demangle",
+ "semver",
  "serde",
  "stack-sizes",
  "wasefire-cli-tools",

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -14,6 +14,7 @@ lazy_static = "1.4.0"
 log = "0.4.21"
 probe-rs = "0.24.0"
 rustc-demangle = "0.1.24"
+semver = "1.0.23"
 serde = { version = "1.0.202", features = ["derive"] }
 stack-sizes = "0.5.0"
 wasefire-cli-tools = { path = "../cli-tools" }

--- a/crates/xtask/src/changelog.rs
+++ b/crates/xtask/src/changelog.rs
@@ -44,7 +44,7 @@ struct Changelog {
 
 impl Changelog {
     fn read_file(path: &str) -> Result<Changelog> {
-        Self::parse(String::from_utf8(fs::read(&path)?)?.as_str())
+        Self::parse(String::from_utf8(fs::read(path)?)?.as_str())
     }
 
     /// Converts raw file contents into a Changelog data structure.
@@ -171,7 +171,7 @@ impl Release {
     }
 }
 
-/// Validates CHANGELOG.md files for all Wasefire crates.
+/// Validates all changelog files.
 pub fn execute_ci() -> Result<()> {
     let paths = cmd::output(Command::new("git").args(["ls-files", "*/CHANGELOG.md"]))?;
 
@@ -186,13 +186,11 @@ pub fn execute_ci() -> Result<()> {
     Ok(())
 }
 
-/// Updates a CHANGELOG.md file and CHANGELOG.md files of dependencies.
-pub fn execute_change(
-    crate_path: &str, _release_type: &ReleaseType, _description: &str,
-) -> Result<()> {
-    ensure!(fs::exists(crate_path), "Crate does not exist: {}", crate_path);
+/// Updates the changelog of a crate and its dependents.
+pub fn execute_change(path: &str, _scope: &ReleaseType, _description: &str) -> Result<()> {
+    ensure!(fs::exists(path), "Crate does not exist: {path}");
 
-    let _changelog = Changelog::read_file(format!("{crate_path}/CHANGELOG.md").as_str())?;
+    let _changelog = Changelog::read_file(format!("{path}/CHANGELOG.md").as_str())?;
 
     todo!("Implement changelog updates");
 }

--- a/crates/xtask/src/changelog.rs
+++ b/crates/xtask/src/changelog.rs
@@ -1,0 +1,332 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use anyhow::{ensure, Result};
+use clap::ValueEnum;
+use semver::Version;
+
+#[derive(Debug, Clone, clap::ValueEnum)]
+pub enum ReleaseType {
+    Major,
+    Minor,
+    Patch,
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+struct Changelog {
+    releases: Vec<Release>,
+
+    /// Incremented to acknowledge the changelog is already up-to-date.
+    ///
+    /// There is a CI test to make sure the changelog is updated when the crate is modified. Some
+    /// modifications are already documented in the changelog, so the test will have a false
+    /// positive. This counter is used to artificially modify the changelog and explicitly
+    /// acknowledge that it's already up-to-date.
+    skip_counter: Option<u32>,
+}
+
+impl Changelog {
+    fn read_file(crate_path: &str) -> Result<Changelog> {
+        let changelog_path = format!("{crate_path}/CHANGELOG.md");
+
+        let changelog_contents = wasefire_cli_tools::fs::read(&changelog_path)?;
+
+        Self::parse(String::from_utf8(changelog_contents)?)
+    }
+
+    /// Converts raw file contents into a Changelog data structure.
+    fn parse(contents: String) -> Result<Changelog> {
+        let mut skip_counter = None;
+        let mut releases = Vec::new();
+
+        // Trim off the trailing comment: <!-- Increment to skip ... -->
+        let contents: Vec<&str> =
+            contents.split("\n\n<!-- Increment to skip CHANGELOG.md test:").collect();
+
+        // Populate skip_counter if we have one.
+        if contents.len() > 1 {
+            let ending = contents[1]
+                .trim()
+                .strip_suffix("-->")
+                .expect("Malformed 'Increment to skip CHANGELOG.md test'")
+                .trim();
+
+            skip_counter = ending.parse::<u32>().ok();
+        }
+
+        let contents = contents[0];
+
+        // Split by release.
+        // Skip(1) to skip the prefix.
+        for each_release in contents.split("\n## ").skip(1) {
+            let mut version_iter = each_release.split("\n### ").into_iter();
+            let release_string = version_iter.next().expect("No release version detected.").trim();
+            let mut release = Release::from(release_string);
+
+            // Each 'Major', 'Minor', 'Patch' section within this release.
+            for each_version in version_iter {
+                let version_parts: Vec<_> = each_version.split_terminator("\n\n").collect();
+
+                ensure!(version_parts.len() == 2, "Failed to parse release: {}", each_version);
+
+                let version_type = ReleaseType::from_str(version_parts[0], true).expect(
+                    format!(
+                        "Failed to parse version_type: {}. Must be 'Major', 'Minor', or 'Patch'.",
+                        version_parts[0]
+                    )
+                    .as_str(),
+                );
+                let version_contents = version_parts[1]
+                    .split("- ")
+                    .map(|str| str.trim().to_string())
+                    .filter(|str| !str.is_empty())
+                    .collect();
+
+                match version_type {
+                    ReleaseType::Major => release.major = version_contents,
+                    ReleaseType::Minor => release.minor = version_contents,
+                    ReleaseType::Patch => release.patch = version_contents,
+                }
+            }
+
+            releases.push(release);
+        }
+
+        Ok(Changelog { releases, skip_counter })
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct Release {
+    version: Version,
+
+    major: Vec<String>,
+    minor: Vec<String>,
+    patch: Vec<String>,
+}
+
+impl Release {
+    fn from(version: &str) -> Self {
+        let semver = Version::parse(version).expect("Invalid string version format.");
+        Release { version: semver, major: Vec::new(), minor: Vec::new(), patch: Vec::new() }
+    }
+}
+
+pub fn execute(crate_path: &str, _version: &ReleaseType, _message: &str) -> Result<()> {
+    ensure!(wasefire_cli_tools::fs::exists(crate_path), "Crate does not exist: {}", crate_path);
+
+    let _changelog = Changelog::read_file(crate_path)?;
+    // TODO: act upon changelog...
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_changelog_success() {
+        let changelog = r"# Changelog
+
+## 0.2.0
+
+### Major
+
+- major update 1
+- major update 2
+
+### Minor
+
+- minor update 1
+- minor update 2
+
+### Patch
+
+- patch update 1
+- patch update 2
+
+## 0.1.0
+
+### Major
+
+- major update 1
+- major update 2
+
+### Minor
+
+- minor update 1
+- minor update 2
+
+### Patch
+
+- patch update 1
+- patch update 2
+";
+
+        assert_eq!(
+            Changelog::parse(changelog.to_string()).expect("Failed to parse changelog."),
+            Changelog {
+                releases: vec![
+                    Release {
+                        version: Version::parse("0.2.0").unwrap(),
+                        major: vec!["major update 1".to_string(), "major update 2".to_string()],
+                        minor: vec!["minor update 1".to_string(), "minor update 2".to_string()],
+                        patch: vec!["patch update 1".to_string(), "patch update 2".to_string()],
+                    },
+                    Release {
+                        version: Version::parse("0.1.0").unwrap(),
+                        major: vec!["major update 1".to_string(), "major update 2".to_string()],
+                        minor: vec!["minor update 1".to_string(), "minor update 2".to_string()],
+                        patch: vec!["patch update 1".to_string(), "patch update 2".to_string()],
+                    }
+                ],
+                skip_counter: None,
+            }
+        );
+    }
+
+    #[test]
+    fn parse_changelog_with_missing_release_type_success() {
+        let changelog = r"# Changelog
+
+## 0.2.0
+
+### Major
+
+- major update 1
+- major update 2
+
+## 0.1.0
+
+### Minor
+
+- minor update 1
+- minor update 2
+
+## 0.0.1
+
+### Patch
+
+- patch update 1
+- patch update 2
+";
+
+        assert_eq!(
+            Changelog::parse(changelog.to_string()).expect("Failed to parse changelog."),
+            Changelog {
+                releases: vec![
+                    Release {
+                        version: Version::parse("0.2.0").unwrap(),
+                        major: vec!["major update 1".to_string(), "major update 2".to_string()],
+                        minor: Vec::new(),
+                        patch: Vec::new(),
+                    },
+                    Release {
+                        version: Version::parse("0.1.0").unwrap(),
+                        major: Vec::new(),
+                        minor: vec!["minor update 1".to_string(), "minor update 2".to_string()],
+                        patch: Vec::new(),
+                    },
+                    Release {
+                        version: Version::parse("0.0.1").unwrap(),
+                        major: Vec::new(),
+                        minor: Vec::new(),
+                        patch: vec!["patch update 1".to_string(), "patch update 2".to_string()],
+                    }
+                ],
+                skip_counter: None,
+            }
+        );
+    }
+
+    #[test]
+    fn parse_changelog_handles_multi_line_description() {
+        let changelog = r"# Changelog
+
+## 0.1.0
+
+### Major
+
+- short 1
+- my long description
+  that spans many lines.
+- short 2
+
+";
+
+        assert_eq!(
+            Changelog::parse(changelog.to_string()).expect("Failed to parse changelog."),
+            Changelog {
+                releases: vec![Release {
+                    version: Version::parse("0.1.0").unwrap(),
+                    major: vec![
+                        "short 1".to_string(),
+                        "my long description\n  that spans many lines.".to_string(),
+                        "short 2".to_string()
+                    ],
+                    minor: Vec::new(),
+                    patch: Vec::new(),
+                }],
+                skip_counter: None,
+            }
+        );
+    }
+
+    #[test]
+    fn parse_changelog_removes_prefix() {
+        let changelog = r"# Changelog
+
+## 0.1.0
+";
+
+        assert_eq!(
+            Changelog::parse(changelog.to_string()).expect("Failed to parse changelog."),
+            Changelog {
+                releases: vec![Release {
+                    version: Version::parse("0.1.0").unwrap(),
+                    major: Vec::new(),
+                    minor: Vec::new(),
+                    patch: Vec::new(),
+                }],
+                skip_counter: None,
+            }
+        );
+    }
+
+    #[test]
+    fn parse_changelog_handles_increment_comment_at_end() {
+        let changelog = r"# Changelog
+## 0.1.0
+
+### Major
+
+- A change
+
+<!-- Increment to skip CHANGELOG.md test: 5 -->";
+
+        assert_eq!(
+            Changelog::parse(changelog.to_string()).expect("Failed to parse changelog."),
+            Changelog {
+                releases: vec![Release {
+                    version: Version::parse("0.1.0").unwrap(),
+                    major: vec!["A change".to_string()],
+                    minor: Vec::new(),
+                    patch: Vec::new(),
+                }],
+                skip_counter: Some(5),
+            }
+        );
+    }
+}

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -26,6 +26,7 @@ use probe_rs::{flashing, Permissions, Session};
 use rustc_demangle::demangle;
 use wasefire_cli_tools::{action, cmd, fs};
 
+mod changelog;
 mod footprint;
 mod lazy;
 mod textreview;
@@ -94,6 +95,18 @@ enum MainCommand {
 
     /// Ensures review can be done in printed form.
     Textreview,
+
+    /// Updates change log of a crate and all dependent crates.
+    Changelog {
+        /// Crate to update suchas "crate/board".
+        crate_path: String,
+
+        // Either "major", "minor", or "patch".
+        version: changelog::ReleaseType,
+
+        /// Message added to the CHANGELOG.md.
+        message: String,
+    },
 }
 
 #[derive(clap::Args)]
@@ -222,6 +235,9 @@ impl Flags {
             MainCommand::Runner(runner) => runner.execute(&self.options),
             MainCommand::Footprint { output } => footprint::compare(&output),
             MainCommand::Textreview => textreview::execute(),
+            MainCommand::Changelog { crate_path, version, message } => {
+                changelog::execute(&crate_path, &version, &message)
+            }
         }
     }
 }

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -235,8 +235,8 @@ enum ChangelogCommand {
         /// Path to the crate that changed (e.g. `crates/board`).
         path: String,
 
-        // Type of change
-        release_type: changelog::ReleaseType,
+        /// Semver scope of the change.
+        scope: changelog::ReleaseType,
 
         /// One-line description of the change.
         description: String,
@@ -252,8 +252,8 @@ impl Flags {
             MainCommand::Textreview => textreview::execute(),
             MainCommand::Changelog(subcommand) => match subcommand.command {
                 ChangelogCommand::Ci => changelog::execute_ci(),
-                ChangelogCommand::Change { path, release_type, description } => {
-                    changelog::execute_change(&path, &release_type, &description)
+                ChangelogCommand::Change { path, scope, description } => {
+                    changelog::execute_change(&path, &scope, &description)
                 }
             },
         }

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -230,16 +230,16 @@ enum ChangelogCommand {
     /// Validates all CHANGELOG.md files.
     Ci,
 
-    /// Updates change log of a crate and all dependent crates.
+    /// Records a change to a crate.
     Change {
-        /// Crate to update suchas "crate/board".
-        crate_path: String,
+        /// Path to the crate that changed (e.g. `crates/board`).
+        path: String,
 
-        // Either "major", "minor", or "patch".
-        version: changelog::ReleaseType,
+        // Type of change
+        release_type: changelog::ReleaseType,
 
-        /// Message added to the CHANGELOG.md.
-        message: String,
+        /// One-line description of the change.
+        description: String,
     },
 }
 
@@ -252,8 +252,8 @@ impl Flags {
             MainCommand::Textreview => textreview::execute(),
             MainCommand::Changelog(subcommand) => match subcommand.command {
                 ChangelogCommand::Ci => changelog::execute_ci(),
-                ChangelogCommand::Change { crate_path, version, message } => {
-                    changelog::execute_change(&crate_path, &version, &message)
+                ChangelogCommand::Change { path, release_type, description } => {
+                    changelog::execute_change(&path, &release_type, &description)
                 }
             },
         }


### PR DESCRIPTION
End goal ([bug](https://github.com/google/wasefire/issues/448)): Create script to automate updating CHANGELOG.md

This task will be done in 2 parts:
1. `xtask changelog ci`: validates all CHANGELOG.md files <-- this PR
2. `xtask changelog {major,minor,patch}`: automatically updates changelogs with a new description.