### PR TITLE
Disable unused-crate-dependencies when using -Zbuild-std

### DIFF
--- a/crates/cli-tools/CHANGELOG.md
+++ b/crates/cli-tools/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Minor
 
+- Add `--allow=unused-crate-dependencies` to `RUSTFLAGS` when building prod applets to work around a
+  `-Zbuild-std` [issue](https://github.com/rust-lang/rust/issues/122105) with that lint
 - Use Rust edition 2024
 - Add `fs::targz_{list,extract}()` to manipulate tarballs
 - Add `fs::download()` for download files

--- a/crates/cli-tools/src/action.rs
+++ b/crates/cli-tools/src/action.rs
@@ -572,6 +572,8 @@ impl RustAppletBuild {
         cargo.args(&self.cargo);
         if self.prod {
             cargo.arg("-Zbuild-std=core,alloc");
+            // TODO(https://github.com/rust-lang/rust/issues/122105): Remove when fixed.
+            rustflags.push("--allow=unused-crate-dependencies".to_string());
             let mut features = "-Zbuild-std-features=panic_immediate_abort".to_string();
             if self.opt_level.is_some_and(OptLevel::optimize_for_size) {
                 features.push_str(",optimize_for_size");

--- a/crates/error/CHANGELOG.md
+++ b/crates/error/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Patch
 
+- Remove dummy alloc dependency
 - Fix clippy lints
 - Add clippy lint
 

--- a/crates/error/src/lib.rs
+++ b/crates/error/src/lib.rs
@@ -16,8 +16,6 @@
 
 #![no_std]
 
-// TODO(https://github.com/rust-lang/rust/issues/122105): Remove when fixed.
-extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std;
 

--- a/crates/logger/CHANGELOG.md
+++ b/crates/logger/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Patch
 
+- Remove dummy alloc dependency
 - Add clippy lint
 
 ## 0.1.6

--- a/crates/logger/src/lib.rs
+++ b/crates/logger/src/lib.rs
@@ -14,9 +14,6 @@
 
 #![cfg_attr(not(any(test, feature = "log")), no_std)]
 
-// TODO(https://github.com/rust-lang/rust/issues/122105): Remove when fixed.
-extern crate alloc;
-
 #[cfg(not(feature = "defmt"))]
 mod no_defmt {
     use core::fmt::{Debug, Display, Formatter, Result};

--- a/crates/one-of/CHANGELOG.md
+++ b/crates/one-of/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Patch
 
+- Remove dummy alloc dependency
 - Add clippy lint
 
 ## 0.1.0

--- a/crates/one-of/src/lib.rs
+++ b/crates/one-of/src/lib.rs
@@ -16,9 +16,6 @@
 
 #![no_std]
 
-// TODO(https://github.com/rust-lang/rust/issues/122105): Remove when fixed.
-extern crate alloc;
-
 /// Makes sure exactly one of the provided feature is enabled.
 ///
 /// For example, `exactly_one_of!["a", "b", "c"]` will expand to:

--- a/crates/runner-nordic/Cargo.toml
+++ b/crates/runner-nordic/Cargo.toml
@@ -16,7 +16,7 @@ embedded-alloc = "0.6.0"
 embedded-hal = "1.0.0"
 embedded-hal-02 = { version = "0.2.7", package = "embedded-hal" }
 embedded-storage = "0.3.1"
-header = { path = "crates/header", features = ["alloc"] }
+header = { path = "crates/header" }
 nrf52840-hal = { version = "0.18.0", features = ["embedded-hal-02"] }
 panic-abort = { version = "0.3.2", optional = true }
 panic-probe = { version = "0.3.2", features = ["print-defmt"], optional = true }

--- a/crates/runner-nordic/crates/header/Cargo.toml
+++ b/crates/runner-nordic/crates/header/Cargo.toml
@@ -6,10 +6,6 @@ license = "Apache-2.0"
 publish = false
 edition = "2024"
 
-[features]
-# TODO(https://github.com/rust-lang/rust/issues/122105): Remove when fixed.
-alloc = []
-
 [lints]
 clippy.literal-string-with-formatting-args = "allow"
 clippy.mod-module-files = "warn"

--- a/crates/runner-nordic/crates/header/src/lib.rs
+++ b/crates/runner-nordic/crates/header/src/lib.rs
@@ -14,9 +14,6 @@
 
 #![no_std]
 
-#[cfg(feature = "alloc")]
-extern crate alloc;
-
 use core::ptr::addr_of;
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]

--- a/crates/sync/CHANGELOG.md
+++ b/crates/sync/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Patch
 
+- Remove dummy alloc dependency
 - Add clippy lint
 
 ## 0.1.1

--- a/crates/sync/src/lib.rs
+++ b/crates/sync/src/lib.rs
@@ -17,9 +17,6 @@
 #![no_std]
 #![deny(unsafe_op_in_unsafe_fn)]
 
-// TODO(https://github.com/rust-lang/rust/issues/122105): Remove when fixed.
-extern crate alloc;
-
 pub use mutex::{Mutex, MutexGuard};
 pub use portable_atomic::*;
 pub use spin::Lazy;

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -493,6 +493,8 @@ impl RunnerOptions {
             rustflags.push("-C link-arg=-Tlink.x".to_string());
             if main.release {
                 cargo.arg("-Zbuild-std=core,alloc");
+                // TODO(https://github.com/rust-lang/rust/issues/122105): Remove when fixed.
+                rustflags.push("--allow=unused-crate-dependencies".to_string());
                 let mut features = "-Zbuild-std-features=panic_immediate_abort".to_string();
                 if self.opt_level.is_some_and(action::OptLevel::optimize_for_size) {
                     features.push_str(",optimize_for_size");
@@ -663,6 +665,8 @@ impl RunnerOptions {
             cargo.current_dir("crates/runner-nordic/crates/bootloader");
             cargo.args(["build", "--release", "--target=thumbv7em-none-eabi"]);
             cargo.args(["-Zbuild-std=core", "-Zbuild-std-features=panic_immediate_abort"]);
+            // TODO(https://github.com/rust-lang/rust/issues/122105): Remove when fixed.
+            cargo.env("RUSTFLAGS", "--allow=unused-crate-dependencies");
             cmd::execute(&mut cargo).await?;
             tokio::task::spawn_blocking(move || {
                 anyhow::Ok(flashing::download_file(


### PR DESCRIPTION
This avoids false positives until https://github.com/rust-lang/rust/issues/122105 is fixed. We anyway run similar commands without `-Zbuild-std` in CI which should catch most if not all unused crate dependencies.