### PR TITLE
Make runner-host platform protocol dynamic over transport

### DIFF
--- a/crates/runner-host/Cargo.lock
+++ b/crates/runner-host/Cargo.lock
@@ -1248,12 +1248,10 @@ dependencies = [
  "wasefire-interpreter",
  "wasefire-logger",
  "wasefire-one-of",
- "wasefire-protocol",
  "wasefire-protocol-tokio",
  "wasefire-protocol-usb",
  "wasefire-scheduler",
  "wasefire-store",
- "wasefire-wire",
  "web-server",
 ]
 

--- a/crates/runner-host/Cargo.toml
+++ b/crates/runner-host/Cargo.toml
@@ -13,20 +13,18 @@ data-encoding = "2.6.0"
 env_logger = "0.11.3"
 rand = "0.8.5"
 tokio = { version = "1.40.0", features = ["full"] }
-usb-device = { version = "0.3.2", optional = true }
-usbd-serial = { version = "0.2.2", optional = true }
-usbip-device = { version = "0.2.0", optional = true }
+usb-device = { version = "0.3.2" }
+usbd-serial = { version = "0.2.2" }
+usbip-device = { version = "0.2.0" }
 wasefire-board-api = { path = "../board", features = ["std"] }
 wasefire-cli-tools = { path = "../cli-tools" }
 wasefire-error = { path = "../error" }
 wasefire-interpreter = { path = "../interpreter", optional = true }
 wasefire-logger = { path = "../logger" }
 wasefire-one-of = { version = "0.1.0-git", path = "../one-of" }
-wasefire-protocol = { path = "../protocol", features = ["device"], optional = true }
-wasefire-protocol-tokio = { path = "../protocol-tokio", features = ["device"], optional = true }
-wasefire-protocol-usb = { path = "../protocol-usb", features = ["device", "std"], optional = true }
+wasefire-protocol-tokio = { path = "../protocol-tokio", features = ["device"] }
+wasefire-protocol-usb = { path = "../protocol-usb", features = ["device", "std"] }
 wasefire-store = { path = "../store", features = ["std"] }
-wasefire-wire = { path = "../wire", optional = true }
 web-server = { path = "crates/web-server", optional = true }
 
 [dependencies.wasefire-scheduler]
@@ -40,6 +38,7 @@ features = [
   "board-api-storage",
   "board-api-timer",
   "board-api-uart",
+  "board-api-usb-serial",
   "software-crypto-aes128-ccm",
   "software-crypto-aes256-gcm",
   "software-crypto-hmac-sha256",
@@ -52,23 +51,12 @@ features = [
 ]
 
 [features]
-default = ["usb"]
 web = ["dep:web-server"]
-# Exactly one must be enabled.
-tcp = ["dep:wasefire-protocol-tokio"]
-unix = ["dep:wasefire-protocol-tokio"]
-usb = [
-  "dep:usb-device",
-  "dep:usbd-serial",
-  "dep:usbip-device",
-  "dep:wasefire-protocol-usb",
-  "wasefire-scheduler/board-api-usb-serial",
-]
 # Exactly one is enabled by xtask.
 debug = [
   "wasefire-logger/log",
-  "wasefire-protocol-tokio?/log",
-  "wasefire-protocol-usb?/log",
+  "wasefire-protocol-tokio/log",
+  "wasefire-protocol-usb/log",
   "wasefire-scheduler/log",
 ]
 release = []

--- a/crates/runner-host/Cargo.toml
+++ b/crates/runner-host/Cargo.toml
@@ -13,15 +13,15 @@ data-encoding = "2.6.0"
 env_logger = "0.11.3"
 rand = "0.8.5"
 tokio = { version = "1.40.0", features = ["full"] }
-usb-device = { version = "0.3.2" }
-usbd-serial = { version = "0.2.2" }
-usbip-device = { version = "0.2.0" }
+usb-device = "0.3.2"
+usbd-serial = "0.2.2"
+usbip-device = "0.2.0"
 wasefire-board-api = { path = "../board", features = ["std"] }
 wasefire-cli-tools = { path = "../cli-tools" }
 wasefire-error = { path = "../error" }
 wasefire-interpreter = { path = "../interpreter", optional = true }
 wasefire-logger = { path = "../logger" }
-wasefire-one-of = { version = "0.1.0-git", path = "../one-of" }
+wasefire-one-of = { path = "../one-of" }
 wasefire-protocol-tokio = { path = "../protocol-tokio", features = ["device"] }
 wasefire-protocol-usb = { path = "../protocol-usb", features = ["device", "std"] }
 wasefire-store = { path = "../store", features = ["std"] }

--- a/crates/runner-host/src/board.rs
+++ b/crates/runner-host/src/board.rs
@@ -22,7 +22,6 @@ mod rng;
 mod storage;
 pub mod timer;
 pub mod uart;
-#[cfg(feature = "usb")]
 pub mod usb;
 
 use tokio::sync::mpsc::Sender;
@@ -38,10 +37,8 @@ pub struct State {
     pub led: bool,
     pub timers: timer::Timers,
     pub uarts: uart::Uarts,
-    #[cfg(any(feature = "tcp", feature = "unix"))]
-    pub pipe: wasefire_protocol_tokio::Pipe,
-    #[cfg(feature = "usb")]
-    pub usb: usb::Usb,
+    pub protocol: platform::protocol::State,
+    pub usb: usb::State,
     pub storage: Option<FileStorage>,
     #[cfg(feature = "web")]
     pub web: web_server::Client,
@@ -76,6 +73,5 @@ impl Api for Board {
     type Storage = storage::Impl;
     type Timer = timer::Impl;
     type Uart = uart::Impl;
-    #[cfg(feature = "usb")]
     type Usb = usb::Impl;
 }

--- a/crates/runner-host/src/board/platform/protocol.rs
+++ b/crates/runner-host/src/board/platform/protocol.rs
@@ -1,0 +1,66 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use wasefire_board_api::platform::protocol::Api;
+use wasefire_error::{Code, Error};
+use wasefire_protocol_tokio::Pipe;
+
+use crate::with_state;
+
+pub enum Impl {}
+
+impl Api for Impl {
+    fn read() -> Result<Option<Box<[u8]>>, Error> {
+        with_state(|state| match &mut state.protocol {
+            State::Pipe(x) => x.read(),
+            State::Usb => state.usb.protocol().read(),
+        })
+    }
+
+    fn write(response: &[u8]) -> Result<(), Error> {
+        with_state(|state| match &mut state.protocol {
+            State::Pipe(x) => x.write(response),
+            State::Usb => state.usb.protocol().write(response),
+        })
+    }
+
+    fn enable() -> Result<(), Error> {
+        with_state(|state| match &mut state.protocol {
+            State::Pipe(x) => x.enable(),
+            State::Usb => state.usb.protocol().enable(),
+        })
+    }
+
+    fn vendor(request: &[u8]) -> Result<Box<[u8]>, Error> {
+        if let Some(request) = request.strip_prefix(b"echo ") {
+            let mut response = request.to_vec().into_boxed_slice();
+            for x in &mut response {
+                if x.is_ascii_alphabetic() {
+                    *x ^= 0x20;
+                }
+                if matches!(*x, b'I' | b'O' | b'i' | b'o') {
+                    *x ^= 0x6;
+                }
+            }
+            Ok(response)
+        } else {
+            Err(Error::user(Code::InvalidArgument))
+        }
+    }
+}
+
+pub enum State {
+    Pipe(Pipe),
+    Usb,
+}

--- a/crates/runner-host/src/board/usb.rs
+++ b/crates/runner-host/src/board/usb.rs
@@ -16,105 +16,111 @@ use std::process::{Child, Command};
 use std::time::Duration;
 
 use anyhow::{ensure, Result};
+use usb_device::class::UsbClass;
 use usb_device::class_prelude::UsbBusAllocator;
 use usb_device::device::StringDescriptors;
 use usb_device::prelude::{UsbDevice, UsbDeviceBuilder, UsbVidPid};
 use usb_device::UsbError;
 use usbd_serial::SerialPort;
 use usbip_device::UsbIpBus;
-use wasefire_board_api::usb::serial::{HasSerial, Serial, WithSerial};
+use wasefire_board_api::usb::serial::Serial;
 use wasefire_board_api::usb::Api;
-use wasefire_error::Error;
-use wasefire_protocol_usb::{HasRpc, Rpc};
+use wasefire_error::{Code, Error};
+use wasefire_protocol_usb::Rpc;
 
-use crate::board::State;
 use crate::with_state;
+
+mod serial;
 
 pub enum Impl {}
 
-pub type ProtocolImpl = wasefire_protocol_usb::Impl<'static, UsbIpBus, crate::board::usb::Impl>;
-
 impl Api for Impl {
-    type Serial = WithSerial<Impl>;
+    type Serial = serial::Impl;
 }
 
-impl HasRpc<'static, UsbIpBus> for Impl {
-    fn with_rpc<R>(f: impl FnOnce(&mut Rpc<'static, UsbIpBus>) -> R) -> R {
-        with_state(|state| f(&mut state.usb.protocol))
+pub struct State {
+    protocol: Option<Rpc<'static, UsbIpBus>>,
+    serial: Option<Serial<'static, UsbIpBus>>,
+    // Some iff at least one class is Some.
+    usb_dev: Option<UsbDevice<'static, UsbIpBus>>,
+}
+
+pub fn init() -> Result<()> {
+    if with_state(|x| x.usb.usb_dev.is_none()) {
+        return Ok(());
     }
-
-    fn vendor(request: &[u8]) -> Result<Box<[u8]>, Error> {
-        crate::board::platform::vendor(request)
-    }
-}
-
-impl HasSerial for Impl {
-    type UsbBus = UsbIpBus;
-
-    fn with_serial<R>(f: impl FnOnce(&mut Serial<Self::UsbBus>) -> R) -> R {
-        with_state(|state| f(&mut state.usb.serial))
-    }
-}
-
-pub struct Usb {
-    pub protocol: Rpc<'static, UsbIpBus>,
-    pub serial: Serial<'static, UsbIpBus>,
-    pub usb_dev: UsbDevice<'static, UsbIpBus>,
-}
-
-impl Default for Usb {
-    fn default() -> Self {
-        let usb_bus = Box::leak(Box::new(UsbBusAllocator::new(UsbIpBus::new())));
-        let protocol = Rpc::new(usb_bus);
-        let serial = Serial::new(SerialPort::new(usb_bus));
-        // TODO: VID and PID should be configurable.
-        let usb_dev = UsbDeviceBuilder::new(usb_bus, UsbVidPid(0x16c0, 0x27dd))
-            .strings(&[StringDescriptors::new(usb_device::LangID::EN).product("Wasefire")])
-            .unwrap()
-            .build();
-        Self { protocol, serial, usb_dev }
-    }
-}
-
-impl Usb {
-    pub fn init() -> Result<()> {
-        ensure!(
-            spawn(&["sudo", "modprobe", "vhci-hcd"]).wait().unwrap().code() == Some(0),
-            "failed to load kernel module for USB/IP"
-        );
-        let mut usbip = spawn(&["sudo", "usbip", "attach", "-r", "localhost", "-b", "1-1"]);
-        loop {
-            with_state(|state| state.usb.poll());
-            match usbip.try_wait().unwrap() {
-                None => continue,
-                Some(e) => ensure!(e.code() == Some(0), "failed to attach remote USB/IP device"),
-            }
-            break;
+    ensure!(
+        spawn(&["sudo", "modprobe", "vhci-hcd"]).wait().unwrap().code() == Some(0),
+        "failed to load kernel module for USB/IP"
+    );
+    let mut usbip = spawn(&["sudo", "usbip", "attach", "-r", "localhost", "-b", "1-1"]);
+    loop {
+        with_state(|state| state.usb.poll());
+        match usbip.try_wait().unwrap() {
+            None => continue,
+            Some(e) => ensure!(e.code() == Some(0), "failed to attach remote USB/IP device"),
         }
-        tokio::spawn({
-            async move {
-                loop {
-                    tokio::time::sleep(Duration::from_millis(1)).await;
-                    with_state(|state| {
-                        let polled = state.usb.poll();
-                        let has_serial = !matches!(
-                            state.usb.serial.port().read(&mut []),
-                            Err(UsbError::WouldBlock)
-                        );
-                        let State { sender, usb: Usb { protocol, serial, .. }, .. } = state;
-                        protocol.tick(|event| drop(sender.try_send(event.into())));
-                        serial.tick(polled && has_serial, |event| {
-                            drop(sender.try_send(event.into()))
-                        });
-                    });
+        break;
+    }
+    tokio::spawn(async move {
+        loop {
+            tokio::time::sleep(Duration::from_millis(1)).await;
+            with_state(|state| {
+                let polled = state.usb.poll();
+                let crate::board::State { sender, usb: State { protocol, serial, .. }, .. } = state;
+                if let Some(protocol) = protocol {
+                    protocol.tick(|event| drop(sender.try_send(event.into())));
                 }
-            }
-        });
-        Ok(())
+                if let Some(serial) = serial {
+                    let has_serial =
+                        !matches!(serial.port().read(&mut []), Err(UsbError::WouldBlock));
+                    serial.tick(polled && has_serial, |event| drop(sender.try_send(event.into())));
+                }
+            });
+        }
+    });
+    Ok(())
+}
+
+impl State {
+    pub fn new(vid_pid: &str, protocol: bool, serial: bool) -> Self {
+        let mut state = State { protocol: None, serial: None, usb_dev: None };
+        if !protocol && !serial {
+            return state;
+        }
+        let usb_bus = Box::leak(Box::new(UsbBusAllocator::new(UsbIpBus::new())));
+        if protocol {
+            state.protocol = Some(Rpc::new(usb_bus));
+        }
+        if serial {
+            state.serial = Some(Serial::new(SerialPort::new(usb_bus)));
+        }
+        let (vid, pid) = vid_pid.split_once(':').expect("--usb-vid-pid must be VID:PID");
+        let vid = u16::from_str_radix(vid, 16).expect("invalid VID");
+        let pid = u16::from_str_radix(pid, 16).expect("invalid PID");
+        state.usb_dev = Some(
+            UsbDeviceBuilder::new(usb_bus, UsbVidPid(vid, pid))
+                .strings(&[StringDescriptors::new(usb_device::LangID::EN).product("Wasefire")])
+                .unwrap()
+                .build(),
+        );
+        state
     }
 
-    pub fn poll(&mut self) -> bool {
-        self.usb_dev.poll(&mut [&mut self.protocol, self.serial.port()])
+    pub fn protocol(&mut self) -> &mut Rpc<'static, UsbIpBus> {
+        self.protocol.as_mut().unwrap()
+    }
+
+    pub fn serial(&mut self) -> Result<&mut Serial<'static, UsbIpBus>, Error> {
+        self.serial.as_mut().ok_or(Error::world(Code::NotImplemented))
+    }
+
+    fn poll(&mut self) -> bool {
+        let usb_dev = self.usb_dev.as_mut().unwrap();
+        let mut classes = Vec::<&mut dyn UsbClass<_>>::with_capacity(2);
+        classes.extend(self.protocol.as_mut().map(|x| x as &mut dyn UsbClass<_>));
+        classes.extend(self.serial.as_mut().map(|x| x.port() as &mut dyn UsbClass<_>));
+        usb_dev.poll(&mut classes)
     }
 }
 

--- a/crates/runner-host/src/board/usb/serial.rs
+++ b/crates/runner-host/src/board/usb/serial.rs
@@ -1,0 +1,42 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use wasefire_board_api::usb::serial::{Api, Event};
+use wasefire_error::Error;
+
+use crate::with_state;
+
+pub enum Impl {}
+
+impl Api for Impl {
+    fn read(output: &mut [u8]) -> Result<usize, Error> {
+        with_state(|x| x.usb.serial()?.read(output))
+    }
+
+    fn write(input: &[u8]) -> Result<usize, Error> {
+        with_state(|x| x.usb.serial()?.write(input))
+    }
+
+    fn flush() -> Result<(), Error> {
+        with_state(|x| x.usb.serial()?.flush())
+    }
+
+    fn enable(event: &Event) -> Result<(), Error> {
+        with_state(|x| x.usb.serial()?.enable(event))
+    }
+
+    fn disable(event: &Event) -> Result<(), Error> {
+        with_state(|x| x.usb.serial()?.disable(event))
+    }
+}

--- a/crates/runner-host/src/cleanup.rs
+++ b/crates/runner-host/src/cleanup.rs
@@ -17,7 +17,6 @@ use std::sync::Mutex;
 
 pub type Cleanup = Box<dyn FnOnce() + Send>;
 
-#[cfg(feature = "unix")]
 pub fn push(cleanup: Cleanup) {
     CLEANUP.lock().unwrap().push(cleanup);
 }

--- a/crates/runner-host/src/main.rs
+++ b/crates/runner-host/src/main.rs
@@ -19,7 +19,6 @@ use std::path::PathBuf;
 use std::sync::Mutex;
 
 use anyhow::Result;
-use board::Board;
 use clap::Parser;
 use tokio::select;
 use tokio::sync::mpsc::{channel, Receiver};
@@ -30,10 +29,12 @@ use wasefire_one_of::exactly_one_of;
 use wasefire_scheduler::Scheduler;
 use wasefire_store::{FileOptions, FileStorage};
 
+use crate::board::platform::protocol::State as ProtocolState;
+use crate::board::Board;
+
 mod board;
 mod cleanup;
 
-exactly_one_of!["tcp", "unix", "usb"];
 exactly_one_of!["debug", "release"];
 exactly_one_of!["native", "wasm"];
 
@@ -47,20 +48,42 @@ fn with_state<R>(f: impl FnOnce(&mut board::State) -> R) -> R {
 #[derive(Parser)]
 struct Flags {
     /// Directory containing files representing the flash.
-    #[clap(long, default_value = "../../target/wasefire")]
+    #[arg(long, default_value = "../../target/wasefire")]
     flash_dir: PathBuf,
 
-    #[cfg(feature = "tcp")]
-    #[clap(long, default_value = "127.0.0.1:3457")]
+    /// Transport to listen to for the platform protocol.
+    #[arg(long, default_value = "usb")]
+    protocol: Protocol,
+
+    /// Address to bind to when --protocol=tcp (ignored otherwise).
+    #[arg(long, default_value = "127.0.0.1:3457")]
     tcp_addr: std::net::SocketAddr,
 
-    #[cfg(feature = "unix")]
-    #[clap(long, default_value = "/tmp/wasefire")]
+    /// Socket path to bind to when --protocol=unix (ignored otherwise).
+    #[arg(long, default_value = "/tmp/wasefire")]
     unix_path: std::path::PathBuf,
 
+    /// The VID:PID to use for the USB device.
+    ///
+    /// A USB device is used when --protocol=usb or --usb-serial (ignored otherwise). Note that USB
+    /// requires sudo.
+    #[arg(long, default_value = "16c0:27dd")]
+    usb_vid_pid: String,
+
+    /// Whether to enable USB serial.
+    #[arg(long)]
+    usb_serial: bool,
+
     #[cfg(feature = "web")]
-    #[clap(flatten)]
+    #[command(flatten)]
     web_options: WebOptions,
+}
+
+#[derive(Clone, clap::ValueEnum)]
+enum Protocol {
+    Tcp,
+    Unix,
+    Usb,
 }
 
 #[test]
@@ -82,7 +105,6 @@ struct WebOptions {
 #[tokio::main]
 async fn main() -> Result<()> {
     env_logger::init();
-    #[cfg_attr(feature = "usb", allow(unused_variables))]
     let flags = Flags::parse();
     std::panic::set_hook(Box::new(|info| {
         eprintln!("{info}");
@@ -124,38 +146,43 @@ async fn main() -> Result<()> {
         let url = format!("{}:{}", flags.web_options.web_host, flags.web_options.web_port);
         web_server::Client::new(&url, sender).await?
     };
-    #[cfg(any(feature = "tcp", feature = "unix"))]
     let push = {
         use wasefire_board_api::platform::protocol::Event;
         let sender = sender.clone();
         move |event: Event| drop(sender.try_send(event.into()))
     };
-    #[cfg(feature = "tcp")]
-    let pipe = wasefire_protocol_tokio::Pipe::new_tcp(flags.tcp_addr, push).await.unwrap();
-    #[cfg(feature = "unix")]
-    let pipe = {
-        let pipe = wasefire_protocol_tokio::Pipe::new_unix(&flags.unix_path, push).await.unwrap();
-        let unix_path = flags.unix_path.clone();
-        crate::cleanup::push(Box::new(move || drop(std::fs::remove_file(unix_path))));
-        pipe
+    let protocol = match flags.protocol {
+        Protocol::Tcp => ProtocolState::Pipe(
+            wasefire_protocol_tokio::Pipe::new_tcp(flags.tcp_addr, push).await.unwrap(),
+        ),
+        Protocol::Unix => {
+            let pipe =
+                wasefire_protocol_tokio::Pipe::new_unix(&flags.unix_path, push).await.unwrap();
+            let unix_path = flags.unix_path.clone();
+            cleanup::push(Box::new(move || drop(std::fs::remove_file(unix_path))));
+            ProtocolState::Pipe(pipe)
+        }
+        Protocol::Usb => ProtocolState::Usb,
     };
+    let usb = board::usb::State::new(
+        &flags.usb_vid_pid,
+        matches!(protocol, ProtocolState::Usb),
+        flags.usb_serial,
+    );
     *STATE.lock().unwrap() = Some(board::State {
         sender,
         button: false,
         led: false,
         timers: board::timer::Timers::default(),
         uarts: board::uart::Uarts::new(),
-        #[cfg(any(feature = "tcp", feature = "unix"))]
-        pipe,
-        #[cfg(feature = "usb")]
-        usb: board::usb::Usb::default(),
+        protocol,
+        usb,
         storage,
         #[cfg(feature = "web")]
         web,
     });
     board::uart::Uarts::init();
-    #[cfg(feature = "usb")]
-    board::usb::Usb::init()?;
+    board::usb::init()?;
     #[cfg(not(feature = "web"))]
     tokio::task::spawn_blocking(|| {
         use std::io::BufRead;

--- a/crates/runner-host/test.sh
+++ b/crates/runner-host/test.sh
@@ -25,5 +25,3 @@ cargo test --bin=runner-host --features=wasm,debug
 cargo check --bin=runner-host --features=wasm,debug,web
 cargo check --bin=runner-host --features=wasm,release
 cargo check --bin=runner-host --target=i686-unknown-linux-gnu --features=native,release
-cargo check --bin=runner-host --no-default-features --features=wasm,debug,tcp
-cargo check --bin=runner-host --no-default-features --features=wasm,debug,unix

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -195,6 +195,10 @@ struct RunnerOptions {
     #[clap(long)]
     features: Vec<String>,
 
+    /// Runner arguments.
+    #[clap(long)]
+    arg: Vec<String>,
+
     /// Optimization level (0, 1, 2, 3, s, z).
     #[clap(long, short = 'O')]
     opt_level: Option<action::OptLevel>,
@@ -475,9 +479,6 @@ impl RunnerOptions {
         }
         if self.no_default_features {
             cargo.arg("--no-default-features");
-        } else if std::env::var_os("CODESPACES").is_some() {
-            log::warn!("Assuming runner --no-default-features when running in a codespace.");
-            cargo.arg("--no-default-features");
         }
         if let Some(log) = &self.log {
             cargo.env(self.log_env(), log);
@@ -522,6 +523,11 @@ impl RunnerOptions {
             if let Some(port) = &self.web_port {
                 cargo.arg(format!("--web-port={port}"));
             }
+            if std::env::var_os("CODESPACES").is_some() {
+                log::warn!("Assuming runner --arg=--protocol=unix when running in a codespace.");
+                cargo.arg("--protocol=unix");
+            }
+            cargo.args(&self.arg);
             cmd::replace(cargo);
         } else {
             cmd::execute(&mut cargo).await?;

--- a/scripts/hwci.sh
+++ b/scripts/hwci.sh
@@ -77,7 +77,7 @@ full() {
 }
 
 case $1 in
-  host) full unix host --no-default-features --features=unix ;;
+  host) full unix host --arg=--protocol=unix ;;
   # P1.01, P1.02, and P1.03 must be connected together (gpio_test).
   nordic) full usb nordic ;;
   *) run --protocol=${1:-usb} "$2" ;;


### PR DESCRIPTION
This is needed for #278 since ideally want a single release of the host runner. And we still want this release to provide support for different transports. In particular because USB requires sudo and doesn't work in GitHub Codespaces.