### PR TITLE
Build cache directly instead of running everything

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,7 +1,7 @@
 [alias]
-update-api = "run --manifest-path ./crates/api-desc/crates/update/Cargo.toml"
-wasefire = "run --manifest-path ./crates/cli/Cargo.toml --features=_dev --"
-xtask = "run --manifest-path ./crates/xtask/Cargo.toml --"
+update-api = "run --manifest-path=crates/api-desc/crates/update/Cargo.toml"
+wasefire = "run --manifest-path=crates/cli/Cargo.toml --features=_dev --"
+xtask = "run --manifest-path=crates/xtask/Cargo.toml --"
 
 [build]
 target-dir = "target"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,9 @@ jobs:
           mode: save
       - if: steps.cache.outputs.cache-hit != 'true'
         name: Compute the cache
-        run: ./scripts/ci-cache.sh
+        run: |
+          sudo apt-get update
+          ./scripts/ci-cache.sh
   matrix:
     runs-on: ubuntu-latest
     needs: [checks, cache]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,27 +57,19 @@ jobs:
       release: ${{ steps.checks.outputs.release }}
   cache:
     runs-on: ubuntu-latest
-    needs: checks
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - if: github.event_name != 'schedule'
-        id: cache
-        name: Restore and save the cache
+      - id: cache
+        name: Restore (then save) the cache
         uses: ./.github/actions/ci-cache
         with:
           mode: save
       - if: steps.cache.outputs.cache-hit != 'true'
-        name: Run all checks ${{ needs.checks.outputs.checks }}
-        uses: ./.github/actions/ci-checks
-        with:
-          checks: ${{ needs.checks.outputs.checks }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-          use-cache: 'false'
-      - if: steps.cache.outputs.cache-hit != 'true'
-        run: rm -rf target && cargo xtask help
+        name: Compute the cache
+        run: ./scripts/ci-cache.sh
   matrix:
     runs-on: ubuntu-latest
-    needs: [checks, cache] # The cache is used by the checks.
+    needs: [checks, cache]
     strategy:
       fail-fast: false
       matrix:

--- a/scripts/ci-cache.sh
+++ b/scripts/ci-cache.sh
@@ -18,6 +18,8 @@ set -e
 
 # This script builds the CI cache.
 
+./scripts/setup.sh
+
 x cargo build --manifest-path=crates/xtask/Cargo.toml
 
 build() {

--- a/scripts/ci-cache.sh
+++ b/scripts/ci-cache.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+. scripts/log.sh
+
+# This script builds the CI cache.
+
+x cargo build --manifest-path=crates/xtask/Cargo.toml
+
+build() {
+  WASEFIRE_WRAPPER_EXEC=n ./scripts/wrapper.sh "$@"
+}
+
+CASE='\([a-z-]*\)[|)]'
+PARENT="s/^  $CASE\$/=\\1/p"
+CHILD="s/^      $CASE.*\$/.\\1/p"
+NORMAL="s/^  $CASE.*\$/\\1/p"
+LAST=
+for cmd in $(sed -n "$PARENT;$CHILD;$NORMAL" scripts/wrapper.sh); do
+  case "$cmd" in
+    =*) LAST=${cmd#=}; continue ;;
+    .*) build $LAST ${cmd#.} ;;
+    *) build $cmd ;;
+  esac
+done

--- a/scripts/wrapper.sh
+++ b/scripts/wrapper.sh
@@ -41,7 +41,7 @@ ensure_cargo() {
 }
 
 IS_CARGO=y
-# This list is read and modified by scripts/upgrade.sh.
+# This list is read and modified by scripts/upgrade.sh. It is also read by scripts/ci-cache.sh.
 case "$1" in
   cargo)
     case "$2" in


### PR DESCRIPTION
We can't run the whole CI in a single runner because we reach the 14G SSD when adding OpenTitan (probably because of all the RISC-V compilation artifacts). So we won't do anything special anymore on `schedule` triggered workflow and we build the cache by simply compiling all cargo wrappers.