### PR TITLE
Pausing execution of interpreter

### DIFF
--- a/crates/interpreter/Cargo.toml
+++ b/crates/interpreter/Cargo.toml
@@ -33,6 +33,8 @@ float-types = ["dep:libm"]
 vector-types = []
 # Enable caching for execution.
 cache = ["dep:lru"]
+# Enable pausing / preemption.
+pause = []
 
 [lints]
 clippy.unit-arg = "allow"

--- a/crates/interpreter/examples/hello.rs
+++ b/crates/interpreter/examples/hello.rs
@@ -13,7 +13,8 @@
 // limitations under the License.
 
 #![allow(unused_crate_dependencies)]
-
+#[cfg(feature = "pause")]
+use portable_atomic::AtomicBool;
 use wasefire_interpreter::*;
 
 fn main() {
@@ -52,11 +53,29 @@ fn main() {
     // the host does neither have enough memory nor virtual memory.
     let mut memory = [0; 5];
 
+    #[cfg(feature = "pause")]
+    let interrupt = AtomicBool::new(false);
+
     // Instantiate the module in the store.
-    let inst = store.instantiate(module, &mut memory).unwrap();
+    let inst = store
+        .instantiate(
+            module,
+            &mut memory,
+            #[cfg(feature = "pause")]
+            Some(&interrupt),
+        )
+        .unwrap();
 
     // Call the "main" function exported by the instance.
-    let mut result = store.invoke(inst, "main", vec![]).unwrap();
+    let mut result = store
+        .invoke(
+            inst,
+            "main",
+            vec![],
+            #[cfg(feature = "pause")]
+            &interrupt,
+        )
+        .unwrap();
 
     // Process calls from the module to the host until "main" terminates.
     loop {
@@ -67,6 +86,8 @@ fn main() {
                 assert!(results.is_empty());
                 break;
             }
+            #[cfg(feature = "pause")]
+            RunResult::Interrupt() => unreachable!(),
         };
 
         // We only linked one function, which has thus index zero.

--- a/crates/interpreter/test.sh
+++ b/crates/interpreter/test.sh
@@ -22,9 +22,11 @@ ensure_submodule third_party/WebAssembly/spec
 list_files() {
   find ../../third_party/WebAssembly/spec/test/core \
     -maxdepth 1 -name '*.wast' -execdir basename -s .wast {} \;
+      find ../../third_party/WebAssembly/pause/test/core \
+    -maxdepth 1 -name '*.wast' -execdir basename -s .wast {} \;
 }
 list_tests() {
-  sed -n 's/^test!(.*, "\([^"]*\)".*);$/\1/p;s/^test!(\([^,]*\).*);$/\1/p' tests/spec.rs
+  sed -n 's/^test!(.*, "\([^"]*\)".*);$/\1/p;s/^test!(\([^,]*\).*);$/\1/p;s/^test!("[^"]*",[^,]+,"\([^"]*\)");$/\1/p' tests/spec.rs | sort
 }
 diff_sorted tests/spec.rs "$(list_files | sort)" $(list_tests)
 
@@ -39,4 +41,4 @@ RUSTFLAGS=--cfg=portable_atomic_unsafe_assume_single_core \
   cargo check --lib --target=riscv32imc-unknown-none-elf
 cargo check --example=hello
 # Run with `-- --test-threads=1 --nocapture` to see unsupported tests.
-cargo test --test=spec --features=debug,toctou,float-types,vector-types
+cargo test --test=spec --features=debug,toctou,float-types,vector-types,pause

--- a/third_party/WebAssembly/pause/test/core/infinite_loop.wast
+++ b/third_party/WebAssembly/pause/test/core/infinite_loop.wast
@@ -1,0 +1,27 @@
+(module
+    (func (export "loopforever")
+        (loop
+        (br 0)
+        )
+    )
+
+    (func $recurseforever 
+        call $recurseforever
+    )
+    (export "recurseforever" (func $recurseforever))
+)
+
+(assert_return (invoke "recurseforever") (i64.const 1111))
+(assert_return (invoke "loopforever") (i64.const 1111))
+
+(assert_trap 
+    (module
+        (func $loopforever
+            (loop
+            (br 0)
+            )
+        )
+
+        (start $loopforever)
+    )
+"interrupt")


### PR DESCRIPTION
Enable preemption / pausing of wasm applets behind a feature flag.
* pass `AtomicBool` as argument
* check the bool on function calls and back edges
* wasm test case with infinite loop and infinite recursion added