### PR TITLE
Increase the max alloc size in prelude

### DIFF
--- a/crates/prelude/CHANGELOG.md
+++ b/crates/prelude/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Minor
 
+- Increase the maximum allocation size with the `wasm` feature
 - Add `fingerprint::{matcher,sensor}` modules for fingerprint matchers and sensors
 - Add `crypto::{ecdsa,ecdh,ed25519}` for ECDSA, ECDH, and Ed25519
 - Add `gpio::{Event,Listener,Handler}` for GPIO event support

--- a/crates/prelude/src/allocator/wasm.rs
+++ b/crates/prelude/src/allocator/wasm.rs
@@ -46,7 +46,7 @@ extern "C" fn alloc(size: u32, align: u32) -> u32 {
     unsafe { ALLOCATOR.alloc(layout) as u32 }
 }
 
-struct Allocator(Mutex<Tlsf<'static, u8, u8, 8, 8>>);
+struct Allocator(Mutex<Tlsf<'static, u16, u8, 11, 8>>);
 
 #[global_allocator]
 static ALLOCATOR: Allocator = Allocator(Mutex::new(Tlsf::DEFAULT));


### PR DESCRIPTION
Allocating more than about 4k would fail. The limit is now about 32k.