### PR TITLE
Remove Default implementation for Module in interpreter

### DIFF
--- a/crates/interpreter/CHANGELOG.md
+++ b/crates/interpreter/CHANGELOG.md
@@ -98,4 +98,4 @@
 
 ## 0.1.0
 
-<!-- Increment to skip CHANGELOG.md test: 3 -->
+<!-- Increment to skip CHANGELOG.md test: 4 -->

--- a/crates/interpreter/CHANGELOG.md
+++ b/crates/interpreter/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## 0.3.2-git
+## 0.4.0-git
+
+### Major
+
+- Remove `Default` implementation for `Module`
 
 ### Minor
 

--- a/crates/interpreter/Cargo.lock
+++ b/crates/interpreter/Cargo.lock
@@ -203,7 +203,7 @@ dependencies = [
 
 [[package]]
 name = "wasefire-interpreter"
-version = "0.3.2-git"
+version = "0.4.0-git"
 dependencies = [
  "lazy_static",
  "libm",

--- a/crates/interpreter/Cargo.toml
+++ b/crates/interpreter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasefire-interpreter"
-version = "0.3.2-git"
+version = "0.4.0-git"
 authors = ["Julien Cretin <cretin@google.com>"]
 license = "Apache-2.0"
 publish = true

--- a/crates/interpreter/src/exec.rs
+++ b/crates/interpreter/src/exec.rs
@@ -118,8 +118,7 @@ impl<'m> Store<'m> {
         &mut self, module: Module<'m>, memory: &'m mut [u8],
     ) -> Result<InstId, Error> {
         let inst_id = self.insts.len();
-        self.insts.push(Instance::default());
-        self.last_inst().module = module;
+        self.insts.push(Instance::new(module));
         for import in self.last_inst().module.imports() {
             let type_ = import.type_(&self.last_inst().module);
             let id = self.resolve(&import, type_)?;
@@ -439,7 +438,7 @@ impl Val {
     }
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 struct Instance<'m> {
     // TODO: Make sure names are unique. Empty name means exports are not linked.
     name: &'m str,
@@ -615,6 +614,21 @@ impl<'m> Store<'m> {
         }
         let (ptr, ext_type_) = found.ok_or_else(not_found)?;
         if ext_type_.matches(&imp_type_) { Ok(ptr) } else { Err(not_found()) }
+    }
+}
+
+impl<'m> Instance<'m> {
+    fn new(module: Module<'m>) -> Self {
+        Instance {
+            name: "",
+            module,
+            funcs: Component::default(),
+            tables: Component::default(),
+            mems: Component::default(),
+            globals: Component::default(),
+            elems: Vec::new(),
+            datas: Vec::new(),
+        }
     }
 }
 

--- a/crates/interpreter/src/module.rs
+++ b/crates/interpreter/src/module.rs
@@ -30,12 +30,6 @@ pub struct Module<'m> {
     cache: Cache<CacheKey, CacheValue>,
 }
 
-impl Default for Module<'_> {
-    fn default() -> Self {
-        Self { binary: &[], types: Vec::new(), cache: Cache::unbounded() }
-    }
-}
-
 #[derive(Debug, PartialEq, Eq, Hash)]
 enum CacheKey {
     Skip { ptr: *const u8, depth: LabelIdx },
@@ -76,7 +70,8 @@ impl<'m> Module<'m> {
     /// The module must be valid.
     pub unsafe fn new_unchecked(binary: &'m [u8]) -> Self {
         // Only keep the sections (i.e. skip the header).
-        let mut module = Module { binary: &binary[8 ..], ..Self::default() };
+        let mut module =
+            Module { binary: &binary[8 ..], types: Vec::new(), cache: Cache::unbounded() };
         if let Some(mut parser) = module.section(SectionId::Type) {
             for _ in 0 .. parser.parse_vec().into_ok() {
                 module.types.push(parser.parse_functype().into_ok());

--- a/crates/interpreter/src/module.rs
+++ b/crates/interpreter/src/module.rs
@@ -69,9 +69,12 @@ impl<'m> Module<'m> {
     ///
     /// The module must be valid.
     pub unsafe fn new_unchecked(binary: &'m [u8]) -> Self {
-        // Only keep the sections (i.e. skip the header).
-        let mut module =
-            Module { binary: &binary[8 ..], types: Vec::new(), cache: Cache::unbounded() };
+        let mut module = Module {
+            // Only keep the sections (i.e. skip the header).
+            binary: &binary[8 ..],
+            types: Vec::new(),
+            cache: Cache::unbounded(),
+        };
         if let Some(mut parser) = module.section(SectionId::Type) {
             for _ in 0 .. parser.parse_vec().into_ok() {
                 module.types.push(parser.parse_functype().into_ok());

--- a/crates/runner-host/Cargo.lock
+++ b/crates/runner-host/Cargo.lock
@@ -2487,7 +2487,7 @@ dependencies = [
 
 [[package]]
 name = "wasefire-interpreter"
-version = "0.3.2-git"
+version = "0.4.0-git"
 dependencies = [
  "num_enum",
  "paste",

--- a/crates/runner-nordic/Cargo.lock
+++ b/crates/runner-nordic/Cargo.lock
@@ -1320,7 +1320,7 @@ dependencies = [
 
 [[package]]
 name = "wasefire-interpreter"
-version = "0.3.2-git"
+version = "0.4.0-git"
 dependencies = [
  "num_enum",
  "paste",

--- a/crates/scheduler/CHANGELOG.md
+++ b/crates/scheduler/CHANGELOG.md
@@ -191,4 +191,4 @@
 
 ## 0.1.0
 
-<!-- Increment to skip CHANGELOG.md test: 5 -->
+<!-- Increment to skip CHANGELOG.md test: 6 -->

--- a/crates/scheduler/Cargo.lock
+++ b/crates/scheduler/Cargo.lock
@@ -897,7 +897,7 @@ dependencies = [
 
 [[package]]
 name = "wasefire-interpreter"
-version = "0.3.2-git"
+version = "0.4.0-git"
 dependencies = [
  "num_enum",
  "paste",

--- a/crates/scheduler/Cargo.toml
+++ b/crates/scheduler/Cargo.toml
@@ -32,7 +32,7 @@ wasefire-store = { version = "0.3.1-git", path = "../store", optional = true }
 wasefire-sync = { version = "0.1.2-git", path = "../sync", optional = true }
 
 [dependencies.wasefire-interpreter]
-version = "0.3.2-git"
+version = "0.4.0-git"
 path = "../interpreter"
 features = ["toctou"]
 optional = true

--- a/crates/wasm-bench/Cargo.lock
+++ b/crates/wasm-bench/Cargo.lock
@@ -1677,7 +1677,7 @@ dependencies = [
 
 [[package]]
 name = "wasefire-interpreter"
-version = "0.3.2-git"
+version = "0.4.0-git"
 dependencies = [
  "libm",
  "num_enum",


### PR DESCRIPTION
This was only present for convenience and not meant to be public.