### PR TITLE
Use 1915:521f for Nordic USB VID:PID

### DIFF
--- a/crates/runner-nordic/src/main.rs
+++ b/crates/runner-nordic/src/main.rs
@@ -327,7 +327,7 @@ fn usbd() {
 
 const fn vid_pid() -> UsbVidPid {
     let vidpid = match option_env!("RUNNER_VIDPID") {
-        None => b"16c0:27dd",
+        None => b"1915:521f",
         Some(x) => x.as_bytes(),
     };
     assert!(vidpid.len() == 9);

--- a/examples/rust/opensk/src/lib.rs
+++ b/examples/rust/opensk/src/lib.rs
@@ -13,6 +13,9 @@
 // limitations under the License.
 
 //! Example applet running OpenSK.
+//!
+//! The Nordic runner needs the usb-ctap, software-crypto-aes256-cbc, software-crypto-p256, and
+//! software-crypto-hmac-sha256 features.
 
 #![no_std]
 wasefire::applet!();


### PR DESCRIPTION
The serial still works with it and it was the reason to use 16c0:27dd.