### PR TITLE
Increment delta_stp by 1 for "if with else" in validation

### DIFF
--- a/crates/interpreter/src/valid.rs
+++ b/crates/interpreter/src/valid.rs
@@ -596,7 +596,9 @@ impl<'a, 'm> Expr<'a, 'm> {
             Else => {
                 match core::mem::replace(&mut self.label().kind, LabelKind::Block) {
                     LabelKind::If(source) => {
-                        self.side_table.stitch(source, self.branch_target(source.result))?
+                        let mut target = self.branch_target(source.result);
+                        target.side_table += 1;
+                        self.side_table.stitch(source, target)?
                     }
                     _ => Err(invalid())?,
                 }


### PR DESCRIPTION
When "if" has an "else", we should skip the entry for "else" in the side table. It was addressed in #690 during execution and should be moved to validation.

#46
