### PR TITLE
Delete applet file if optimizing fails

### DIFF
--- a/crates/cli-tools/CHANGELOG.md
+++ b/crates/cli-tools/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Major
 
+- Change `action::optimize_wasm()` to delete the applet on error
 - Remove `action::Transfer::chunk_size` used by `action::{AppletInstall,PlatformUpdate}`
 - Make `action::Rpc` private
 - Remove `action::PlatformUpdate::metadata()` which is now vendor-specific

--- a/crates/cli-tools/CHANGELOG.md
+++ b/crates/cli-tools/CHANGELOG.md
@@ -86,4 +86,4 @@
 
 ## 0.1.0
 
-<!-- Increment to skip CHANGELOG.md test: 14 -->
+<!-- Increment to skip CHANGELOG.md test: 15 -->

--- a/crates/cli-tools/src/action.rs
+++ b/crates/cli-tools/src/action.rs
@@ -810,13 +810,11 @@ impl Display for OptLevel {
 ///
 /// This also computes the side-table and inserts it as the first section.
 pub async fn optimize_wasm(applet: impl AsRef<Path>, opt_level: Option<OptLevel>) -> Result<()> {
-    match optimize_wasm_(applet.as_ref(), opt_level).await {
-        Ok(()) => Ok(()),
-        Err(error) => {
-            let _ = fs::remove_file(applet).await;
-            Err(error)
-        }
+    let result = optimize_wasm_(applet.as_ref(), opt_level).await;
+    if result.is_err() {
+        let _ = fs::remove_file(applet).await;
     }
+    result
 }
 
 async fn optimize_wasm_(applet: impl AsRef<Path>, opt_level: Option<OptLevel>) -> Result<()> {

--- a/crates/cli-tools/src/action.rs
+++ b/crates/cli-tools/src/action.rs
@@ -810,6 +810,16 @@ impl Display for OptLevel {
 ///
 /// This also computes the side-table and inserts it as the first section.
 pub async fn optimize_wasm(applet: impl AsRef<Path>, opt_level: Option<OptLevel>) -> Result<()> {
+    match optimize_wasm_(applet.as_ref(), opt_level).await {
+        Ok(()) => Ok(()),
+        Err(error) => {
+            let _ = fs::remove_file(applet).await;
+            Err(error)
+        }
+    }
+}
+
+async fn optimize_wasm_(applet: impl AsRef<Path>, opt_level: Option<OptLevel>) -> Result<()> {
     let mut strip = Command::new("wasm-strip");
     strip.arg(applet.as_ref());
     cmd::execute(&mut strip).await?;


### PR DESCRIPTION
Otherwise reruning the command will wrongly succeed.