### PR TITLE
Reduce delta_ip by 1 for "if without else" in validation

### DIFF
--- a/crates/interpreter/src/valid.rs
+++ b/crates/interpreter/src/valid.rs
@@ -426,8 +426,18 @@ impl SideTable {
         self.entries.push(None);
     }
 
-    fn stitch(&mut self, source: SideTableBranch, target: SideTableBranch) -> CheckResult {
-        let delta_ip = Self::delta(source, target, |x| x.parser.as_ptr() as isize)?;
+    fn stitch(
+        &mut self, source: SideTableBranch, target: SideTableBranch, is_if_without_else: bool,
+    ) -> CheckResult {
+        let mut delta_ip = Self::delta(source, target, |x| x.parser.as_ptr() as isize)?;
+        if is_if_without_else {
+            let Some(reduced_delta_ip) = delta_ip.checked_sub(1) else {
+                #[cfg(feature = "debug")]
+                eprintln!("side-table subtraction overflow {delta_ip} - 1");
+                return Err(unsupported(if_debug!(Unsupported::SideTable)));
+            };
+            delta_ip = reduced_delta_ip;
+        }
         let delta_stp = Self::delta(source, target, |x| x.side_table as isize)?;
         let val_cnt = u32::try_from(target.result).map_err(|_| {
             #[cfg(feature = "debug")]
@@ -596,7 +606,7 @@ impl<'a, 'm> Expr<'a, 'm> {
             Else => {
                 match core::mem::replace(&mut self.label().kind, LabelKind::Block) {
                     LabelKind::If(source) => {
-                        self.side_table.stitch(source, self.branch_target(source.result))?
+                        self.side_table.stitch(source, self.branch_target(source.result), false)?
                     }
                     _ => Err(invalid())?,
                 }
@@ -851,12 +861,12 @@ impl<'a, 'm> Expr<'a, 'm> {
         let results_len = self.label().type_.results.len();
         let target = self.branch_target(results_len);
         for source in core::mem::take(&mut self.label().branches) {
-            self.side_table.stitch(source, target)?;
+            self.side_table.stitch(source, target, false)?;
         }
         let label = self.label();
         if let LabelKind::If(source) = label.kind {
             check(label.type_.params == label.type_.results)?;
-            self.side_table.stitch(source, target)?;
+            self.side_table.stitch(source, target, true)?;
         }
         let results = self.label().type_.results;
         self.pops(results)?;
@@ -879,7 +889,7 @@ impl<'a, 'm> Expr<'a, 'm> {
                 label.type_.results
             }
             LabelKind::Loop(target) => {
-                self.side_table.stitch(source, target)?;
+                self.side_table.stitch(source, target, false)?;
                 label.type_.params
             }
         })


### PR DESCRIPTION
Jumping from "if without else" should be 1 step less than jumping from "if with else". For "if without else", we don't want to jump over the "end" because `exit_label()` need to be [called](https://github.com/zhouwfang/wasefire/blob/de6c7e889865736cb1f11877d5d4e1e9f50729a8/crates/interpreter/src/exec.rs#L788) at the "end". But for "if with else", we want to jump over the "else" because otherwise we would be forced to jump to the "end" at "else" (normally, we would reach "else" after executing the true branch of "if", and we should not execute the "else" branch).

This is equivalent to https://github.com/google/wasefire/blob/main/crates/interpreter/src/parser.rs#L566-L569, which will be deprecated with the side table applied in `exec.rs`.

#46