### PR TITLE
Just touch libapplet.a to ensure native applet

### DIFF
--- a/scripts/test-helper.sh
+++ b/scripts/test-helper.sh
@@ -20,13 +20,12 @@ SELF="$0"
 
 ensure_applet() {
   ( cd "$GIT_ROOT"
-    if [ ! -e target/wasefire/applet.wasm ]; then
-      mkdir -p target/wasefire
-      x touch target/wasefire/applet.wasm
-    fi
-    if [ ! -e target/wasefire/libapplet.a ]; then
-      x cargo xtask --native-target=thumbv7em-none-eabi applet rust hello
-    fi
+    for file in applet.wasm libapplet.a; do
+      if [ ! -e target/wasefire/$file ]; then
+        mkdir -p target/wasefire
+        x touch target/wasefire/$file
+      fi
+    done
   )
 }
 


### PR DESCRIPTION
No need to compile one. We only use cargo check in testing (not cargo build), so we won't attempt to link the applet. The fact that we don't link is also important because the existing native applet could have been for another target triple.