### PR TITLE
Run wasm-bench on i686-unknown-linux-gnu for linux

### DIFF
--- a/crates/wasm-bench/run.sh
+++ b/crates/wasm-bench/run.sh
@@ -32,7 +32,7 @@ done
 
 case "$1" in
   linux)
-    TARGET="$(rustc -vV | sed -n 's/^host: //p')"
+    TARGET=i686-unknown-linux-gnu
     RUN=
     ;;
   nordic)

--- a/crates/wasm-bench/src/runtime/wasmtime.rs
+++ b/crates/wasm-bench/src/runtime/wasmtime.rs
@@ -25,13 +25,12 @@ pub(crate) fn run(wasm: &[u8]) -> f32 {
     config.async_stack_size(16 * 1024);
     config.max_wasm_stack(8 * 1024);
     config.memory_reservation_for_growth(0);
+    config.memory_init_cow(false);
+    config.memory_reservation(0);
     config.wasm_relaxed_simd(false);
     config.wasm_simd(false);
     let engine = Engine::new(&config).unwrap();
-    #[cfg(feature = "_target-embedded")]
     let module = unsafe { Module::deserialize_raw(&engine, wasm.into()) }.unwrap();
-    #[cfg(not(feature = "_target-embedded"))]
-    let module = Module::new(&engine, wasm).unwrap();
     let mut store = Store::new(&engine, ());
     let mut linker = Linker::new(&engine);
     static CLOCK: TakeCell<u64> = TakeCell::new(None);

--- a/crates/wasm-bench/test.sh
+++ b/crates/wasm-bench/test.sh
@@ -21,8 +21,8 @@ ensure_submodule third_party/wasm3/wasm-coremark
 
 test_helper
 
-cargo test --bin=wasm-bench --features=target-linux,runtime-base
-cargo test --bin=wasm-bench --features=target-linux,runtime-wasmtime
+cargo test --bin=wasm-bench --target=i686-unknown-linux-gnu --features=target-linux,runtime-base
+cargo test --bin=wasm-bench --target=i686-unknown-linux-gnu --features=target-linux,runtime-wasmtime
 
 cargo check --bin=wasm-bench --target=thumbv7em-none-eabi --features=target-nordic,runtime-base
 cargo check --bin=wasm-bench --target=thumbv7em-none-eabi --features=target-nordic,runtime-wasmtime


### PR DESCRIPTION
This permit to run pulley on linux instead of wasm. This makes the benchmark more fair.

| | CoreMark | Time | Flash | Module |
| - | - | - | - | - |
| linux base perf | 42 | 17s | 456k | 9459 |
| linux wasmtime | 1180 | 27s | 7.5G | 15720 |