### PR TITLE
Stop trying to use minimal versions

### DIFF
--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -40,18 +40,8 @@ for crate in $(get_crates); do
   update_crate "$crate" "$(cargo_info_version "$crate")"
 done
 
-# TODO(https://github.com/rust-lang/cargo/issues/10307): Remove the loop and inline.
-update_breaking() {
-  while ! x cargo -Z unstable-options update --manifest-path=$1 --breaking; do
-    t 'Manually fix the issue with `cargo update <spec>` and hit ENTER'
-    read garbage
-  done
-}
-for crate in $TOPOLOGICAL_ORDER; do
-  update_breaking crates/$crate/Cargo.toml
-done
 for path in $(git ls-files '*/Cargo.toml'); do
-  update_breaking $path
+  ./scripts/wrapper.sh cargo upgrade --manifest-path=$path --incompatible=allow
 done
 
 ( cd examples/assemblyscript

--- a/scripts/wrapper.sh
+++ b/scripts/wrapper.sh
@@ -46,6 +46,7 @@ case "$1" in
   cargo)
     case "$2" in
       bloat) ensure_cargo cargo-bloat 0.12.1 ;;
+      upgrade) ensure_cargo cargo-edit 0.13.1 ;;
       *) e "Wrapper does not support 'cargo $2'" ;;
     esac
     ;;


### PR DESCRIPTION
We are anyway living at "head" (recent nightly, etc). This also simplifies dealing with security fixes. Ideally this would be controlled by #583.