### PR TITLE
Fix platform protocol API documentation

### DIFF
--- a/crates/board/CHANGELOG.md
+++ b/crates/board/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Major
 
+- (Only when `api-platform-protocol` is used) Change `platform::protocol::Api::{enable,disable}()`
+  to also control whether requests are accepted
 - (Only when `api-storage` is used) The reexported `wasefire-store::Storage` now uses
   `wasefire-error` for errors
 

--- a/crates/board/src/platform/protocol.rs
+++ b/crates/board/src/platform/protocol.rs
@@ -37,10 +37,12 @@ pub trait Api {
     /// Writes a response for the last request.
     fn write(response: &[u8]) -> Result<(), Error>;
 
-    /// Enables an event to be triggered when a request is received.
+    /// Starts accepting requests.
+    ///
+    /// Also triggers an event each time a request is received.
     fn enable() -> Result<(), Error>;
 
-    /// Disables events from being triggered.
+    /// Stops accepting requests.
     fn disable() -> Result<(), Error>;
 
     /// Handles vendor-specific requests.


### PR DESCRIPTION
The current implementation in protocol-usb matches the new documentation. The rationale for the change is to provide quick feedback to the host that the device is not ready to handle requests yet. This is not a big change because this part of the board API is not exposed to the applet API. It is exclusively used by the scheduler. We might want to do similar (and bigger) changes to other parts of the API (like UART or USB serial).