### PR TITLE
Revert serialport from 4.7.0 to 4.6.1 due to regression

### DIFF
--- a/crates/cli-tools/CHANGELOG.md
+++ b/crates/cli-tools/CHANGELOG.md
@@ -76,4 +76,4 @@
 
 ## 0.1.0
 
-<!-- Increment to skip CHANGELOG.md test: 6 -->
+<!-- Increment to skip CHANGELOG.md test: 7 -->

--- a/crates/cli-tools/Cargo.lock
+++ b/crates/cli-tools/Cargo.lock
@@ -1263,9 +1263,9 @@ dependencies = [
 
 [[package]]
 name = "serialport"
-version = "4.7.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ecfc4858c2266c7695d8b8460bbd612fa81bd2e250f5f0dd16195e4b4f8b3d8"
+checksum = "779e2977f0cc2ff39708fef48f96f3768ac8ddd8c6caaaab82e83bd240ef99b2"
 dependencies = [
  "bitflags 2.9.0",
  "cfg-if",

--- a/crates/cli-tools/Cargo.toml
+++ b/crates/cli-tools/Cargo.toml
@@ -26,7 +26,7 @@ reqwest = { version = "0.12.14", default-features = false, features = ["default-
 rusb = { version = "0.9.4", default-features = false, optional = true }
 semver = { version = "1.0.26", default-features = false, optional = true }
 serde = { version = "1.0.219", default-features = false, features = ["derive"] }
-serialport = { version = "4.7.0", default-features = false, optional = true }
+serialport = { version = "4.6.1", default-features = false, optional = true }
 tar = { version = "0.4.44", default-features = false }
 toml = { version = "0.8.20", default-features = false, features = ["display", "parse"] }
 wasefire-common = { version = "0.1.0-git", path = "../common", optional = true }

--- a/crates/cli-tools/src/action/usb_serial.rs
+++ b/crates/cli-tools/src/action/usb_serial.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use anyhow::{Result, bail};
+pub use serialport;
 use serialport::{SerialPort, SerialPortType};
 
 /// Options to connect to a USB serial.

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -66,4 +66,4 @@
 
 ## 0.1.0
 
-<!-- Increment to skip CHANGELOG.md test: 11 -->
+<!-- Increment to skip CHANGELOG.md test: 12 -->

--- a/crates/cli/Cargo.lock
+++ b/crates/cli/Cargo.lock
@@ -1444,9 +1444,9 @@ dependencies = [
 
 [[package]]
 name = "serialport"
-version = "4.7.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ecfc4858c2266c7695d8b8460bbd612fa81bd2e250f5f0dd16195e4b4f8b3d8"
+checksum = "779e2977f0cc2ff39708fef48f96f3768ac8ddd8c6caaaab82e83bd240ef99b2"
 dependencies = [
  "bitflags 2.9.0",
  "cfg-if",

--- a/crates/xtask/Cargo.lock
+++ b/crates/xtask/Cargo.lock
@@ -2014,9 +2014,9 @@ dependencies = [
 
 [[package]]
 name = "serialport"
-version = "4.7.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ecfc4858c2266c7695d8b8460bbd612fa81bd2e250f5f0dd16195e4b4f8b3d8"
+checksum = "779e2977f0cc2ff39708fef48f96f3768ac8ddd8c6caaaab82e83bd240ef99b2"
 dependencies = [
  "bitflags 2.9.0",
  "cfg-if",

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -16,7 +16,7 @@ log = "0.4.26"
 probe-rs = "0.27.0"
 rustc-demangle = "0.1.24"
 serde = { version = "1.0.219", features = ["derive"] }
-serialport = "4.7.0"
+serialport = "4.6.1"
 stack-sizes = "0.5.0"
 tokio = { version = "1.44.0", features = ["full"] }
 wasefire-cli-tools = { path = "../cli-tools", features = ["action", "changelog"] }

--- a/examples/rust/exercises/client/Cargo.lock
+++ b/examples/rust/exercises/client/Cargo.lock
@@ -252,7 +252,6 @@ dependencies = [
  "interface",
  "p256",
  "rand",
- "serialport",
  "wasefire-cli-tools",
 ]
 
@@ -1037,26 +1036,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libudev"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b324152da65df7bb95acfcaab55e3097ceaab02fb19b228a9eb74d55f135e0"
-dependencies = [
- "libc",
- "libudev-sys",
-]
-
-[[package]]
-name = "libudev-sys"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c8469b4a23b962c1396b9b451dda50ef5b283e8dd309d69033475fa9b334324"
-dependencies = [
- "libc",
- "pkg-config",
-]
-
-[[package]]
 name = "libusb1-sys"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1656,16 +1635,15 @@ dependencies = [
 
 [[package]]
 name = "serialport"
-version = "4.7.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ecfc4858c2266c7695d8b8460bbd612fa81bd2e250f5f0dd16195e4b4f8b3d8"
+checksum = "779e2977f0cc2ff39708fef48f96f3768ac8ddd8c6caaaab82e83bd240ef99b2"
 dependencies = [
  "bitflags 2.9.0",
  "cfg-if",
  "core-foundation 0.10.0",
  "core-foundation-sys",
  "io-kit-sys",
- "libudev",
  "mach2",
  "nix",
  "scopeguard",

--- a/examples/rust/exercises/client/Cargo.toml
+++ b/examples/rust/exercises/client/Cargo.toml
@@ -10,11 +10,11 @@ clap = { version = "4.5.32", features = ["derive"] }
 interface = { path = "../interface" }
 p256 = "0.13.2"
 rand = "0.9.0"
-serialport = { version = "4.7.0", optional = true }
 wasefire-cli-tools = { path = "../../../../crates/cli-tools", features = ["action"] }
 
 [features]
-usb = ["dep:serialport"] # Use USB serial instead of UART.
+# Use USB serial instead of UART.
+usb = []
 
 [lints]
 clippy.literal-string-with-formatting-args = "allow"

--- a/examples/rust/exercises/client/src/main.rs
+++ b/examples/rust/exercises/client/src/main.rs
@@ -104,7 +104,7 @@ fn main() {
 }
 
 #[cfg(feature = "usb")]
-type Serial = Box<dyn serialport::SerialPort>;
+type Serial = Box<dyn wasefire_cli_tools::action::usb_serial::serialport::SerialPort>;
 #[cfg(not(feature = "usb"))]
 type Serial = std::os::unix::net::UnixStream;
 

--- a/examples/rust/hsm/host/Cargo.lock
+++ b/examples/rust/hsm/host/Cargo.lock
@@ -556,7 +556,6 @@ dependencies = [
  "common",
  "env_logger",
  "log",
- "serialport",
  "wasefire-cli-tools",
 ]
 
@@ -916,26 +915,6 @@ dependencies = [
  "bitflags 2.9.0",
  "libc",
  "redox_syscall",
-]
-
-[[package]]
-name = "libudev"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b324152da65df7bb95acfcaab55e3097ceaab02fb19b228a9eb74d55f135e0"
-dependencies = [
- "libc",
- "libudev-sys",
-]
-
-[[package]]
-name = "libudev-sys"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c8469b4a23b962c1396b9b451dda50ef5b283e8dd309d69033475fa9b334324"
-dependencies = [
- "libc",
- "pkg-config",
 ]
 
 [[package]]
@@ -1455,16 +1434,15 @@ dependencies = [
 
 [[package]]
 name = "serialport"
-version = "4.7.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ecfc4858c2266c7695d8b8460bbd612fa81bd2e250f5f0dd16195e4b4f8b3d8"
+checksum = "779e2977f0cc2ff39708fef48f96f3768ac8ddd8c6caaaab82e83bd240ef99b2"
 dependencies = [
  "bitflags 2.9.0",
  "cfg-if",
  "core-foundation 0.10.0",
  "core-foundation-sys",
  "io-kit-sys",
- "libudev",
  "mach2",
  "nix",
  "scopeguard",

--- a/examples/rust/hsm/host/Cargo.toml
+++ b/examples/rust/hsm/host/Cargo.toml
@@ -11,7 +11,6 @@ clap = { version = "4.5.32", features = ["derive"] }
 common = { path = "../common", features = ["std"] }
 env_logger = "0.11.7"
 log = "0.4.26"
-serialport = "4.7.0"
 wasefire-cli-tools = { path = "../../../../crates/cli-tools", features = ["action"] }
 
 [lints]

--- a/examples/rust/hsm/host/src/main.rs
+++ b/examples/rust/hsm/host/src/main.rs
@@ -19,8 +19,8 @@ use std::time::Instant;
 use anyhow::{Result, anyhow};
 use clap::Parser;
 use common::{Deserialize, Deserializer, Error, Request, Response, Serialize, Serializer};
-use serialport::SerialPort;
 use wasefire_cli_tools::action::usb_serial::ConnectionOptions;
+use wasefire_cli_tools::action::usb_serial::serialport::SerialPort;
 
 #[derive(Parser)]
 struct Flags {

--- a/examples/rust/protocol/host/Cargo.lock
+++ b/examples/rust/protocol/host/Cargo.lock
@@ -1451,9 +1451,9 @@ dependencies = [
 
 [[package]]
 name = "serialport"
-version = "4.7.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ecfc4858c2266c7695d8b8460bbd612fa81bd2e250f5f0dd16195e4b4f8b3d8"
+checksum = "779e2977f0cc2ff39708fef48f96f3768ac8ddd8c6caaaab82e83bd240ef99b2"
 dependencies = [
  "bitflags 2.9.0",
  "cfg-if",

--- a/examples/rust/update/host/Cargo.lock
+++ b/examples/rust/update/host/Cargo.lock
@@ -548,7 +548,6 @@ dependencies = [
  "clap",
  "env_logger",
  "log",
- "serialport",
  "wasefire-cli-tools",
 ]
 
@@ -908,26 +907,6 @@ dependencies = [
  "bitflags 2.9.0",
  "libc",
  "redox_syscall",
-]
-
-[[package]]
-name = "libudev"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b324152da65df7bb95acfcaab55e3097ceaab02fb19b228a9eb74d55f135e0"
-dependencies = [
- "libc",
- "libudev-sys",
-]
-
-[[package]]
-name = "libudev-sys"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c8469b4a23b962c1396b9b451dda50ef5b283e8dd309d69033475fa9b334324"
-dependencies = [
- "libc",
- "pkg-config",
 ]
 
 [[package]]
@@ -1447,16 +1426,15 @@ dependencies = [
 
 [[package]]
 name = "serialport"
-version = "4.7.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ecfc4858c2266c7695d8b8460bbd612fa81bd2e250f5f0dd16195e4b4f8b3d8"
+checksum = "779e2977f0cc2ff39708fef48f96f3768ac8ddd8c6caaaab82e83bd240ef99b2"
 dependencies = [
  "bitflags 2.9.0",
  "cfg-if",
  "core-foundation 0.10.0",
  "core-foundation-sys",
  "io-kit-sys",
- "libudev",
  "mach2",
  "nix",
  "scopeguard",

--- a/examples/rust/update/host/Cargo.toml
+++ b/examples/rust/update/host/Cargo.toml
@@ -10,7 +10,6 @@ anyhow = "1.0.97"
 clap = { version = "4.5.32", features = ["derive"] }
 env_logger = "0.11.7"
 log = "0.4.26"
-serialport = "4.7.0"
 wasefire-cli-tools = { path = "../../../../crates/cli-tools", features = ["action"] }
 
 [lints]

--- a/examples/rust/update/host/src/main.rs
+++ b/examples/rust/update/host/src/main.rs
@@ -17,8 +17,8 @@ use std::path::PathBuf;
 
 use anyhow::Result;
 use clap::Parser;
-use wasefire_cli_tools::action::usb_serial::serialport::SerialPort;
 use wasefire_cli_tools::action::usb_serial::ConnectionOptions;
+use wasefire_cli_tools::action::usb_serial::serialport::SerialPort;
 
 /// Updates a firmware through USB serial.
 #[derive(Parser)]

--- a/examples/rust/update/host/src/main.rs
+++ b/examples/rust/update/host/src/main.rs
@@ -17,7 +17,7 @@ use std::path::PathBuf;
 
 use anyhow::Result;
 use clap::Parser;
-use serialport::SerialPort;
+use wasefire_cli_tools::action::usb_serial::serialport::SerialPort;
 use wasefire_cli_tools::action::usb_serial::ConnectionOptions;
 
 /// Updates a firmware through USB serial.


### PR DESCRIPTION
See https://github.com/serialport/serialport-rs/issues/243.