### PR TITLE
Fix opensk example

### DIFF
--- a/crates/runner-host/src/board/usb.rs
+++ b/crates/runner-host/src/board/usb.rs
@@ -21,7 +21,6 @@ use usb_device::UsbError;
 use usb_device::class::UsbClass;
 use usb_device::class_prelude::UsbBusAllocator;
 use usb_device::prelude::UsbDevice;
-use usbd_hid::descriptor::{CtapReport, SerializedDescriptor};
 use usbd_hid::hid_class::HIDClass;
 use usbd_serial::SerialPort;
 use usbip_device::UsbIpBus;
@@ -105,7 +104,12 @@ impl State {
             state.protocol = Some(Rpc::new(usb_bus));
         }
         if ctap {
-            state.ctap = Some(Ctap::new(HIDClass::new(usb_bus, CtapReport::desc(), 255)));
+            const CTAP_REPORT_DESCRIPTOR: &[u8] = &[
+                0x06, 0xd0, 0xf1, 0x09, 0x01, 0xa1, 0x01, 0x09, 0x20, 0x15, 0x00, 0x26, 0xff, 0x00,
+                0x75, 0x08, 0x95, 0x40, 0x81, 0x02, 0x09, 0x21, 0x15, 0x00, 0x26, 0xff, 0x00, 0x75,
+                0x08, 0x95, 0x40, 0x91, 0x02, 0xc0,
+            ];
+            state.ctap = Some(Ctap::new(HIDClass::new(usb_bus, CTAP_REPORT_DESCRIPTOR, 5)));
         }
         if serial {
             state.serial = Some(Serial::new(SerialPort::new(usb_bus)));

--- a/crates/runner-nordic/src/main.rs
+++ b/crates/runner-nordic/src/main.rs
@@ -55,8 +55,6 @@ use usb_device::class::UsbClass;
 use usb_device::class_prelude::UsbBusAllocator;
 use usb_device::device::UsbDevice;
 #[cfg(feature = "usb-ctap")]
-use usbd_hid::descriptor::{CtapReport, SerializedDescriptor};
-#[cfg(feature = "usb-ctap")]
 use usbd_hid::hid_class::HIDClass;
 #[cfg(feature = "usb-serial")]
 use usbd_serial::SerialPort;
@@ -171,7 +169,13 @@ fn main() -> ! {
     let usb_bus = USB_BUS.write(usb_bus);
     let protocol = wasefire_protocol_usb::Rpc::new(usb_bus);
     #[cfg(feature = "usb-ctap")]
-    let ctap = Ctap::new(HIDClass::new(usb_bus, CtapReport::desc(), 255));
+    const CTAP_REPORT_DESCRIPTOR: &[u8] = &[
+        0x06, 0xd0, 0xf1, 0x09, 0x01, 0xa1, 0x01, 0x09, 0x20, 0x15, 0x00, 0x26, 0xff, 0x00, 0x75,
+        0x08, 0x95, 0x40, 0x81, 0x02, 0x09, 0x21, 0x15, 0x00, 0x26, 0xff, 0x00, 0x75, 0x08, 0x95,
+        0x40, 0x91, 0x02, 0xc0,
+    ];
+    #[cfg(feature = "usb-ctap")]
+    let ctap = Ctap::new(HIDClass::new(usb_bus, CTAP_REPORT_DESCRIPTOR, 5));
     #[cfg(feature = "usb-serial")]
     let serial = Serial::new(SerialPort::new(usb_bus));
     board::platform::init_serial(&p.FICR);


### PR DESCRIPTION
The CTAP report descriptor was wrong, the timer logic was flipped, and we were having nested `ctap::Listener::new(Read)` (the one in `main()` and the one in `user_presence.rs`). This PR also adds winking support which fixes the nested listener issue at the same time.