### PR TITLE
[WIP] Implementation of atomic_wait / atomic_notify

### DIFF
--- a/crates/interpreter/Cargo.lock
+++ b/crates/interpreter/Cargo.lock
@@ -89,6 +89,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "syn"
 version = "2.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -121,6 +130,7 @@ dependencies = [
  "num_enum",
  "paste",
  "portable-atomic",
+ "spin",
  "wast",
 ]
 

--- a/crates/interpreter/Cargo.toml
+++ b/crates/interpreter/Cargo.toml
@@ -16,13 +16,15 @@ libm = { version = "0.2.8", default-features = false, optional = true }
 lru = { version = "0.12.3", default-features = false, optional = true }
 num_enum = { version = "0.7.2", default-features = false }
 paste = { version = "1.0.15", default-features = false }
-portable-atomic = { version = "1.6.0", default-features = false }
+portable-atomic = { version = "1.6.0" }# , default-features = false }
+spin = { version = "0.9.8",  default-features = false, features = ["spin_mutex", "portable_atomic"]}
 
 [dev-dependencies]
 lazy_static = "1.4.0"
 wast = "214.0.0"
 
 [features]
+# default = ["threads", "debug"]
 # Enable debugging features (only works for targets with std).
 debug = []
 # Use safe operations when time-of-use and time-of-check differ.

--- a/crates/interpreter/src/parser.rs
+++ b/crates/interpreter/src/parser.rs
@@ -702,7 +702,8 @@ impl<'m, M: Mode> Parser<'m, M> {
 
 /// Maximum number of locals (must be less than 2^32).
 // NOTE: This should be configurable.
-const MAX_LOCALS: usize = 100;
+// NOTE: Spec test skip_stack_guard_page needs lots of locals.
+const MAX_LOCALS: usize = 10000;
 
 fn check_eq<M: Mode, T: Eq>(x: T, y: T) -> MResult<(), M> {
     M::check(|| x == y)

--- a/crates/runner-host/Cargo.lock
+++ b/crates/runner-host/Cargo.lock
@@ -1829,6 +1829,7 @@ dependencies = [
  "num_enum",
  "paste",
  "portable-atomic",
+ "spin",
 ]
 
 [[package]]

--- a/crates/scheduler/Cargo.lock
+++ b/crates/scheduler/Cargo.lock
@@ -786,6 +786,7 @@ dependencies = [
  "num_enum",
  "paste",
  "portable-atomic",
+ "spin",
 ]
 
 [[package]]


### PR DESCRIPTION
We discussed a solution to have multiple threads with a single store while we wait for the [shared-everything-threads](https://github.com/WebAssembly/shared-everything-threads) to land. This is opposed to the `instance-per-thread` solution as implemented in [wasi-threads](https://github.com/WebAssembly/wasi-threads?tab=readme-ov-file#design-choice-instance-per-thread).

This commit is still WIP, but maybe a good point to pause and have a discussion of where we will take this.

Right now it contains:
- Adding support for multi-threaded tests in `spec.rs`
- Thread-safe module instantiation
- Very basic wait / notify implementation

This is somewhat working, it passes the wait notify test cases. Right now we have only ever one thread per module instantiation, which makes things easier to argue about.

I wonder though, in the desired use case, does that assumption still hold?