### PR TITLE
Disable SIMD support for Pulley

### DIFF
--- a/crates/wasm-bench/.cargo/config.toml
+++ b/crates/wasm-bench/.cargo/config.toml
@@ -1,3 +1,0 @@
-[target.thumbv7em-none-eabi]
-runner = "../../scripts/wrapper.sh probe-rs run --chip=nRF52840_xxAA"
-rustflags = ["-Clink-arg=-Tlink.x"]

--- a/crates/wasm-bench/build.rs
+++ b/crates/wasm-bench/build.rs
@@ -37,6 +37,8 @@ fn main() {
         config.generate_address_map(false);
         config.memory_init_cow(false);
         config.memory_reservation(0);
+        config.wasm_relaxed_simd(false);
+        config.wasm_simd(false);
         let engine = wasmtime::Engine::new(&config).unwrap();
         module = engine.precompile_module(&module).unwrap();
     }

--- a/crates/wasm-bench/src/runtime/wasmtime.rs
+++ b/crates/wasm-bench/src/runtime/wasmtime.rs
@@ -25,6 +25,8 @@ pub(crate) fn run(wasm: &[u8]) -> f32 {
     config.async_stack_size(16 * 1024);
     config.max_wasm_stack(8 * 1024);
     config.memory_reservation_for_growth(0);
+    config.wasm_relaxed_simd(false);
+    config.wasm_simd(false);
     let engine = Engine::new(&config).unwrap();
     #[cfg(feature = "_target-embedded")]
     let module = unsafe { Module::deserialize_raw(&engine, wasm.into()) }.unwrap();


### PR DESCRIPTION
| | CoreMark | Time | Flash | Module | Data | Heap | Stack |
| - | - | - | - | - | - | - | - |
| linux base perf | 52.142586 | 23.232s | 455229 | 9459 | - | - | - |
| linux wasmtime perf | 22394.744 | 18.499s | 7887795 | 7771 | - | - | - |
| nordic base size | 0.14136074 | 141.786s | 93000 | 9459 | 65580 | 3336 | 2324 |
| nordic wasmtime size | 4.1841006 | 16.754s | 224080 | 15720 | 176 | 108792 | 5280 |

The flash size in #889 was wrong because `cargo size` ignores `build-std`. The correct sizes were:

| | Flash |
| - | - |
| nordic base size | 92960 |
| nordic wasmtime size | 263740 |

Notice also that disabling SIMD not only reduced the footprint but also improved the performance.