### PR TITLE
Only take the initial frame in interpreter::Thread::new()

### DIFF
--- a/crates/interpreter/CHANGELOG.md
+++ b/crates/interpreter/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Minor
 
 - Implement `From<Error>` for `wasefire_error::Error`
+- Simplify `Thread::new`
 
 ### Patch
 

--- a/crates/interpreter/CHANGELOG.md
+++ b/crates/interpreter/CHANGELOG.md
@@ -5,10 +5,10 @@
 ### Minor
 
 - Implement `From<Error>` for `wasefire_error::Error`
-- Simplify `Thread::new`
 
 ### Patch
 
+- Only take the initial frame in `Thread::new()` 
 - Fix and test the `cache` feature in continuous integration
 
 ## 0.3.0

--- a/crates/interpreter/CHANGELOG.md
+++ b/crates/interpreter/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Patch
 
-- Only take the initial frame in `Thread::new()` 
+- Only take the initial frame in `Thread::new()`
 - Fix and test the `cache` feature in continuous integration
 
 ## 0.3.0


### PR DESCRIPTION
Make `Thread::new` only take a single `Frame`.

#46 