### PR TITLE
Enable interpreter/debug in runner-host/debug

### DIFF
--- a/crates/runner-host/Cargo.toml
+++ b/crates/runner-host/Cargo.toml
@@ -57,6 +57,7 @@ features = [
 # Exactly one is enabled by xtask.
 debug = [
   "dep:env_logger",
+  "wasefire-interpreter/debug",
   "wasefire-logger/log",
   "wasefire-protocol-tokio/log",
   "wasefire-protocol-usb/log",


### PR DESCRIPTION
This is useful until #42 is fixed, by using `RUST_BACKTRACE=1`.