### PR TITLE
Make sure CLI compiles with cargo install

### DIFF
--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -47,4 +47,4 @@
 
 ## 0.1.0
 
-<!-- Increment to skip CHANGELOG.md test: 10 -->
+<!-- Increment to skip CHANGELOG.md test: 11 -->

--- a/crates/cli/Cargo.lock
+++ b/crates/cli/Cargo.lock
@@ -791,6 +791,7 @@ dependencies = [
  "env_logger",
  "tokio",
  "wasefire-cli-tools",
+ "wasefire-one-of",
 ]
 
 [[package]]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -11,9 +11,6 @@ include = ["/LICENSE", "/src/"]
 keywords = ["cli", "embedded", "framework", "wasm"]
 categories = ["command-line-utilities", "embedded", "wasm"]
 
-[package.metadata.docs.rs]
-features = ["_dev"]
-
 [[bin]]
 name = "wasefire"
 path = "src/main.rs"
@@ -24,6 +21,7 @@ clap = { version = "4.5.4", default-features = false, features = ["default", "de
 clap_complete = { version = "4.5.2", default-features = false }
 env_logger = { version = "0.11.3", default-features = false, features = ["default"] }
 wasefire-cli-tools = { version = "0.2.0-git", path = "../cli-tools", features = ["action"] }
+wasefire-one-of = { version = "0.1.0-git", path = "../one-of" }
 
 [dependencies.tokio]
 version = "1.40.0"
@@ -32,6 +30,7 @@ features = ["macros", "parking_lot", "rt", "rt-multi-thread"]
 
 [features]
 _dev = []
+_prod = []
 
 [lints]
 clippy.unit-arg = "allow"

--- a/crates/cli/test.sh
+++ b/crates/cli/test.sh
@@ -21,3 +21,4 @@ test_helper
 
 cargo test --bin=wasefire
 cargo check --bin=wasefire --features=_dev
+WASEFIRE_HOST_PLATFORM=/dev/null cargo check --bin=wasefire --features=_prod

--- a/crates/cli/test.sh
+++ b/crates/cli/test.sh
@@ -19,4 +19,5 @@ set -e
 
 test_helper
 
-cargo test --bin=wasefire --features=_dev
+cargo test --bin=wasefire
+cargo check --bin=wasefire --features=_dev

--- a/scripts/artifacts.sh
+++ b/scripts/artifacts.sh
@@ -48,7 +48,7 @@ for target in $TARGETS; do
     cargo build --manifest-path=crates/runner-host/Cargo.toml --release --target=$target \
       --features=debug,wasm
     export WASEFIRE_HOST_PLATFORM=$PWD/target/$target/release/runner-host
-    cargo build --manifest-path=crates/cli/Cargo.toml --release --target=$target
+    cargo build --manifest-path=crates/cli/Cargo.toml --release --target=$target --features=_prod
   )
   artifact=artifacts/wasefire-$target
   cp target/$target/release/wasefire $artifact


### PR DESCRIPTION
And show an error for the host command. Once we support self-update, we can suggest to self-update (with force in case it's the same version).