### PR TITLE
Release artifacts in tar.gz format to preserve file permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,8 @@ jobs:
       - run: |
           mv ${{ steps.attest.outputs.bundle-path }} attestation.intoto.jsonl
           echo 'attestation.intoto.jsonl#Provenance attestation' >> artifacts.txt
+          ( cd artifacts && sha256sum * > ../sha256sum.txt )
+          echo 'sha256sum.txt#Checksums' >> artifacts.txt
           COMMIT=$(git rev-parse -q --verify HEAD)
           DATE=$(git log -1 --pretty=%cs)
           xargs --arg-file=artifacts.txt --delimiter='\n' \

--- a/scripts/artifacts.sh
+++ b/scripts/artifacts.sh
@@ -23,13 +23,14 @@ i "Generate notes.txt"
 cat <<EOF > notes.txt
 See the [changelog] for the list of changes in this release.
 
-You can use the following command to verify a downloaded asset:
+You can use the following command to check your downloaded assets:
 
-    gh attestation verify --repo=google/wasefire <asset-path>
+    sha256sum --ignore-missing --check sha256sum.txt
 
-You may also download the provenance attestation and use the \`--bundle\` flag:
+You can use one of the following commands to verify a downloaded asset:
 
-    gh attestation verify --owner=google --bundle=attestation.intoto.jsonl <asset-path>
+    gh attestation verify --repo=google/wasefire ASSET_PATH
+    gh attestation verify --owner=google --bundle=attestation.intoto.jsonl ASSET_PATH
 
 [changelog]: https://github.com/google/wasefire/blob/main/docs/releases/$DATE.md
 EOF
@@ -49,8 +50,10 @@ for target in $TARGETS; do
       --features=debug,wasm
     export WASEFIRE_HOST_PLATFORM=$PWD/target/$target/release/runner-host
     cargo build --manifest-path=crates/cli/Cargo.toml --release --target=$target --features=_prod
+    cp target/$target/release/wasefire artifacts/wasefire-$target
+    cd artifacts
+    tar czf wasefire-$target.tar.gz wasefire-$target
+    rm wasefire-$target
   )
-  artifact=artifacts/wasefire-$target
-  cp target/$target/release/wasefire $artifact
-  echo "$artifact#Wasefire CLI ($target)" >> artifacts.txt
+  echo "artifacts/wasefire-$target.tar.gz#Wasefire CLI ($target)" >> artifacts.txt
 done


### PR DESCRIPTION
Also add a checksum file in addition to the provenance attestation file.