### PR TITLE
Fix branch table logic

### DIFF
--- a/crates/interpreter/src/side_table.rs
+++ b/crates/interpreter/src/side_table.rs
@@ -106,6 +106,7 @@ pub fn serialize(side_table: &[MetadataEntry]) -> Result<Vec<u8>, Error> {
 #[repr(transparent)]
 pub struct BranchTableEntry([u8; 6]);
 
+#[derive(Debug)]
 pub struct BranchTableEntryView {
     /// The amount to adjust the instruction pointer by if the branch is taken.
     pub delta_ip: i32,


### PR DESCRIPTION
The main changes are:
- Do not create a branch table entry for unreachable code. This saves space and permits a uniform treatment of branches.
- Use the correct stack length for the Loop branch target (we're taking the branch before being in the label, so the current stack needs to be added).
- Take the Else source and target branches at the correct time (i.e. when the stack is the expected one such that the stack length is correctly computed).