### PR TITLE
Shorten timeout of matrix jobs to 15 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,7 @@ jobs:
         with:
           checks: "[\"${{ matrix.check }}\"]"
           token: ${{ secrets.GITHUB_TOKEN }}
+        timeout-minutes: 15
   ubuntu:
     runs-on: ubuntu-latest
     needs: matrix


### PR DESCRIPTION
The `hwci host` job may "freeze" because of process management in shell.