### PR TITLE
Support optimizing for size for wasm-bench

### DIFF
--- a/crates/wasm-bench/.cargo/config.toml
+++ b/crates/wasm-bench/.cargo/config.toml
@@ -1,3 +1,3 @@
 [target.thumbv7em-none-eabi]
-runner = "probe-rs run --chip=nRF52840_xxAA"
+runner = "../../scripts/wrapper.sh probe-rs run --chip=nRF52840_xxAA"
 rustflags = ["-Clink-arg=-Tlink.x"]

--- a/crates/wasm-bench/Cargo.toml
+++ b/crates/wasm-bench/Cargo.toml
@@ -62,6 +62,10 @@ codegen-units = 1
 lto = true
 panic = "abort"
 
+[profile.release-size]
+inherits = "release"
+opt-level = "z"
+
 [lints]
 clippy.literal-string-with-formatting-args = "allow"
 clippy.mod-module-files = "warn"


### PR DESCRIPTION
Results for Nordic only:

| Runtime | Opt | Result | Flash | RAM |
| --- | --- | --- | --- | --- |
| Base | Perf | 0.0937 | 144708 - 7771 = 136937 | 5416 |
| Base | Size | 0.0462 | 97536 - 7771 = 89765 | 5432 |
| Wasmi | Perf | 4.55 (49x) | 855240 - 7771 = 847469 (6.2x) | 91872 (17x) |
| Wasmi | Size | 2.15 (47x) | 466628 - 7771 = 458857 (5.1x) | 91872 (17x) |
| Wasmtime | Perf | OOM | 658292 - 264912 = 393380 (2.9x) | >264912 |
| Wasmtime | Size | OOM | 529936 - 264912 = 265024 (3x) | >264912 |