### PR TITLE
Use instead of restoring side table for Loop

### DIFF
--- a/crates/interpreter/src/exec.rs
+++ b/crates/interpreter/src/exec.rs
@@ -15,7 +15,6 @@
 // TODO: Some toctou could be used instead of panic.
 use alloc::vec;
 use alloc::vec::Vec;
-use core::fmt::Debug;
 
 use crate::error::*;
 use crate::module::*;

--- a/crates/interpreter/src/lib.rs
+++ b/crates/interpreter/src/lib.rs
@@ -148,6 +148,7 @@ mod parser;
 mod side_table;
 mod syntax;
 mod toctou;
+mod util;
 mod valid;
 
 pub use error::{Error, TRAP_CODE, Unsupported};

--- a/crates/interpreter/src/parser.rs
+++ b/crates/interpreter/src/parser.rs
@@ -64,10 +64,6 @@ impl<'m, M: Mode> Parser<'m, M> {
         Ok(result)
     }
 
-    pub fn parse_bytes_reversely(&mut self, delta: i32) -> MResult<&'m [u8], M> {
-        unimplemented!()
-    }
-
     pub fn split_at(&mut self, len: usize) -> MResult<Parser<'m, M>, M> {
         Ok(Self::internal_new(self.parse_bytes(len)?))
     }
@@ -565,15 +561,6 @@ impl<'m, M: Mode> Parser<'m, M> {
                 Instr::End => depth -= 1,
                 _ => (),
             }
-        }
-        Ok(())
-    }
-
-    pub fn skip_to(&mut self, delta: i32) -> MResult<(), M> {
-        if delta >= 0 {
-            self.parse_bytes(delta as usize)?;
-        } else {
-            self.parse_bytes_reversely(delta)?;
         }
         Ok(())
     }

--- a/crates/interpreter/src/parser.rs
+++ b/crates/interpreter/src/parser.rs
@@ -64,6 +64,10 @@ impl<'m, M: Mode> Parser<'m, M> {
         Ok(result)
     }
 
+    pub fn parse_bytes_reversely(&mut self, delta: i32) -> MResult<&'m [u8], M> {
+        unimplemented!()
+    }
+
     pub fn split_at(&mut self, len: usize) -> MResult<Parser<'m, M>, M> {
         Ok(Self::internal_new(self.parse_bytes(len)?))
     }
@@ -561,6 +565,15 @@ impl<'m, M: Mode> Parser<'m, M> {
                 Instr::End => depth -= 1,
                 _ => (),
             }
+        }
+        Ok(())
+    }
+
+    pub fn skip_to(&mut self, delta: i32) -> MResult<(), M> {
+        if delta >= 0 {
+            self.parse_bytes(delta as usize)?;
+        } else {
+            self.parse_bytes_reversely(delta)?;
         }
         Ok(())
     }

--- a/crates/interpreter/src/util.rs
+++ b/crates/interpreter/src/util.rs
@@ -1,0 +1,21 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// TODO(dev/fast-interp): Add debug asserts when `off` is positive and negative, and `toctou`
+// support.
+pub fn offset_front<T>(cur: &[T], off: isize) -> &[T] {
+    unsafe {
+        core::slice::from_raw_parts(cur.as_ptr().offset(off), (cur.len() as isize - off) as usize)
+    }
+}


### PR DESCRIPTION
On my Linux Docker container:

1. 

CoreMark results of this PR: 37.991516 (in 18.695s), 36.7287 (in 19.258s)

CoreMark results of https://github.com/google/wasefire/pull/690: 37.101162 (in 19.133s), 37.39716 (in 18.996s)

Look very similar. Not sure about `nordic`.

2. 

CoreMark results of `main`: 28.791477 (in 18.09s), 28.814291 (in 17.734s)

So there does seem some minor performance improvement with `delta_ip` and `delta_stp`.

https://github.com/google/wasefire/issues/46