### PR TITLE
Use humantime again

### DIFF
--- a/crates/cli-tools/CHANGELOG.md
+++ b/crates/cli-tools/CHANGELOG.md
@@ -78,4 +78,4 @@
 
 ## 0.1.0
 
-<!-- Increment to skip CHANGELOG.md test: 10 -->
+<!-- Increment to skip CHANGELOG.md test: 11 -->

--- a/crates/cli-tools/Cargo.lock
+++ b/crates/cli-tools/Cargo.lock
@@ -242,12 +242,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cyborgtime"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "817fa642fb0ee7fe42e95783e00e0969927b96091bdd4b9b1af082acd943913b"
-
-[[package]]
 name = "data-encoding"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -528,6 +522,12 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "humantime"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b112acc8b3adf4b107a8ec20977da0273a8c386765a3ec0229bd500a1443f9f"
 
 [[package]]
 name = "hyper"
@@ -1788,9 +1788,9 @@ dependencies = [
  "anyhow",
  "cargo_metadata",
  "clap",
- "cyborgtime",
  "data-encoding",
  "flate2",
+ "humantime",
  "indicatif",
  "log",
  "reqwest",

--- a/crates/cli-tools/Cargo.toml
+++ b/crates/cli-tools/Cargo.toml
@@ -17,9 +17,9 @@ all-features = true
 [dependencies]
 anyhow = { version = "1.0.98", default-features = false, features = ["std"] }
 cargo_metadata = { version = "0.20.0", default-features = false, optional = true }
-cyborgtime = { version = "2.1.1", default-features = false, optional = true }
 data-encoding = { version = "2.9.0", default-features = false, features = ["std"], optional = true }
 flate2 = { version = "1.1.2", default-features = false, features = ["rust_backend"] }
+humantime = { version = "2.2.0", default-features = false, optional = true }
 indicatif = { version = "0.17.12", default-features = false, optional = true }
 log = { version = "0.4.27", default-features = false }
 reqwest = { version = "0.12.22", default-features = false, features = ["default-tls", "http2"] }
@@ -66,8 +66,8 @@ optional = true
 action = [
   "cargo",
   "dep:clap",
-  "dep:cyborgtime",
   "dep:data-encoding",
+  "dep:humantime",
   "dep:indicatif",
   "dep:rusb",
   "dep:serialport",

--- a/crates/cli-tools/src/action.rs
+++ b/crates/cli-tools/src/action.rs
@@ -47,7 +47,7 @@ pub struct ConnectionOptions {
 
     /// Timeout to send or receive with the USB protocol.
     #[arg(long, default_value = "0s")]
-    timeout: cyborgtime::Duration,
+    timeout: humantime::Duration,
 }
 
 impl ConnectionOptions {
@@ -238,7 +238,7 @@ pub struct Wait {
     ///
     /// The command doesn't return `None` in that case.
     #[arg(long, conflicts_with = "wait")]
-    period: Option<cyborgtime::Duration>,
+    period: Option<humantime::Duration>,
 }
 
 impl Wait {
@@ -283,7 +283,7 @@ impl Wait {
 pub struct PlatformList {
     /// Timeout to send or receive on the platform protocol.
     #[arg(long, default_value = "1s")]
-    timeout: cyborgtime::Duration,
+    timeout: humantime::Duration,
 }
 
 impl PlatformList {

--- a/crates/cli-tools/src/action/usb_serial.rs
+++ b/crates/cli-tools/src/action/usb_serial.rs
@@ -25,7 +25,7 @@ pub struct ConnectionOptions {
 
     /// Timeout to send or receive with the USB serial.
     #[arg(long, default_value = "1s")]
-    timeout: cyborgtime::Duration,
+    timeout: humantime::Duration,
 }
 
 impl ConnectionOptions {

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -67,4 +67,4 @@
 
 ## 0.1.0
 
-<!-- Increment to skip CHANGELOG.md test: 17 -->
+<!-- Increment to skip CHANGELOG.md test: 18 -->

--- a/crates/cli/Cargo.lock
+++ b/crates/cli/Cargo.lock
@@ -312,12 +312,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cyborgtime"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "817fa642fb0ee7fe42e95783e00e0969927b96091bdd4b9b1af082acd943913b"
-
-[[package]]
 name = "data-encoding"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -609,6 +603,12 @@ name = "httparse"
 version = "1.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946"
+
+[[package]]
+name = "humantime"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b112acc8b3adf4b107a8ec20977da0273a8c386765a3ec0229bd500a1443f9f"
 
 [[package]]
 name = "hyper"
@@ -2017,9 +2017,9 @@ dependencies = [
  "anyhow",
  "cargo_metadata",
  "clap",
- "cyborgtime",
  "data-encoding",
  "flate2",
+ "humantime",
  "indicatif",
  "log",
  "reqwest",

--- a/crates/xtask/Cargo.lock
+++ b/crates/xtask/Cargo.lock
@@ -303,12 +303,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cyborgtime"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "817fa642fb0ee7fe42e95783e00e0969927b96091bdd4b9b1af082acd943913b"
-
-[[package]]
 name = "data-encoding"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -600,6 +594,12 @@ name = "httparse"
 version = "1.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946"
+
+[[package]]
+name = "humantime"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b112acc8b3adf4b107a8ec20977da0273a8c386765a3ec0229bd500a1443f9f"
 
 [[package]]
 name = "hyper"
@@ -2006,9 +2006,9 @@ dependencies = [
  "anyhow",
  "cargo_metadata",
  "clap",
- "cyborgtime",
  "data-encoding",
  "flate2",
+ "humantime",
  "indicatif",
  "log",
  "reqwest",

--- a/examples/rust/exercises/client/Cargo.lock
+++ b/examples/rust/exercises/client/Cargo.lock
@@ -372,12 +372,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cyborgtime"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "817fa642fb0ee7fe42e95783e00e0969927b96091bdd4b9b1af082acd943913b"
-
-[[package]]
 name = "data-encoding"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -768,6 +762,12 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "humantime"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b112acc8b3adf4b107a8ec20977da0273a8c386765a3ec0229bd500a1443f9f"
 
 [[package]]
 name = "hyper"
@@ -2251,9 +2251,9 @@ dependencies = [
  "anyhow",
  "cargo_metadata",
  "clap",
- "cyborgtime",
  "data-encoding",
  "flate2",
+ "humantime",
  "indicatif",
  "log",
  "reqwest",

--- a/examples/rust/hsm/host/Cargo.lock
+++ b/examples/rust/hsm/host/Cargo.lock
@@ -310,12 +310,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cyborgtime"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "817fa642fb0ee7fe42e95783e00e0969927b96091bdd4b9b1af082acd943913b"
-
-[[package]]
 name = "data-encoding"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -631,6 +625,12 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "humantime"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b112acc8b3adf4b107a8ec20977da0273a8c386765a3ec0229bd500a1443f9f"
 
 [[package]]
 name = "hyper"
@@ -1996,9 +1996,9 @@ dependencies = [
  "anyhow",
  "cargo_metadata",
  "clap",
- "cyborgtime",
  "data-encoding",
  "flate2",
+ "humantime",
  "indicatif",
  "log",
  "reqwest",

--- a/examples/rust/protocol/host/Cargo.lock
+++ b/examples/rust/protocol/host/Cargo.lock
@@ -303,12 +303,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cyborgtime"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "817fa642fb0ee7fe42e95783e00e0969927b96091bdd4b9b1af082acd943913b"
-
-[[package]]
 name = "data-encoding"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -615,6 +609,12 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "humantime"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b112acc8b3adf4b107a8ec20977da0273a8c386765a3ec0229bd500a1443f9f"
 
 [[package]]
 name = "hyper"
@@ -2010,9 +2010,9 @@ dependencies = [
  "anyhow",
  "cargo_metadata",
  "clap",
- "cyborgtime",
  "data-encoding",
  "flate2",
+ "humantime",
  "indicatif",
  "log",
  "reqwest",

--- a/examples/rust/update/host/Cargo.lock
+++ b/examples/rust/update/host/Cargo.lock
@@ -303,12 +303,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cyborgtime"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "817fa642fb0ee7fe42e95783e00e0969927b96091bdd4b9b1af082acd943913b"
-
-[[package]]
 name = "data-encoding"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -623,6 +617,12 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "humantime"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b112acc8b3adf4b107a8ec20977da0273a8c386765a3ec0229bd500a1443f9f"
 
 [[package]]
 name = "hyper"
@@ -1988,9 +1988,9 @@ dependencies = [
  "anyhow",
  "cargo_metadata",
  "clap",
- "cyborgtime",
  "data-encoding",
  "flate2",
+ "humantime",
  "indicatif",
  "log",
  "reqwest",


### PR DESCRIPTION
RustSec [has withdrawn](https://rustsec.org/advisories/RUSTSEC-2025-0014.html) their vulnerability about humantime being unmaintained. This partially reverts #798.