### PR TITLE
Test and bench interpreter cache

### DIFF
--- a/crates/interpreter/CHANGELOG.md
+++ b/crates/interpreter/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Implement `From<Error>` for `wasefire_error::Error`
 
+### Patch
+
+- Fix and test the `cache` feature in continuous integration
+
 ## 0.3.0
 
 ### Major

--- a/crates/interpreter/Cargo.lock
+++ b/crates/interpreter/Cargo.lock
@@ -3,10 +3,44 @@
 version = 3
 
 [[package]]
+name = "ahash"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
+
+[[package]]
 name = "bumpalo"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+ "allocator-api2",
+]
 
 [[package]]
 name = "lazy_static"
@@ -31,6 +65,9 @@ name = "lru"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3262e75e648fce39813cb56ac41f3c3e3f65217ebf3844d818d1f9398cfb0dc"
+dependencies = [
+ "hashbrown",
+]
 
 [[package]]
 name = "memchr"
@@ -57,6 +94,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "paste"
@@ -112,6 +155,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68f5e5f3158ecfd4b8ff6fe086db7c8467a2dfdac97fe420f2b7c4aa97af66d6"
 
 [[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
 name = "wasefire-error"
 version = "0.1.2-git"
 dependencies = [
@@ -152,4 +201,24 @@ dependencies = [
  "memchr",
  "unicode-width",
  "wasm-encoder",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]

--- a/crates/interpreter/Cargo.toml
+++ b/crates/interpreter/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["embedded", "no-std", "wasm"]
 
 [dependencies]
 libm = { version = "0.2.8", default-features = false, optional = true }
-lru = { version = "0.12.3", default-features = false, optional = true }
+lru = { version = "0.12.3", default-features = false, features = ["hashbrown"], optional = true }
 num_enum = { version = "0.7.2", default-features = false }
 paste = { version = "1.0.15", default-features = false }
 portable-atomic = { version = "1.6.0", default-features = false }

--- a/crates/interpreter/test.sh
+++ b/crates/interpreter/test.sh
@@ -23,6 +23,7 @@ test_helper
 
 cargo test --lib --features=toctou
 cargo check --lib --target=thumbv7em-none-eabi
+cargo check --lib --target=thumbv7em-none-eabi --features=cache
 cargo check --lib --target=riscv32imc-unknown-none-elf \
   --features=portable-atomic/critical-section
 RUSTFLAGS=--cfg=portable_atomic_unsafe_assume_single_core \

--- a/crates/wasm-bench/run.sh
+++ b/crates/wasm-bench/run.sh
@@ -38,5 +38,6 @@ case $1-$2 in
 esac
 
 FEATURES=--features=target-$1,runtime-$2
+shift 2
 
-x cargo run --release $TARGET $FEATURES
+x cargo run --release $TARGET $FEATURES "$@"


### PR DESCRIPTION
The `lru` crate needs the `hashbrown` feature to be no-std.

| Command | CoreMark | Time | RAM |
| --- | --- | --- | --- |
| `./run.sh nordic base` | 0.09058217 | 221.118s | 5384 |
| `./run.sh nordic base --features=wasefire-interpreter/cache` | 0.12708579 | 157.305s | 8700 |

Using the cache is 40% faster on this benchmark for 60% more RAM usage.