### PR TITLE
Only timeout on recv if winking

### DIFF
--- a/examples/rust/opensk/src/env.rs
+++ b/examples/rust/opensk/src/env.rs
@@ -20,7 +20,7 @@ use wasefire::error::Space;
 
 mod clock;
 mod crypto;
-mod hid_connection;
+pub(crate) mod hid_connection;
 mod persist;
 mod rng;
 mod user_presence;

--- a/examples/rust/opensk/src/env/hid_connection.rs
+++ b/examples/rust/opensk/src/env/hid_connection.rs
@@ -43,9 +43,9 @@ pub(crate) fn recv(packet: &mut [u8; 64], timeout_ms: Option<usize>) -> CtapResu
         if ctap::read(packet).map_err(convert_error)? {
             return Ok(RecvStatus::Received(UsbEndpoint::MainHid));
         }
-        scheduling::wait_until(|| timeout_is_over() || listener.is_notified());
         if timeout_is_over() {
             return Ok(RecvStatus::Timeout);
         }
+        scheduling::wait_until(|| timeout_is_over() || listener.is_notified());
     }
 }

--- a/examples/rust/opensk/src/lib.rs
+++ b/examples/rust/opensk/src/lib.rs
@@ -55,7 +55,8 @@ fn main() -> ! {
             (true, false) => wink = None,
         }
         let mut packet = [0; 64];
-        match opensk_ctap.env().hid_connection().recv(&mut packet, 100).unwrap() {
+        let timeout = wink.is_some().then_some(500);
+        match env::hid_connection::recv(&mut packet, timeout).unwrap() {
             RecvStatus::Timeout => continue,
             RecvStatus::Received(endpoint) => assert_eq!(endpoint, UsbEndpoint::MainHid),
         }


### PR DESCRIPTION
This way, the applet can sleep as long as nothing happens. (The platform doesn't because it has to check USB regularly, but still sleeps between USB interrupts.)