### PR TITLE
Use Pulley for Wasmtime in wasm-bench

### DIFF
--- a/crates/wasm-bench/Cargo.lock
+++ b/crates/wasm-bench/Cargo.lock
@@ -3,15 +3,12 @@
 version = 4
 
 [[package]]
-name = "ahash"
-version = "0.8.11"
+name = "addr2line"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
 dependencies = [
- "cfg-if",
- "once_cell",
- "version_check",
- "zerocopy",
+ "gimli",
 ]
 
 [[package]]
@@ -46,15 +43,26 @@ checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
 
 [[package]]
 name = "arbitrary"
-version = "1.3.2"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d5a26814d8dcb93b0e5a0ff3c6d80a8843bafb21b39e8e18a6f05471870e110"
+checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
 
 [[package]]
 name = "arrayvec"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
+
+[[package]]
+name = "async-trait"
+version = "0.1.86"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "644dd749086bf3771a2fbc5f256fdb982d53f011c7d5d560304eafeecebce79d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
 
 [[package]]
 name = "atty"
@@ -87,6 +95,12 @@ name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "bindgen"
@@ -130,6 +144,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -161,6 +184,11 @@ name = "cc"
 version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74b6a57f98764a267ff415d50a25e6e166f3831a5071af4995296ea97d210490"
+dependencies = [
+ "jobserver",
+ "libc",
+ "once_cell",
+]
 
 [[package]]
 name = "cexpr"
@@ -199,7 +227,7 @@ dependencies = [
  "bitflags 1.3.2",
  "strsim",
  "textwrap",
- "unicode-width",
+ "unicode-width 0.1.13",
  "vec_map",
 ]
 
@@ -249,19 +277,48 @@ dependencies = [
 ]
 
 [[package]]
-name = "cranelift-bforest"
-version = "0.115.0"
+name = "cpp_demangle"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac89549be94911dd0e839b4a7db99e9ed29c17517e1c026f61066884c168aa3c"
+checksum = "96e58d342ad113c2b878f16d5d034c03be492ae460cdbc02b7f0f2284d310c7d"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cranelift-assembler-x64"
+version = "0.118.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git#9afc64b4728d6e2067aa52331ff7b1d6f5275b5e"
+dependencies = [
+ "cranelift-assembler-x64-meta",
+]
+
+[[package]]
+name = "cranelift-assembler-x64-meta"
+version = "0.118.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git#9afc64b4728d6e2067aa52331ff7b1d6f5275b5e"
+
+[[package]]
+name = "cranelift-bforest"
+version = "0.118.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git#9afc64b4728d6e2067aa52331ff7b1d6f5275b5e"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.115.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9bd49369f76c77e34e641af85d0956869237832c118964d08bf5f51f210875a"
+version = "0.118.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git#9afc64b4728d6e2067aa52331ff7b1d6f5275b5e"
 dependencies = [
  "serde",
  "serde_derive",
@@ -269,11 +326,11 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.115.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd96ce9cf8efebd7f5ab8ced5a0ce44250280bbae9f593d74a6d7effc3582a35"
+version = "0.118.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git#9afc64b4728d6e2067aa52331ff7b1d6f5275b5e"
 dependencies = [
  "bumpalo",
+ "cranelift-assembler-x64",
  "cranelift-bforest",
  "cranelift-bitset",
  "cranelift-codegen-meta",
@@ -282,10 +339,11 @@ dependencies = [
  "cranelift-entity",
  "cranelift-isle",
  "gimli",
- "hashbrown 0.14.5",
+ "hashbrown",
  "log",
+ "pulley-interpreter",
  "regalloc2",
- "rustc-hash 2.0.0",
+ "rustc-hash 2.1.1",
  "serde",
  "smallvec",
  "target-lexicon",
@@ -293,33 +351,31 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.115.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a68e358827afe4bfb6239fcbf6fbd5ac56206ece8a99c8f5f9bbd518773281a"
+version = "0.118.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git#9afc64b4728d6e2067aa52331ff7b1d6f5275b5e"
 dependencies = [
+ "cranelift-assembler-x64",
  "cranelift-codegen-shared",
+ "pulley-interpreter",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.115.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e184c9767afbe73d50c55ec29abcf4c32f9baf0d9d22b86d58c4d55e06dee181"
+version = "0.118.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git#9afc64b4728d6e2067aa52331ff7b1d6f5275b5e"
 
 [[package]]
 name = "cranelift-control"
-version = "0.115.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cc7664f2a66f053e33f149e952bb5971d138e3af637f5097727ed6dc0ed95dd"
+version = "0.118.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git#9afc64b4728d6e2067aa52331ff7b1d6f5275b5e"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.115.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "118597e3a9cf86c3556fa579a7a23b955fa18231651a52a77a2475d305a9cf84"
+version = "0.118.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git#9afc64b4728d6e2067aa52331ff7b1d6f5275b5e"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -328,9 +384,8 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.115.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7638ea1efb069a0aa18d8ee67401b6b0d19f6bfe5de5e9ede348bfc80bb0d8c7"
+version = "0.118.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git#9afc64b4728d6e2067aa52331ff7b1d6f5275b5e"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -340,15 +395,13 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.115.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15c53e1152a0b01c4ed2b1e0535602b8e86458777dd9d18b28732b16325c7dc0"
+version = "0.118.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git#9afc64b4728d6e2067aa52331ff7b1d6f5275b5e"
 
 [[package]]
 name = "cranelift-native"
-version = "0.115.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b7d8f895444fa52dd7bdd0bed11bf007a7fb43af65a6deac8fcc4094c6372f7"
+version = "0.118.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git#9afc64b4728d6e2067aa52331ff7b1d6f5275b5e"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -371,16 +424,91 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "crunchy"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "cty"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b365fabc795046672053e29c954733ec3b05e4be654ab130fe8f1f94d7051f35"
+
+[[package]]
+name = "debugid"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
+dependencies = [
+ "uuid",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
+name = "directories-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339ee130d97a610ea5a5872d2bbb130fdf68884ff09d3028b81bec8a1ac23bbc"
+dependencies = [
+ "cfg-if",
+ "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
 
 [[package]]
 name = "downcast-rs"
@@ -450,6 +578,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a21dea9854beb860f3062d10228ce9b976da520a73474aed3171ec276bc0c032"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "env_logger"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -470,12 +607,12 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -501,6 +638,49 @@ name = "foldhash"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
+
+[[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "fxprof-processed-profile"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27d12c0aed7f1e24276a241aadc4cb8ea9f83000f34bc062b7cc2d51e3b0fabd"
+dependencies = [
+ "bitflags 2.6.0",
+ "debugid",
+ "fxhash",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
 
 [[package]]
 name = "gimli"
@@ -536,15 +716,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
 dependencies = [
  "byteorder",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash",
 ]
 
 [[package]]
@@ -605,12 +776,12 @@ checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
 
 [[package]]
 name = "indexmap"
-version = "2.2.6"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
+checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.5",
+ "hashbrown",
  "serde",
 ]
 
@@ -625,9 +796,38 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.11"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+
+[[package]]
+name = "ittapi"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b996fe614c41395cdaedf3cf408a9534851090959d90d54a535f675550b64b1"
+dependencies = [
+ "anyhow",
+ "ittapi-sys",
+ "log",
+]
+
+[[package]]
+name = "ittapi-sys"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5385394064fa2c886205dba02598013ce83d3e92d33dbdc0c52fe0e7bf4fc"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "lazy_static"
@@ -642,16 +842,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
-name = "leb128"
-version = "0.2.5"
+name = "leb128fmt"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.155"
+version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
 name = "libloading"
@@ -668,6 +868,16 @@ name = "libm"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
+
+[[package]]
+name = "libredox"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+dependencies = [
+ "bitflags 2.6.0",
+ "libc",
+]
 
 [[package]]
 name = "linked_list_allocator"
@@ -830,7 +1040,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
  "crc32fast",
- "hashbrown 0.15.2",
+ "hashbrown",
  "indexmap",
  "memchr",
 ]
@@ -863,6 +1073,12 @@ name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
 name = "portable-atomic"
@@ -904,13 +1120,12 @@ dependencies = [
 
 [[package]]
 name = "pulley-interpreter"
-version = "28.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "403a1a95f4c18a45c86c7bff13df00347afd0abcbf2e54af273c837339ffcf77"
+version = "31.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git#9afc64b4728d6e2067aa52331ff7b1d6f5275b5e"
 dependencies = [
  "cranelift-bitset",
  "log",
- "sptr",
+ "wasmtime-math",
 ]
 
 [[package]]
@@ -929,6 +1144,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
+name = "rayon"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom",
+ "libredox",
+ "thiserror",
+]
+
+[[package]]
 name = "regalloc2"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -936,9 +1182,9 @@ checksum = "145c1c267e14f20fb0f88aa76a1c5ffec42d592c1d28b3cd9148ae35916158d3"
 dependencies = [
  "allocator-api2",
  "bumpalo",
- "hashbrown 0.15.2",
+ "hashbrown",
  "log",
- "rustc-hash 2.0.0",
+ "rustc-hash 2.1.1",
  "smallvec",
 ]
 
@@ -1047,6 +1293,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+
+[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1054,9 +1306,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustc_version"
@@ -1069,22 +1321,22 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.34"
+version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
  "bitflags 2.6.0",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "ryu"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
 
 [[package]]
 name = "semver"
@@ -1097,9 +1349,12 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.23"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
+checksum = "f79dfe2d285b0488816f30e700a7438c5a73d816b5b7d3ac72fbc48b0d185e03"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "semver-parser"
@@ -1129,13 +1384,34 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.118"
+version = "1.0.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d947f6b3163d8857ea16c4fa0dd4840d52f3041039a85decd46867eb1abef2e4"
+checksum = "d434192e7da787e94a6ea7e9670b26a036d0ca41e0b7efb2676dd32bae872949"
 dependencies = [
  "itoa",
+ "memchr",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -1189,11 +1465,11 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2c04b93fc15d79b39c63218f15e3fdffaa4c227830686e3b7c5f41244eb3e50"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
- "unicode-width",
+ "unicode-width 0.1.13",
 ]
 
 [[package]]
@@ -1220,9 +1496,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.16"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+checksum = "e502f78cdbb8ba4718f566c418c52bc729126ffd16baee5baa718cf25dd5a69a"
 
 [[package]]
 name = "termcolor"
@@ -1239,23 +1515,68 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
- "unicode-width",
+ "unicode-width 0.1.13",
 ]
 
 [[package]]
 name = "thiserror"
-version = "1.0.61"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.61"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
+name = "toml"
+version = "0.8.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
+name = "trait-variant"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70977707304198400eb4835a78f6a9f928bf41bba420deb8fdb175cd965d77a7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1287,10 +1608,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.4"
+name = "unicode-width"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "usb-device"
@@ -1301,6 +1628,12 @@ dependencies = [
  "heapless",
  "portable-atomic",
 ]
+
+[[package]]
+name = "uuid"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c1f41ffb7cf259f1ecc2876861a17e7142e63ead296f671f81f6ae85903e0d6"
 
 [[package]]
 name = "vcell"
@@ -1316,9 +1649,9 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "void"
@@ -1354,6 +1687,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
 name = "wasm-bench"
 version = "0.1.0"
 dependencies = [
@@ -1374,12 +1713,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.221.2"
+version = "0.225.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17a3bd88f2155da63a1f2fcb8a56377a24f0b6dfed12733bb5f544e86f690c5"
+checksum = "6f7eac0445cac73bcf09e6a97f83248d64356dccf9f2b100199769b6b42464e5"
 dependencies = [
- "leb128",
- "wasmparser",
+ "leb128fmt",
+ "wasmparser 0.225.0",
 ]
 
 [[package]]
@@ -1415,7 +1754,7 @@ dependencies = [
  "wasmi_collections",
  "wasmi_core",
  "wasmi_ir",
- "wasmparser",
+ "wasmparser 0.221.2",
 ]
 
 [[package]]
@@ -1450,38 +1789,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9845c470a2e10b61dd42c385839cdd6496363ed63b5c9e420b5488b77bd22083"
 dependencies = [
  "bitflags 2.6.0",
- "hashbrown 0.15.2",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.225.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36e5456165f81e64cb9908a0fe9b9d852c2c74582aa3fe2be3c2da57f937d3ae"
+dependencies = [
+ "bitflags 2.6.0",
+ "hashbrown",
  "indexmap",
- "semver 1.0.23",
+ "semver 1.0.25",
  "serde",
 ]
 
 [[package]]
 name = "wasmprinter"
-version = "0.221.2"
+version = "0.225.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a80742ff1b9e6d8c231ac7c7247782c6fc5bce503af760bca071811e5fc9ee56"
+checksum = "8c32de8f41929f40bb595d1309549c58bbe1b43b05627fe42517e23a50230e0a"
 dependencies = [
  "anyhow",
  "termcolor",
- "wasmparser",
+ "wasmparser 0.225.0",
 ]
 
 [[package]]
 name = "wasmtime"
-version = "28.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f639ecae347b9a2227e453a7b7671e84370a0b61f47a15e0390fe9b7725e47b3"
+version = "31.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git#9afc64b4728d6e2067aa52331ff7b1d6f5275b5e"
 dependencies = [
+ "addr2line",
  "anyhow",
+ "async-trait",
  "bitflags 2.6.0",
  "bumpalo",
  "cc",
  "cfg-if",
- "hashbrown 0.14.5",
+ "encoding_rs",
+ "fxprof-processed-profile",
+ "gimli",
+ "hashbrown",
  "indexmap",
+ "ittapi",
  "libc",
- "libm",
  "log",
  "mach2",
  "memfd",
@@ -1491,38 +1843,66 @@ dependencies = [
  "postcard",
  "psm",
  "pulley-interpreter",
+ "rayon",
  "rustix",
+ "semver 1.0.25",
  "serde",
  "serde_derive",
+ "serde_json",
  "smallvec",
  "sptr",
  "target-lexicon",
- "wasmparser",
+ "trait-variant",
+ "wasm-encoder",
+ "wasmparser 0.225.0",
  "wasmtime-asm-macros",
+ "wasmtime-cache",
  "wasmtime-component-macro",
+ "wasmtime-component-util",
  "wasmtime-cranelift",
  "wasmtime-environ",
  "wasmtime-fiber",
+ "wasmtime-jit-debug",
  "wasmtime-jit-icache-coherence",
+ "wasmtime-math",
  "wasmtime-slab",
  "wasmtime-versioned-export-macros",
+ "wasmtime-winch",
+ "wat",
  "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "wasmtime-asm-macros"
-version = "28.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "882a18800471cfc063c8b3ccf75723784acc3fd534009ac09421f2fac2fcdcec"
+version = "31.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git#9afc64b4728d6e2067aa52331ff7b1d6f5275b5e"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
+name = "wasmtime-cache"
+version = "31.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git#9afc64b4728d6e2067aa52331ff7b1d6f5275b5e"
+dependencies = [
+ "anyhow",
+ "base64 0.21.7",
+ "directories-next",
+ "log",
+ "postcard",
+ "rustix",
+ "serde",
+ "serde_derive",
+ "sha2",
+ "toml",
+ "windows-sys 0.59.0",
+ "zstd",
+]
+
+[[package]]
 name = "wasmtime-component-macro"
-version = "28.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb5c0a77c9e1927c3d471f53cc13767c3d3438e5d5ffd394e3eb31c86445fd60"
+version = "31.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git#9afc64b4728d6e2067aa52331ff7b1d6f5275b5e"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -1535,15 +1915,13 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-util"
-version = "28.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43702ca98bf5162eca0573db691ed9ecd36d716f8c6688410fe26ec16b6f9bcb"
+version = "31.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git#9afc64b4728d6e2067aa52331ff7b1d6f5275b5e"
 
 [[package]]
 name = "wasmtime-cranelift"
-version = "28.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20070aa5b75080a8932ec328419faf841df2bc6ceb16b55b0df2b952098392a2"
+version = "31.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git#9afc64b4728d6e2067aa52331ff7b1d6f5275b5e"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -1556,21 +1934,22 @@ dependencies = [
  "itertools",
  "log",
  "object",
+ "pulley-interpreter",
  "smallvec",
  "target-lexicon",
  "thiserror",
- "wasmparser",
+ "wasmparser 0.225.0",
  "wasmtime-environ",
  "wasmtime-versioned-export-macros",
 ]
 
 [[package]]
 name = "wasmtime-environ"
-version = "28.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2604ddb24879d4dc1dedcb7081d7a8e017259bce916fdae097a97db52cbaab80"
+version = "31.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git#9afc64b4728d6e2067aa52331ff7b1d6f5275b5e"
 dependencies = [
  "anyhow",
+ "cpp_demangle",
  "cranelift-bitset",
  "cranelift-entity",
  "gimli",
@@ -1578,20 +1957,22 @@ dependencies = [
  "log",
  "object",
  "postcard",
+ "rustc-demangle",
+ "semver 1.0.25",
  "serde",
  "serde_derive",
  "smallvec",
  "target-lexicon",
  "wasm-encoder",
- "wasmparser",
+ "wasmparser 0.225.0",
  "wasmprinter",
+ "wasmtime-component-util",
 ]
 
 [[package]]
 name = "wasmtime-fiber"
-version = "28.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98593412d2b167ebe2b59d4a17a184978a72f976b53b3a0ec05629451079ac1d"
+version = "31.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git#9afc64b4728d6e2067aa52331ff7b1d6f5275b5e"
 dependencies = [
  "anyhow",
  "cc",
@@ -1603,10 +1984,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasmtime-jit-debug"
+version = "31.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git#9afc64b4728d6e2067aa52331ff7b1d6f5275b5e"
+dependencies = [
+ "cc",
+ "object",
+ "rustix",
+ "wasmtime-versioned-export-macros",
+]
+
+[[package]]
 name = "wasmtime-jit-icache-coherence"
-version = "28.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d40d7722b9e1fbeae135715710a8a2570b1e6cf72b74dd653962d89831c6c70d"
+version = "31.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git#9afc64b4728d6e2067aa52331ff7b1d6f5275b5e"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -1615,16 +2006,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasmtime-math"
+version = "31.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git#9afc64b4728d6e2067aa52331ff7b1d6f5275b5e"
+dependencies = [
+ "libm",
+]
+
+[[package]]
 name = "wasmtime-slab"
-version = "28.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8579c335220b4ece9aa490a0e8b46de78cd342b195ab21ff981d095e14b52383"
+version = "31.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git#9afc64b4728d6e2067aa52331ff7b1d6f5275b5e"
 
 [[package]]
 name = "wasmtime-versioned-export-macros"
-version = "28.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7de0a56fb0a69b185968f2d7a9ba54750920a806470dff7ad8de91ac06d277e"
+version = "31.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git#9afc64b4728d6e2067aa52331ff7b1d6f5275b5e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1632,15 +2029,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasmtime-winch"
+version = "31.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git#9afc64b4728d6e2067aa52331ff7b1d6f5275b5e"
+dependencies = [
+ "anyhow",
+ "cranelift-codegen",
+ "gimli",
+ "object",
+ "target-lexicon",
+ "wasmparser 0.225.0",
+ "wasmtime-cranelift",
+ "wasmtime-environ",
+ "winch-codegen",
+]
+
+[[package]]
 name = "wasmtime-wit-bindgen"
-version = "28.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "969f83022dac3435d6469edb582ceed04cfe32aa44dc3ef16e5cb55574633df8"
+version = "31.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git#9afc64b4728d6e2067aa52331ff7b1d6f5275b5e"
 dependencies = [
  "anyhow",
  "heck",
  "indexmap",
  "wit-parser",
+]
+
+[[package]]
+name = "wast"
+version = "225.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61496027ff707f9fa9e0b22c34ec163eb7adb1070df565e32a9180a76e4300b"
+dependencies = [
+ "bumpalo",
+ "leb128fmt",
+ "memchr",
+ "unicode-width 0.2.0",
+ "wasm-encoder",
+]
+
+[[package]]
+name = "wat"
+version = "1.225.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89e72a33942234fd0794bcdac30e43b448de3187512414267678e511c6755f11"
+dependencies = [
+ "wast",
 ]
 
 [[package]]
@@ -1685,6 +2119,23 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "winch-codegen"
+version = "31.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git#9afc64b4728d6e2067aa52331ff7b1d6f5275b5e"
+dependencies = [
+ "anyhow",
+ "cranelift-codegen",
+ "gimli",
+ "regalloc2",
+ "smallvec",
+ "target-lexicon",
+ "thiserror",
+ "wasmparser 0.225.0",
+ "wasmtime-cranelift",
+ "wasmtime-environ",
+]
 
 [[package]]
 name = "windows-sys"
@@ -1769,39 +2220,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "wit-parser"
-version = "0.221.2"
+name = "winnow"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbe1538eea6ea5ddbe5defd0dc82539ad7ba751e1631e9185d24a931f0a5adc8"
+checksum = "59690dea168f2198d1a3b0cac23b8063efcd11012f10ae4698f284808c8ef603"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.225.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebefaa234e47224f10ce60480c5bfdece7497d0f3b87a12b41ff39e5c8377a78"
 dependencies = [
  "anyhow",
  "id-arena",
  "indexmap",
  "log",
- "semver 1.0.23",
+ "semver 1.0.25",
  "serde",
  "serde_derive",
  "serde_json",
  "unicode-xid",
- "wasmparser",
+ "wasmparser 0.225.0",
 ]
 
 [[package]]
-name = "zerocopy"
-version = "0.7.35"
+name = "zstd"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+checksum = "fcf2b778a664581e31e389454a7072dab1647606d44f7feea22cd5abb9c9f3f9"
 dependencies = [
- "zerocopy-derive",
+ "zstd-safe",
 ]
 
 [[package]]
-name = "zerocopy-derive"
-version = "0.7.35"
+name = "zstd-safe"
+version = "7.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+checksum = "54a3ab4db68cea366acc5c897c7b4d4d1b8994a9cd6e6f841f8964566a419059"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.96",
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.13+zstd.1.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38ff0f21cfee8f97d94cef41359e0c89aa6113028ab0291aa8ca0038995a95aa"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]

--- a/crates/wasm-bench/Cargo.toml
+++ b/crates/wasm-bench/Cargo.toml
@@ -41,21 +41,21 @@ git = "https://github.com/bytecodealliance/wasmtime.git"
 features = ["pulley"]
 
 [features]
-_embedded-target = ["dep:embedded-alloc", "wasmtime?/pulley"]
+_target-embedded = ["dep:embedded-alloc", "wasmtime?/pulley"]
 runtime-base = ["dep:wasefire-interpreter"]
 runtime-wasm3 = ["dep:wasm3"]
 runtime-wasmi = ["dep:wasmi"]
 runtime-wasmtime = ["dep:wasmtime"]
 target-linux = ["wasmtime?/cranelift"]
 target-nordic = [
-  "_embedded-target",
+  "_target-embedded",
   "dep:cortex-m",
   "dep:cortex-m-rt",
   "dep:nrf52840-hal",
   "dep:panic-rtt-target",
   "dep:rtt-target",
 ]
-target-riscv = ["_embedded-target", "dep:portable-atomic", "dep:riscv", "dep:riscv-rt"]
+target-riscv = ["_target-embedded", "dep:portable-atomic", "dep:riscv", "dep:riscv-rt"]
 
 [profile.release]
 codegen-units = 1

--- a/crates/wasm-bench/Cargo.toml
+++ b/crates/wasm-bench/Cargo.toml
@@ -31,26 +31,31 @@ features = ["build-bindgen", "use-32bit-slots"]
 optional = true
 
 [dependencies.wasmtime]
-version = "28.0.0"
+git = "https://github.com/bytecodealliance/wasmtime.git"
 default-features = false
-features = ["cranelift", "runtime"]
+features = ["runtime"]
 optional = true
 
+[build-dependencies.wasmtime]
+git = "https://github.com/bytecodealliance/wasmtime.git"
+features = ["pulley"]
+
 [features]
+_embedded-target = ["dep:embedded-alloc", "wasmtime?/pulley"]
 runtime-base = ["dep:wasefire-interpreter"]
 runtime-wasm3 = ["dep:wasm3"]
 runtime-wasmi = ["dep:wasmi"]
 runtime-wasmtime = ["dep:wasmtime"]
-target-linux = []
+target-linux = ["wasmtime?/cranelift"]
 target-nordic = [
+  "_embedded-target",
   "dep:cortex-m",
   "dep:cortex-m-rt",
-  "dep:embedded-alloc",
   "dep:nrf52840-hal",
   "dep:panic-rtt-target",
   "dep:rtt-target",
 ]
-target-riscv = ["dep:embedded-alloc", "dep:portable-atomic", "dep:riscv", "dep:riscv-rt"]
+target-riscv = ["_embedded-target", "dep:portable-atomic", "dep:riscv", "dep:riscv-rt"]
 
 [profile.release]
 codegen-units = 1

--- a/crates/wasm-bench/build.rs
+++ b/crates/wasm-bench/build.rs
@@ -17,16 +17,60 @@ use std::io::Write;
 use std::path::PathBuf;
 
 fn main() {
-    let memory = if std::env::var_os("CARGO_FEATURE_TARGET_NORDIC").is_some() {
-        Some(include_bytes!("memory-nordic.x").as_slice())
+    let out = PathBuf::from(std::env::var_os("OUT_DIR").unwrap());
+    let target = if std::env::var_os("CARGO_FEATURE_TARGET_LINUX").is_some() {
+        Target::Linux
+    } else if std::env::var_os("CARGO_FEATURE_TARGET_NORDIC").is_some() {
+        Target::Nordic
     } else if std::env::var_os("CARGO_FEATURE_TARGET_RISCV").is_some() {
-        Some(include_bytes!("memory-riscv.x").as_slice())
+        Target::Riscv
     } else {
-        None
+        panic!("one of target-{{linux,nordic,riscv}} must be enabled")
+    };
+    let runtime = if std::env::var_os("CARGO_FEATURE_RUNTIME_BASE").is_some() {
+        Runtime::Base
+    } else if std::env::var_os("CARGO_FEATURE_RUNTIME_WASM3").is_some() {
+        Runtime::Wasm3
+    } else if std::env::var_os("CARGO_FEATURE_RUNTIME_WASMI").is_some() {
+        Runtime::Wasmi
+    } else if std::env::var_os("CARGO_FEATURE_RUNTIME_WASMTIME").is_some() {
+        Runtime::Wasmtime
+    } else {
+        panic!("one of runtime-{{base,wasm3,wasmi,wasmtime}} must be enabled")
+    };
+    let memory = match target {
+        Target::Linux => None,
+        Target::Nordic => Some(include_bytes!("memory-nordic.x").as_slice()),
+        Target::Riscv => Some(include_bytes!("memory-riscv.x").as_slice()),
     };
     if let Some(memory) = memory {
-        let out = PathBuf::from(std::env::var_os("OUT_DIR").unwrap());
         println!("cargo:rustc-link-search={}", out.display());
         File::create(out.join("memory.x")).unwrap().write_all(memory).unwrap();
     }
+    let module = if runtime == Runtime::Wasmtime && target != Target::Linux {
+        let mut config = wasmtime::Config::new();
+        config.target("pulley32").unwrap();
+        let engine = wasmtime::Engine::new(&config).unwrap();
+        &engine.precompile_module(WASM).unwrap()
+    } else {
+        WASM
+    };
+    std::fs::write(out.join("module.bin"), module).unwrap();
+}
+
+const WASM: &[u8] = include_bytes!("../../third_party/wasm3/wasm-coremark/coremark-minimal.wasm");
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Target {
+    Linux,
+    Nordic,
+    Riscv,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Runtime {
+    Base,
+    Wasm3,
+    Wasmi,
+    Wasmtime,
 }

--- a/crates/wasm-bench/build.rs
+++ b/crates/wasm-bench/build.rs
@@ -47,7 +47,7 @@ fn main() {
         println!("cargo:rustc-link-search={}", out.display());
         File::create(out.join("memory.x")).unwrap().write_all(memory).unwrap();
     }
-    let module = if runtime == Runtime::Wasmtime && target != Target::Linux {
+    let module = if runtime == Runtime::Wasmtime && target.is_embedded() {
         let mut config = wasmtime::Config::new();
         config.target("pulley32").unwrap();
         let engine = wasmtime::Engine::new(&config).unwrap();
@@ -73,4 +73,14 @@ enum Runtime {
     Wasm3,
     Wasmi,
     Wasmtime,
+}
+
+impl Target {
+    fn is_embedded(self) -> bool {
+        match self {
+            Target::Linux => false,
+            Target::Nordic => true,
+            Target::Riscv => true,
+        }
+    }
 }

--- a/crates/wasm-bench/run.sh
+++ b/crates/wasm-bench/run.sh
@@ -33,7 +33,7 @@ esac
 
 # See test.sh for supported (and tested) combinations.
 case $1-$2 in
-  *-base|nordic-wasmi) ;;
+  *-base|linux-*|nordic-wasmi|nordic-wasmtime) ;;
   *) e "Unsupported combination: $1 $2" ;;
 esac
 

--- a/crates/wasm-bench/run.sh
+++ b/crates/wasm-bench/run.sh
@@ -39,5 +39,7 @@ esac
 
 FEATURES=--features=target-$1,runtime-$2
 shift 2
+set -- --release $TARGET $FEATURES "$@"
 
-x cargo run --release $TARGET $FEATURES "$@"
+[ -z "$TARGET" ] || x ../../scripts/wrapper.sh cargo-size "$@"
+x cargo run "$@"

--- a/crates/wasm-bench/src/main.rs
+++ b/crates/wasm-bench/src/main.rs
@@ -13,13 +13,13 @@
 // limitations under the License.
 
 #![no_std]
-#![cfg_attr(any(feature = "target-nordic", feature = "target-riscv"), no_main)]
+#![cfg_attr(not(feature = "target-linux"), no_main)]
 
 extern crate alloc;
 #[cfg(feature = "target-linux")]
 extern crate std;
 
-#[cfg(any(feature = "target-nordic", feature = "target-riscv"))]
+#[cfg(not(feature = "target-linux"))]
 mod allocator;
 #[cfg_attr(feature = "runtime-base", path = "runtime/base.rs")]
 #[cfg_attr(feature = "runtime-wasm3", path = "runtime/wasm3.rs")]
@@ -31,13 +31,12 @@ mod runtime;
 #[cfg_attr(feature = "target-riscv", path = "target/riscv.rs")]
 mod target;
 
-const WASM: &[u8] =
-    include_bytes!("../../../third_party/wasm3/wasm-coremark/coremark-minimal.wasm");
+const MODULE: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/module.bin"));
 
 fn main() {
     println!("Running CoreMark measurement...");
     let start = target::clock_ms();
-    let result = runtime::run(WASM);
+    let result = runtime::run(MODULE);
     let duration = target::clock_ms() - start;
     println!("CoreMark result: {} (in {}s)", result, duration as f32 / 1000.);
 }

--- a/crates/wasm-bench/src/main.rs
+++ b/crates/wasm-bench/src/main.rs
@@ -13,13 +13,13 @@
 // limitations under the License.
 
 #![no_std]
-#![cfg_attr(not(feature = "target-linux"), no_main)]
+#![cfg_attr(feature = "_target-embedded", no_main)]
 
 extern crate alloc;
-#[cfg(feature = "target-linux")]
+#[cfg(not(feature = "_target-embedded"))]
 extern crate std;
 
-#[cfg(not(feature = "target-linux"))]
+#[cfg(feature = "_target-embedded")]
 mod allocator;
 #[cfg_attr(feature = "runtime-base", path = "runtime/base.rs")]
 #[cfg_attr(feature = "runtime-wasm3", path = "runtime/wasm3.rs")]

--- a/crates/wasm-bench/src/runtime/wasmi.rs
+++ b/crates/wasm-bench/src/runtime/wasmi.rs
@@ -17,16 +17,12 @@ use wasmi::*;
 pub(crate) fn run(wasm: &[u8]) -> f32 {
     let engine = Engine::default();
     let module = Module::new(&engine, wasm).unwrap();
-
     let mut store = Store::new(&engine, ());
     let mut linker = Linker::<()>::new(&engine);
-
     let clock_ms =
         Func::wrap(&mut store, move |_: Caller<'_, ()>| -> u64 { crate::target::clock_ms() });
     linker.define("env", "clock_ms", clock_ms).unwrap();
-
     let instance = linker.instantiate(&mut store, &module).unwrap().start(&mut store).unwrap();
-
     let func = instance.get_typed_func::<(), f32>(&store, "run").unwrap();
     func.call(&mut store, ()).unwrap()
 }

--- a/crates/wasm-bench/src/runtime/wasmtime.rs
+++ b/crates/wasm-bench/src/runtime/wasmtime.rs
@@ -16,17 +16,28 @@ use wasmtime::*;
 
 pub(crate) fn run(wasm: &[u8]) -> f32 {
     let engine = Engine::default();
+    #[cfg(not(feature = "target-linux"))]
+    let module = unsafe { Module::deserialize(&engine, wasm) }.unwrap();
+    #[cfg(feature = "target-linux")]
     let module = Module::new(&engine, wasm).unwrap();
-
     let mut store = Store::new(&engine, ());
     let mut linker = Linker::new(&engine);
-
     let clock_ms =
         Func::wrap(&mut store, move |_: Caller<'_, ()>| -> u64 { crate::target::clock_ms() });
     linker.define(&mut store, "env", "clock_ms", clock_ms).unwrap();
-
     let instance = linker.instantiate(&mut store, &module).unwrap();
-
     let func = instance.get_typed_func::<(), f32>(&mut store, "run").unwrap();
     func.call(&mut store, ()).unwrap()
 }
+
+#[unsafe(no_mangle)]
+extern "C" fn wasmtime_tls_get() -> *mut u8 {
+    unsafe { TLS_PTR }
+}
+
+#[unsafe(no_mangle)]
+extern "C" fn wasmtime_tls_set(ptr: *mut u8) {
+    unsafe { TLS_PTR = ptr }
+}
+
+static mut TLS_PTR: *mut u8 = core::ptr::null_mut();

--- a/crates/wasm-bench/test.sh
+++ b/crates/wasm-bench/test.sh
@@ -30,8 +30,7 @@ cargo check --bin=wasm-bench --target=thumbv7em-none-eabi --features=target-nord
 # wasm3/source/wasm3.h:16:10: fatal error: 'stdlib.h' file not found
 # cargo check --bin=wasm-bench --target=thumbv7em-none-eabi --features=target-nordic,runtime-wasm3
 cargo check --bin=wasm-bench --target=thumbv7em-none-eabi --features=target-nordic,runtime-wasmi
-# error in crate arbitrary: can't find crate for `std`
-# cargo check --bin=wasm-bench --target=thumbv7em-none-eabi --features=target-nordic,runtime-wasmtime
+cargo check --bin=wasm-bench --target=thumbv7em-none-eabi --features=target-nordic,runtime-wasmtime
 
 cargo check --bin=wasm-bench --target=riscv32imc-unknown-none-elf \
   --features=target-riscv,runtime-base
@@ -41,6 +40,6 @@ cargo check --bin=wasm-bench --target=riscv32imc-unknown-none-elf \
 # error: no method named `compare_exchange` found for struct `AtomicUsize` in the current scope
 # cargo check --bin=wasm-bench --target=riscv32imc-unknown-none-elf \
 #   --features=target-riscv,runtime-wasmi
-# error in crate once_cell: can't find crate for `std`
+# error: unresolved import `alloc::sync`
 # cargo check --bin=wasm-bench --target=riscv32imc-unknown-none-elf \
 #   --features=target-riscv,runtime-wasmtime

--- a/taplo.toml
+++ b/taplo.toml
@@ -8,7 +8,7 @@ reorder_keys = true
 
 [[rule]]
 formatting = { reorder_keys = false }
-keys = ["dependencies.*", "package"]
+keys = ["build-dependencies.*", "dependencies.*", "dev-dependencies.*", "package"]
 
 [[rule]]
 formatting = { reorder_keys = true }


### PR DESCRIPTION
| Target | Runtime | Perf | Flash | RAM |
| --- | --- | --- | --- | --- |
| Linux | Base | 33.1 | | |
| Linux | Wasm3 | 2531 (76x) | | |
| Linux | Wasmi | 1556 (47x) | | |
| Linux | Wasmtime | 22652 (684x) | | |
| Nordic | Base | 0.0925 | 144920 | 5384 |
| Nordic | Wasmi | 4.6 (50x) | 856552 (5.9x) | 91872 (17x) |
| Nordic | Wasmtime | OOM | 659260 (4.5x) | >264912 (>49x) |

Note that the CoreMark module uses 7771 bytes of Flash, which are included in the numbers given above.