### PR TITLE
Properly disable warnings in unsolved exercise tests

### DIFF
--- a/examples/rust/exercises/test.sh
+++ b/examples/rust/exercises/test.sh
@@ -20,7 +20,7 @@ set -ex
 for part in part-*; do
   ( cd $part
     # This is only to update the Cargo.lock file.
-    cargo check --target=wasm32-unknown-unknown 2>/dev/null
+    RUSTFLAGS=--allow=warnings cargo check --target=wasm32-unknown-unknown
     # We check the usual for solutions though.
     [ ${part%-sol} = $part ] && exit
     cargo fmt -- --check


### PR DESCRIPTION
Now that https://github.com/rust-lang/cargo/issues/8010 has been fixed.