### PR TITLE
Work around GitHub limitations regarding PR reviews

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,3 @@
 * @ia0
-/crates/runner-host/crates/web-client/ @chris-dietz @ia0
+/crates/runner-host/crates/web-client/ @chris-dietz @ia0 @ia0-review
+/.github/CODEOWNERS @ia0


### PR DESCRIPTION
We are affected by those GitHub issues:
- https://github.com/orgs/community/discussions/6292
- https://github.com/orgs/community/discussions/9636

For the first one, we created @ia0-review. For the second one, we have to make sure that a file has either exactly @ia0 as code owner, or both @ia0 and @ia0-review. This PR is fixing this second issue. It is also making sure @ia0 is the code owner of the CODEOWNERS file.