### PR TITLE
Use `[u8]` instead of `[u16]` to not rely on alignment

### DIFF
--- a/crates/interpreter/Cargo.lock
+++ b/crates/interpreter/Cargo.lock
@@ -15,26 +15,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
-name = "bytemuck"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78834c15cb5d5efe3452d58b1e8ba890dd62d21907f867f383358198e56ebca5"
-dependencies = [
- "bytemuck_derive",
-]
-
-[[package]]
-name = "bytemuck_derive"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fa76293b4f7bb636ab88fd78228235b5248b4d05cc589aed610f954af5d7c7a"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -170,7 +150,6 @@ dependencies = [
 name = "wasefire-interpreter"
 version = "0.3.2-git"
 dependencies = [
- "bytemuck",
  "lazy_static",
  "libm",
  "num_enum",

--- a/crates/interpreter/Cargo.toml
+++ b/crates/interpreter/Cargo.toml
@@ -12,7 +12,6 @@ keywords = ["embedded", "framework", "no-std", "wasm"]
 categories = ["embedded", "no-std", "wasm"]
 
 [dependencies]
-bytemuck = { version = "1.16.0", default-features = false, features = ["derive"] }
 libm = { version = "0.2.8", default-features = false, optional = true }
 num_enum = { version = "0.7.2", default-features = false }
 paste = { version = "1.0.15", default-features = false }

--- a/crates/interpreter/src/module.rs
+++ b/crates/interpreter/src/module.rs
@@ -28,7 +28,8 @@ use crate::*;
 pub struct Module<'m> {
     binary: &'m [u8],
     types: Vec<FuncType<'m>>,
-    // TODO(dev/fast-interp): Use a shallow (unstructured) view in the flash.
+    // TODO(dev/fast-interp): Change the type to `SideTableView` which will be parsed by
+    // `new_unchecked()`.
     side_table: &'m [MetadataEntry],
 }
 

--- a/crates/interpreter/src/side_table.rs
+++ b/crates/interpreter/src/side_table.rs
@@ -59,7 +59,7 @@ impl<'m> Metadata<'m> {
     }
 
     pub fn branch_table(&self) -> &[BranchTableEntry] {
-        let entry_size = 6;
+        let entry_size = size_of::<BranchTableEntry>();
         assert_eq!(
             self.0.len() % entry_size,
             0,

--- a/crates/interpreter/src/side_table.rs
+++ b/crates/interpreter/src/side_table.rs
@@ -61,14 +61,14 @@ impl<'m> Metadata<'m> {
     pub fn branch_table(&self) -> &[BranchTableEntry] {
         let entry_size = size_of::<BranchTableEntry>();
         assert_eq!(
-            self.0.len() % entry_size,
+            (self.0.len() - 10) % entry_size,
             0,
-            "Metadata length must be divisible by {} bytes",
+            "Metadata length for branch table must be divisible by {} bytes",
             entry_size
         );
         unsafe {
             core::slice::from_raw_parts(
-                self.0.as_ptr() as *const BranchTableEntry,
+                self.0[10 ..].as_ptr() as *const BranchTableEntry,
                 self.0.len() / entry_size,
             )
         }

--- a/crates/interpreter/src/valid.rs
+++ b/crates/interpreter/src/valid.rs
@@ -146,7 +146,7 @@ impl ValidMode for Verify {
         check(parser.parse_section_id()? == SectionId::Custom)?;
         let mut section = parser.split_section()?;
         check(section.parse_name()? == "wasefire-sidetable")?;
-        SideTableView::new(parser)
+        SideTableView::new(parser.save())
     }
 
     fn next_branch_table<'a, 'm>(

--- a/crates/runner-host/Cargo.lock
+++ b/crates/runner-host/Cargo.lock
@@ -2396,7 +2396,6 @@ dependencies = [
 name = "wasefire-interpreter"
 version = "0.3.2-git"
 dependencies = [
- "bytemuck",
  "num_enum",
  "paste",
  "portable-atomic",

--- a/crates/runner-nordic/Cargo.lock
+++ b/crates/runner-nordic/Cargo.lock
@@ -1193,7 +1193,6 @@ dependencies = [
 name = "wasefire-interpreter"
 version = "0.3.2-git"
 dependencies = [
- "bytemuck",
  "num_enum",
  "paste",
  "portable-atomic",

--- a/crates/scheduler/Cargo.lock
+++ b/crates/scheduler/Cargo.lock
@@ -779,7 +779,6 @@ dependencies = [
 name = "wasefire-interpreter"
 version = "0.3.2-git"
 dependencies = [
- "bytemuck",
  "num_enum",
  "paste",
  "portable-atomic",

--- a/crates/wasm-bench/Cargo.lock
+++ b/crates/wasm-bench/Cargo.lock
@@ -143,20 +143,6 @@ name = "bytemuck"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78834c15cb5d5efe3452d58b1e8ba890dd62d21907f867f383358198e56ebca5"
-dependencies = [
- "bytemuck_derive",
-]
-
-[[package]]
-name = "bytemuck_derive"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fa76293b4f7bb636ab88fd78228235b5248b4d05cc589aed610f954af5d7c7a"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.96",
-]
 
 [[package]]
 name = "byteorder"
@@ -1360,7 +1346,6 @@ dependencies = [
 name = "wasefire-interpreter"
 version = "0.3.2-git"
 dependencies = [
- "bytemuck",
  "libm",
  "num_enum",
  "paste",


### PR DESCRIPTION
#46