### PR TITLE
Support pulley applets using Wasmtime

### DIFF
--- a/crates/cli-tools/CHANGELOG.md
+++ b/crates/cli-tools/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 ### Minor
 
+- Add `action::RustAppletBuild::pulley` to build a Pulley applet
+- Add `action::compile_pulley()` to compile a Pulley applet
 - Add `fs::has_changed()` to check whether a file needs update
 - Add `action::compute_sidetable()` to compute the side-table
 - Implement `Clone` for `action::Transfer`

--- a/crates/cli-tools/Cargo.lock
+++ b/crates/cli-tools/Cargo.lock
@@ -8,7 +8,16 @@ version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
 dependencies = [
- "gimli",
+ "gimli 0.31.1",
+]
+
+[[package]]
+name = "addr2line"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9acbfca36652500c911ddb767ed433e3ed99b032b5d935be73c6923662db1d43"
+dependencies = [
+ "gimli 0.32.2",
 ]
 
 [[package]]
@@ -16,6 +25,12 @@ name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "anstyle"
@@ -28,6 +43,12 @@ name = "anyhow"
 version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
+
+[[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 
 [[package]]
 name = "atomic-waker"
@@ -47,11 +68,11 @@ version = "0.3.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
 dependencies = [
- "addr2line",
+ "addr2line 0.24.2",
  "cfg-if",
  "libc",
  "miniz_oxide",
- "object",
+ "object 0.36.7",
  "rustc-demangle",
  "windows-targets 0.52.6",
 ]
@@ -79,6 +100,9 @@ name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+dependencies = [
+ "allocator-api2",
+]
 
 [[package]]
 name = "bytemuck"
@@ -202,6 +226,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
 name = "console"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -240,6 +273,131 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cranelift-assembler-x64"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "cranelift-assembler-x64-meta",
+]
+
+[[package]]
+name = "cranelift-assembler-x64-meta"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "cranelift-srcgen",
+]
+
+[[package]]
+name = "cranelift-bforest"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "cranelift-entity",
+]
+
+[[package]]
+name = "cranelift-bitset"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
+name = "cranelift-codegen"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "bumpalo",
+ "cranelift-assembler-x64",
+ "cranelift-bforest",
+ "cranelift-bitset",
+ "cranelift-codegen-meta",
+ "cranelift-codegen-shared",
+ "cranelift-control",
+ "cranelift-entity",
+ "cranelift-isle",
+ "gimli 0.32.2",
+ "hashbrown",
+ "log",
+ "pulley-interpreter",
+ "regalloc2",
+ "rustc-hash",
+ "serde",
+ "smallvec",
+ "target-lexicon",
+ "wasmtime-internal-math",
+]
+
+[[package]]
+name = "cranelift-codegen-meta"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "cranelift-assembler-x64-meta",
+ "cranelift-codegen-shared",
+ "cranelift-srcgen",
+ "heck",
+ "pulley-interpreter",
+]
+
+[[package]]
+name = "cranelift-codegen-shared"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+
+[[package]]
+name = "cranelift-control"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "arbitrary",
+]
+
+[[package]]
+name = "cranelift-entity"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "cranelift-bitset",
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
+name = "cranelift-frontend"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "cranelift-codegen",
+ "log",
+ "smallvec",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-isle"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+
+[[package]]
+name = "cranelift-native"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "cranelift-codegen",
+ "libc",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-srcgen"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+
+[[package]]
 name = "crc32fast"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -275,6 +433,24 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "encode_unicode"
@@ -315,6 +491,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -353,6 +535,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foreign-types"
@@ -447,6 +635,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
+name = "gimli"
+version = "0.32.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6298e594375a7fead9efd5568f0a46e6a154fb6a9bdcbe3c06946ffd81a5f6"
+dependencies = [
+ "fallible-iterator",
+ "indexmap",
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "h2"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -479,6 +678,10 @@ name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+ "serde",
+]
 
 [[package]]
 name = "heapless"
@@ -735,6 +938,7 @@ checksum = "f2481980430f9f78649238835720ddccc57e52df14ffce1c6f37391d61b563e9"
 dependencies = [
  "equivalent",
  "hashbrown",
+ "serde",
 ]
 
 [[package]]
@@ -787,6 +991,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -803,10 +1016,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "libc"
 version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
+
+[[package]]
+name = "libm"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "libredox"
@@ -952,6 +1177,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "crc32fast",
+ "hashbrown",
+ "indexmap",
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1047,6 +1284,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
 
 [[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "serde",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1062,6 +1311,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "pulley-interpreter"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "cranelift-bitset",
+ "log",
+ "pulley-macros",
+ "wasmtime-internal-math",
+]
+
+[[package]]
+name = "pulley-macros"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1086,6 +1356,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
 dependencies = [
  "bitflags 2.9.4",
+]
+
+[[package]]
+name = "regalloc2"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68e18e1ef763167dc6718c28a5585e62f907590a21028b8e87be1318f19ef1cb"
+dependencies = [
+ "allocator-api2",
+ "bumpalo",
+ "hashbrown",
+ "log",
+ "rustc-hash",
+ "smallvec",
 ]
 
 [[package]]
@@ -1155,6 +1439,12 @@ name = "rustc-demangle"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustix"
@@ -1388,6 +1678,9 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "socket2"
@@ -1472,6 +1765,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "target-lexicon"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e502f78cdbb8ba4718f566c418c52bc729126ffd16baee5baa718cf25dd5a69a"
+
+[[package]]
 name = "tempfile"
 version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1482,6 +1781,15 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -1851,6 +2159,7 @@ dependencies = [
  "wasefire-protocol-tokio",
  "wasefire-protocol-usb",
  "wasefire-wire",
+ "wasmtime",
 ]
 
 [[package]]
@@ -2045,6 +2354,195 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.237.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efe92d1321afa53ffc88a57c497bb7330c3cf84c98ffdba4a4caf6a0684fad3c"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.237.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d2a40ca0d2bdf4b0bf36c13a737d0b2c58e4c8aaefe1c57f336dd75369ca250"
+dependencies = [
+ "bitflags 2.9.4",
+ "hashbrown",
+ "indexmap",
+ "semver",
+ "serde",
+]
+
+[[package]]
+name = "wasmprinter"
+version = "0.237.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d00c979bd801d8d7e4b40de564bcb27526fcbaf58e3aff15fe2df7e135f5b397"
+dependencies = [
+ "anyhow",
+ "termcolor",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmtime"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "addr2line 0.25.0",
+ "anyhow",
+ "bitflags 2.9.4",
+ "bumpalo",
+ "cfg-if",
+ "hashbrown",
+ "indexmap",
+ "libc",
+ "log",
+ "object 0.37.3",
+ "once_cell",
+ "postcard",
+ "pulley-interpreter",
+ "rustix",
+ "serde",
+ "serde_derive",
+ "target-lexicon",
+ "wasmparser",
+ "wasmtime-environ",
+ "wasmtime-internal-cranelift",
+ "wasmtime-internal-fiber",
+ "wasmtime-internal-jit-debug",
+ "wasmtime-internal-jit-icache-coherence",
+ "wasmtime-internal-math",
+ "wasmtime-internal-unwinder",
+ "wasmtime-internal-versioned-export-macros",
+]
+
+[[package]]
+name = "wasmtime-environ"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "anyhow",
+ "cranelift-bitset",
+ "cranelift-entity",
+ "gimli 0.32.2",
+ "indexmap",
+ "log",
+ "object 0.37.3",
+ "postcard",
+ "serde",
+ "serde_derive",
+ "smallvec",
+ "target-lexicon",
+ "wasm-encoder",
+ "wasmparser",
+ "wasmprinter",
+]
+
+[[package]]
+name = "wasmtime-internal-asm-macros"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "wasmtime-internal-cranelift"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "cranelift-codegen",
+ "cranelift-control",
+ "cranelift-entity",
+ "cranelift-frontend",
+ "cranelift-native",
+ "gimli 0.32.2",
+ "itertools",
+ "log",
+ "object 0.37.3",
+ "pulley-interpreter",
+ "smallvec",
+ "target-lexicon",
+ "thiserror",
+ "wasmparser",
+ "wasmtime-environ",
+ "wasmtime-internal-math",
+ "wasmtime-internal-unwinder",
+ "wasmtime-internal-versioned-export-macros",
+]
+
+[[package]]
+name = "wasmtime-internal-fiber"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "anyhow",
+ "cc",
+ "cfg-if",
+ "libc",
+ "rustix",
+ "wasmtime-internal-asm-macros",
+ "wasmtime-internal-versioned-export-macros",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "wasmtime-internal-jit-debug"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "cc",
+ "wasmtime-internal-versioned-export-macros",
+]
+
+[[package]]
+name = "wasmtime-internal-jit-icache-coherence"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "libc",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "wasmtime-internal-math"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "libm",
+]
+
+[[package]]
+name = "wasmtime-internal-unwinder"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "cranelift-codegen",
+ "log",
+ "object 0.37.3",
+]
+
+[[package]]
+name = "wasmtime-internal-versioned-export-macros"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2079,6 +2577,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0978bf7171b3d90bac376700cb56d606feb40f251a475a5d6634613564460b22"
+dependencies = [
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/crates/cli-tools/Cargo.toml
+++ b/crates/cli-tools/Cargo.toml
@@ -62,6 +62,14 @@ path = "../protocol-usb"
 features = ["host", "log"]
 optional = true
 
+# TODO(wasmtime > 36.0.2): Use crates.io
+[dependencies.wasmtime]
+git = "https://github.com/bytecodealliance/wasmtime.git"
+rev = "0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+default-features = false
+features = ["cranelift", "pulley"]
+optional = true
+
 [features]
 action = [
   "cargo",
@@ -77,6 +85,7 @@ action = [
   "dep:wasefire-protocol-tokio",
   "dep:wasefire-protocol-usb",
   "dep:wasefire-wire",
+  "dep:wasmtime",
   "tokio/time",
 ]
 cargo = ["dep:cargo_metadata"]

--- a/crates/cli/CHANGELOG.md
+++ b/crates/cli/CHANGELOG.md
@@ -70,4 +70,4 @@
 
 ## 0.1.0
 
-<!-- Increment to skip CHANGELOG.md test: 24 -->
+<!-- Increment to skip CHANGELOG.md test: 25 -->

--- a/crates/cli/Cargo.lock
+++ b/crates/cli/Cargo.lock
@@ -8,7 +8,16 @@ version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
 dependencies = [
- "gimli",
+ "gimli 0.31.1",
+]
+
+[[package]]
+name = "addr2line"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9acbfca36652500c911ddb767ed433e3ed99b032b5d935be73c6923662db1d43"
+dependencies = [
+ "gimli 0.32.2",
 ]
 
 [[package]]
@@ -25,6 +34,12 @@ checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "anstream"
@@ -83,6 +98,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -100,11 +121,11 @@ version = "0.3.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
 dependencies = [
- "addr2line",
+ "addr2line 0.24.2",
  "cfg-if",
  "libc",
  "miniz_oxide",
- "object",
+ "object 0.36.7",
  "rustc-demangle",
  "windows-targets 0.52.6",
 ]
@@ -132,6 +153,9 @@ name = "bumpalo"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+dependencies = [
+ "allocator-api2",
+]
 
 [[package]]
 name = "bytemuck"
@@ -265,6 +289,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror 2.0.12",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -309,6 +342,131 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cranelift-assembler-x64"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "cranelift-assembler-x64-meta",
+]
+
+[[package]]
+name = "cranelift-assembler-x64-meta"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "cranelift-srcgen",
+]
+
+[[package]]
+name = "cranelift-bforest"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "cranelift-entity",
+]
+
+[[package]]
+name = "cranelift-bitset"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
+name = "cranelift-codegen"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "bumpalo",
+ "cranelift-assembler-x64",
+ "cranelift-bforest",
+ "cranelift-bitset",
+ "cranelift-codegen-meta",
+ "cranelift-codegen-shared",
+ "cranelift-control",
+ "cranelift-entity",
+ "cranelift-isle",
+ "gimli 0.32.2",
+ "hashbrown",
+ "log",
+ "pulley-interpreter",
+ "regalloc2",
+ "rustc-hash",
+ "serde",
+ "smallvec",
+ "target-lexicon",
+ "wasmtime-internal-math",
+]
+
+[[package]]
+name = "cranelift-codegen-meta"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "cranelift-assembler-x64-meta",
+ "cranelift-codegen-shared",
+ "cranelift-srcgen",
+ "heck",
+ "pulley-interpreter",
+]
+
+[[package]]
+name = "cranelift-codegen-shared"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+
+[[package]]
+name = "cranelift-control"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "arbitrary",
+]
+
+[[package]]
+name = "cranelift-entity"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "cranelift-bitset",
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
+name = "cranelift-frontend"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "cranelift-codegen",
+ "log",
+ "smallvec",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-isle"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+
+[[package]]
+name = "cranelift-native"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "cranelift-codegen",
+ "libc",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-srcgen"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+
+[[package]]
 name = "crc32fast"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -344,6 +502,24 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "encode_unicode"
@@ -398,13 +574,19 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
 
 [[package]]
 name = "fastrand"
@@ -439,6 +621,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foreign-types"
@@ -521,6 +709,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
+name = "gimli"
+version = "0.32.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6298e594375a7fead9efd5568f0a46e6a154fb6a9bdcbe3c06946ffd81a5f6"
+dependencies = [
+ "fallible-iterator",
+ "indexmap",
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "h2"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -553,6 +752,10 @@ name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+dependencies = [
+ "foldhash",
+ "serde",
+]
 
 [[package]]
 name = "heapless"
@@ -840,6 +1043,7 @@ checksum = "3954d50fe15b02142bf25d3b8bdadb634ec3948f103d04ffe3031bc8fe9d7058"
 dependencies = [
  "equivalent",
  "hashbrown",
+ "serde",
 ]
 
 [[package]]
@@ -898,6 +1102,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -938,10 +1151,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "libc"
 version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+
+[[package]]
+name = "libm"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "libredox"
@@ -971,6 +1196,12 @@ name = "linux-raw-sys"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "litemap"
@@ -1093,6 +1324,18 @@ version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "crc32fast",
+ "hashbrown",
+ "indexmap",
  "memchr",
 ]
 
@@ -1224,12 +1467,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "serde",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "pulley-interpreter"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "cranelift-bitset",
+ "log",
+ "pulley-macros",
+ "wasmtime-internal-math",
+]
+
+[[package]]
+name = "pulley-macros"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1248,6 +1524,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
 dependencies = [
  "bitflags 2.9.1",
+]
+
+[[package]]
+name = "regalloc2"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68e18e1ef763167dc6718c28a5585e62f907590a21028b8e87be1318f19ef1cb"
+dependencies = [
+ "allocator-api2",
+ "bumpalo",
+ "hashbrown",
+ "log",
+ "rustc-hash",
+ "smallvec",
 ]
 
 [[package]]
@@ -1348,6 +1638,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
 name = "rustix"
 version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1356,8 +1652,21 @@ dependencies = [
  "bitflags 2.9.1",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.14",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
+dependencies = [
+ "bitflags 2.9.1",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.9.4",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1576,6 +1885,9 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "socket2"
@@ -1676,6 +1988,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "target-lexicon"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e502f78cdbb8ba4718f566c418c52bc729126ffd16baee5baa718cf25dd5a69a"
+
+[[package]]
 name = "tempfile"
 version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1684,8 +2002,17 @@ dependencies = [
  "cfg-if",
  "fastrand",
  "once_cell",
- "rustix",
+ "rustix 0.38.34",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -2100,6 +2427,7 @@ dependencies = [
  "wasefire-protocol-tokio",
  "wasefire-protocol-usb",
  "wasefire-wire",
+ "wasmtime",
 ]
 
 [[package]]
@@ -2284,6 +2612,195 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.237.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efe92d1321afa53ffc88a57c497bb7330c3cf84c98ffdba4a4caf6a0684fad3c"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.237.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d2a40ca0d2bdf4b0bf36c13a737d0b2c58e4c8aaefe1c57f336dd75369ca250"
+dependencies = [
+ "bitflags 2.9.1",
+ "hashbrown",
+ "indexmap",
+ "semver",
+ "serde",
+]
+
+[[package]]
+name = "wasmprinter"
+version = "0.237.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d00c979bd801d8d7e4b40de564bcb27526fcbaf58e3aff15fe2df7e135f5b397"
+dependencies = [
+ "anyhow",
+ "termcolor",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmtime"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "addr2line 0.25.0",
+ "anyhow",
+ "bitflags 2.9.1",
+ "bumpalo",
+ "cfg-if",
+ "hashbrown",
+ "indexmap",
+ "libc",
+ "log",
+ "object 0.37.3",
+ "once_cell",
+ "postcard",
+ "pulley-interpreter",
+ "rustix 1.0.8",
+ "serde",
+ "serde_derive",
+ "target-lexicon",
+ "wasmparser",
+ "wasmtime-environ",
+ "wasmtime-internal-cranelift",
+ "wasmtime-internal-fiber",
+ "wasmtime-internal-jit-debug",
+ "wasmtime-internal-jit-icache-coherence",
+ "wasmtime-internal-math",
+ "wasmtime-internal-unwinder",
+ "wasmtime-internal-versioned-export-macros",
+]
+
+[[package]]
+name = "wasmtime-environ"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "anyhow",
+ "cranelift-bitset",
+ "cranelift-entity",
+ "gimli 0.32.2",
+ "indexmap",
+ "log",
+ "object 0.37.3",
+ "postcard",
+ "serde",
+ "serde_derive",
+ "smallvec",
+ "target-lexicon",
+ "wasm-encoder",
+ "wasmparser",
+ "wasmprinter",
+]
+
+[[package]]
+name = "wasmtime-internal-asm-macros"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "wasmtime-internal-cranelift"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "cranelift-codegen",
+ "cranelift-control",
+ "cranelift-entity",
+ "cranelift-frontend",
+ "cranelift-native",
+ "gimli 0.32.2",
+ "itertools",
+ "log",
+ "object 0.37.3",
+ "pulley-interpreter",
+ "smallvec",
+ "target-lexicon",
+ "thiserror 2.0.12",
+ "wasmparser",
+ "wasmtime-environ",
+ "wasmtime-internal-math",
+ "wasmtime-internal-unwinder",
+ "wasmtime-internal-versioned-export-macros",
+]
+
+[[package]]
+name = "wasmtime-internal-fiber"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "anyhow",
+ "cc",
+ "cfg-if",
+ "libc",
+ "rustix 1.0.8",
+ "wasmtime-internal-asm-macros",
+ "wasmtime-internal-versioned-export-macros",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "wasmtime-internal-jit-debug"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "cc",
+ "wasmtime-internal-versioned-export-macros",
+]
+
+[[package]]
+name = "wasmtime-internal-jit-icache-coherence"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "libc",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "wasmtime-internal-math"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "libm",
+]
+
+[[package]]
+name = "wasmtime-internal-unwinder"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "cranelift-codegen",
+ "log",
+ "object 0.37.3",
+]
+
+[[package]]
+name = "wasmtime-internal-versioned-export-macros"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2318,6 +2835,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0978bf7171b3d90bac376700cb56d606feb40f251a475a5d6634613564460b22"
+dependencies = [
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/crates/runner-host/Cargo.lock
+++ b/crates/runner-host/Cargo.lock
@@ -8,7 +8,7 @@ version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
 dependencies = [
- "gimli",
+ "gimli 0.31.1",
 ]
 
 [[package]]
@@ -129,6 +129,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
 
 [[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -150,7 +161,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "miniz_oxide",
- "object",
+ "object 0.36.7",
  "rustc-demangle",
  "windows-targets 0.52.6",
 ]
@@ -330,6 +341,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -364,6 +384,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "cranelift-bitset"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
+name = "cranelift-entity"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "cranelift-bitset",
+ "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -567,6 +606,12 @@ dependencies = [
 
 [[package]]
 name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
@@ -608,12 +653,12 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -665,6 +710,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foreign-types"
@@ -794,6 +845,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
+name = "gimli"
+version = "0.32.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6298e594375a7fead9efd5568f0a46e6a154fb6a9bdcbe3c06946ffd81a5f6"
+
+[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -846,6 +903,10 @@ name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+dependencies = [
+ "foldhash",
+ "serde",
+]
 
 [[package]]
 name = "headers"
@@ -1139,6 +1200,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
+
+[[package]]
 name = "idna"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1167,6 +1234,7 @@ checksum = "3954d50fe15b02142bf25d3b8bdadb634ec3948f103d04ffe3031bc8fe9d7058"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.2",
+ "serde",
 ]
 
 [[package]]
@@ -1258,6 +1326,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
+name = "libm"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
+
+[[package]]
 name = "libredox"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1273,6 +1347,12 @@ name = "linux-raw-sys"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "litemap"
@@ -1297,10 +1377,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
+name = "mach2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+
+[[package]]
+name = "memfd"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad38eb12aea514a0466ea40a80fd8cc83637065948eb4a426e4aa46261175227"
+dependencies = [
+ "rustix 1.0.8",
+]
 
 [[package]]
 name = "mime"
@@ -1405,6 +1503,15 @@ name = "object"
 version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
 dependencies = [
  "memchr",
 ]
@@ -1601,6 +1708,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "serde",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1625,6 +1744,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "pulley-interpreter"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "cranelift-bitset",
+ "log",
+ "pulley-macros",
+ "wasmtime-internal-math",
+]
+
+[[package]]
+name = "pulley-macros"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1831,8 +1971,21 @@ dependencies = [
  "bitflags 2.9.1",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.14",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
+dependencies = [
+ "bitflags 2.9.1",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.9.4",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2062,6 +2215,9 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "socket2"
@@ -2180,6 +2336,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "target-lexicon"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e502f78cdbb8ba4718f566c418c52bc729126ffd16baee5baa718cf25dd5a69a"
+
+[[package]]
 name = "tempfile"
 version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2188,7 +2350,7 @@ dependencies = [
  "cfg-if",
  "fastrand",
  "once_cell",
- "rustix",
+ "rustix 0.38.34",
  "windows-sys 0.59.0",
 ]
 
@@ -2447,6 +2609,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "universal-hash"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2527,7 +2695,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "065e4eaf93db81d5adac82d9cef8f8da314cb640fa7f89534b972383f1cf80fc"
 dependencies = [
  "embedded-hal",
- "embedded-io",
+ "embedded-io 0.6.1",
  "nb 1.1.0",
  "usb-device",
 ]
@@ -2793,6 +2961,7 @@ dependencies = [
  "wasefire-slice-cell",
  "wasefire-store",
  "wasefire-sync",
+ "wasmtime",
 ]
 
 [[package]]
@@ -2915,6 +3084,163 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.237.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d2a40ca0d2bdf4b0bf36c13a737d0b2c58e4c8aaefe1c57f336dd75369ca250"
+dependencies = [
+ "bitflags 2.9.1",
+ "hashbrown 0.15.2",
+ "indexmap",
+ "semver",
+ "serde",
+]
+
+[[package]]
+name = "wasmtime"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bitflags 2.9.1",
+ "bumpalo",
+ "cc",
+ "cfg-if",
+ "hashbrown 0.15.2",
+ "indexmap",
+ "libc",
+ "log",
+ "mach2",
+ "memfd",
+ "object 0.37.3",
+ "postcard",
+ "pulley-interpreter",
+ "serde",
+ "serde_derive",
+ "smallvec",
+ "target-lexicon",
+ "wasmparser",
+ "wasmtime-environ",
+ "wasmtime-internal-asm-macros",
+ "wasmtime-internal-component-macro",
+ "wasmtime-internal-fiber",
+ "wasmtime-internal-math",
+ "wasmtime-internal-slab",
+ "wasmtime-internal-unwinder",
+ "wasmtime-internal-versioned-export-macros",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "wasmtime-environ"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "anyhow",
+ "cranelift-bitset",
+ "cranelift-entity",
+ "gimli 0.32.2",
+ "indexmap",
+ "log",
+ "object 0.37.3",
+ "postcard",
+ "serde",
+ "serde_derive",
+ "smallvec",
+ "target-lexicon",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmtime-internal-asm-macros"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "wasmtime-internal-component-macro"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "anyhow",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+ "wasmtime-internal-component-util",
+ "wasmtime-internal-wit-bindgen",
+ "wit-parser",
+]
+
+[[package]]
+name = "wasmtime-internal-component-util"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+
+[[package]]
+name = "wasmtime-internal-fiber"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "anyhow",
+ "cc",
+ "cfg-if",
+ "libc",
+ "rustix 1.0.8",
+ "wasmtime-internal-asm-macros",
+ "wasmtime-internal-versioned-export-macros",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "wasmtime-internal-math"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "libm",
+]
+
+[[package]]
+name = "wasmtime-internal-slab"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+
+[[package]]
+name = "wasmtime-internal-unwinder"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "log",
+ "object 0.37.3",
+]
+
+[[package]]
+name = "wasmtime-internal-versioned-export-macros"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "wasmtime-internal-wit-bindgen"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "anyhow",
+ "bitflags 2.9.1",
+ "heck",
+ "indexmap",
+ "wit-parser",
 ]
 
 [[package]]
@@ -3119,6 +3445,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
  "bitflags 2.9.1",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.237.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2596a5bc7c24cc965b56ad6ff9e32394c4e401764f89620a888519c6e849ab"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
 ]
 
 [[package]]

--- a/crates/runner-host/Cargo.toml
+++ b/crates/runner-host/Cargo.toml
@@ -82,6 +82,7 @@ debug = [
 release = []
 # Exactly one is enabled by xtask.
 native = ["wasefire-scheduler/native"]
+pulley = ["wasefire-scheduler/pulley"]
 wasm = ["dep:wasefire-interpreter", "wasefire-scheduler/wasm"]
 
 [lints]

--- a/crates/runner-host/src/main.rs
+++ b/crates/runner-host/src/main.rs
@@ -39,7 +39,7 @@ mod cleanup;
 mod web;
 
 exactly_one_of!["debug", "release"];
-exactly_one_of!["native", "wasm"];
+exactly_one_of!["native", "pulley", "wasm"];
 
 static STATE: Mutex<Option<board::State>> = Mutex::new(None);
 static RECEIVER: Mutex<Option<Receiver<Event<Board>>>> = Mutex::new(None);

--- a/crates/runner-host/test.sh
+++ b/crates/runner-host/test.sh
@@ -28,5 +28,7 @@ test_helper
 
 cargo test --bin=runner-host --target=i686-unknown-linux-gnu --features=wasm,debug
 cargo check --bin=runner-host --target=i686-unknown-linux-gnu --features=wasm,release
+cargo check --bin=runner-host --target=i686-unknown-linux-gnu --features=pulley,debug
+cargo check --bin=runner-host --target=i686-unknown-linux-gnu --features=pulley,release
 cargo check --bin=runner-host --target=i686-unknown-linux-gnu --features=native,debug
 cargo check --bin=runner-host --target=i686-unknown-linux-gnu --features=native,release

--- a/crates/runner-nordic/Cargo.lock
+++ b/crates/runner-nordic/Cargo.lock
@@ -39,14 +39,31 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
  "once_cell",
  "version_check",
- "zerocopy 0.7.35",
+ "zerocopy 0.8.26",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.99"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -60,9 +77,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.3.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "az"
@@ -111,9 +128,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.5.0"
+version = "2.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
+checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
 
 [[package]]
 name = "ble-adv"
@@ -131,6 +148,12 @@ checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
+
+[[package]]
+name = "bumpalo"
+version = "3.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "bytemuck"
@@ -174,10 +197,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "cfg-if"
-version = "1.0.0"
+name = "cc"
+version = "1.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "590f9024a68a8c40351881787f1934dc11afd69090f5edb6831464694d836ea3"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
 
 [[package]]
 name = "cipher"
@@ -187,6 +220,15 @@ checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common",
  "inout",
+]
+
+[[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror",
 ]
 
 [[package]]
@@ -236,11 +278,30 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.12"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "cranelift-bitset"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
+name = "cranelift-entity"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "cranelift-bitset",
+ "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -251,9 +312,9 @@ checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crunchy"
-version = "0.2.2"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
@@ -309,7 +370,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -365,9 +426,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.7.9"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid",
  "zeroize",
@@ -466,6 +527,12 @@ checksum = "361a90feb7004eca4019fb28352a9465666b24f840f5c3cddf0ff13920590b89"
 
 [[package]]
 name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
@@ -483,26 +550,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
-name = "ff"
-version = "0.13.0"
+name = "equivalent"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
  "rand_core 0.6.4",
  "subtle",
 ]
 
 [[package]]
-name = "fixed"
-version = "1.27.0"
+name = "find-msvc-tools"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fc715d38bea7b5bf487fcd79bcf8c209f0b58014f3018a7a19c2b855f472048"
+checksum = "e178e4fba8a2726903f6ba98a6d221e76f9c12c650d5dc0e6afdc50677b49650"
+
+[[package]]
+name = "fixed"
+version = "1.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707070ccf8c4173548210893a0186e29c266901b71ed20cd9e2ca0193dfe95c3"
 dependencies = [
  "az",
  "bytemuck",
  "half",
  "typenum",
 ]
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "fugit"
@@ -541,6 +636,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.32.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6298e594375a7fead9efd5568f0a46e6a154fb6a9bdcbe3c06946ffd81a5f6"
+
+[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -553,9 +654,9 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "2.4.1"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
+checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
 dependencies = [
  "cfg-if",
  "crunchy",
@@ -589,6 +690,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+ "serde",
+]
+
+[[package]]
 name = "header"
 version = "0.1.0"
 dependencies = [
@@ -604,7 +715,7 @@ checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
 dependencies = [
  "atomic-polyfill",
  "hash32 0.2.1",
- "rustc_version 0.4.0",
+ "rustc_version 0.4.1",
  "spin 0.9.8",
  "stable_deref_trait",
 ]
@@ -620,6 +731,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -629,19 +746,48 @@ dependencies = [
 ]
 
 [[package]]
-name = "inout"
-version = "0.1.3"
+name = "id-arena"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
+checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
+
+[[package]]
+name = "indexmap"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2481980430f9f78649238835720ddccc57e52df14ffce1c6f37391d61b563e9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.15.5",
+ "serde",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "generic-array",
 ]
 
 [[package]]
-name = "libc"
-version = "0.2.155"
+name = "itoa"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "libc"
+version = "0.2.175"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
+
+[[package]]
+name = "libm"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "linked_list_allocator"
@@ -650,10 +796,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9afa463f5405ee81cdb9cc2baf37e08ec7e4c8209442b5d72c04cfb2cd6e6286"
 
 [[package]]
-name = "lock_api"
-version = "0.4.12"
+name = "linux-raw-sys"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+
+[[package]]
+name = "lock_api"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -661,9 +813,33 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.25"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+
+[[package]]
+name = "mach2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "memchr"
+version = "2.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+
+[[package]]
+name = "memfd"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad38eb12aea514a0466ea40a80fd8cc83637065948eb4a426e4aa46261175227"
+dependencies = [
+ "rustix",
+]
 
 [[package]]
 name = "nb"
@@ -691,7 +867,7 @@ dependencies = [
  "embedded-dma",
  "embedded-hal 0.2.7",
  "embedded-hal 1.0.0",
- "embedded-io",
+ "embedded-io 0.6.1",
  "embedded-storage",
  "fixed",
  "nb 1.1.0",
@@ -755,10 +931,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "once_cell"
-version = "1.20.3"
+name = "object"
+version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "opaque-debug"
@@ -819,6 +1004,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
 
 [[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "serde",
+]
+
+[[package]]
 name = "primeorder"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -856,6 +1053,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "pulley-interpreter"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "cranelift-bitset",
+ "log",
+ "pulley-macros",
+ "wasmtime-internal-math",
+]
+
+[[package]]
+name = "pulley-macros"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -906,7 +1124,7 @@ name = "rubble"
 version = "0.0.5"
 source = "git+https://github.com/jmichelp/rubble.git?rev=d545f4f598d081c0177f38500792e353a7d932a3#d545f4f598d081c0177f38500792e353a7d932a3"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.9.4",
  "defmt 0.3.100",
  "fugit",
  "heapless 0.7.17",
@@ -975,18 +1193,37 @@ dependencies = [
 
 [[package]]
 name = "rustc_version"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
- "semver 1.0.23",
+ "semver 1.0.26",
+]
+
+[[package]]
+name = "rustix"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
+dependencies = [
+ "bitflags 2.9.4",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
 ]
 
 [[package]]
 name = "rustversion"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "scopeguard"
@@ -1029,9 +1266,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.23"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
+checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 
 [[package]]
 name = "semver-parser"
@@ -1041,22 +1278,34 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.210"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.210"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.106",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.143"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -1071,6 +1320,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "signature"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1078,6 +1333,15 @@ checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -1116,9 +1380,9 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "subtle"
-version = "2.5.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "svgbobdoc"
@@ -1164,19 +1428,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "thiserror"
-version = "2.0.12"
+name = "target-lexicon"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+checksum = "e502f78cdbb8ba4718f566c418c52bc729126ffd16baee5baa718cf25dd5a69a"
+
+[[package]]
+name = "thiserror"
+version = "2.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.12"
+version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+checksum = "6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1200,6 +1470,12 @@ name = "unicode-width"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "universal-hash"
@@ -1251,7 +1527,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb573c76e7884035ac5e1ab4a81234c187a82b6100140af0ab45757650ccda38"
 dependencies = [
  "byteorder",
- "hashbrown",
+ "hashbrown 0.13.2",
  "log",
  "proc-macro2",
  "quote",
@@ -1267,7 +1543,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "065e4eaf93db81d5adac82d9cef8f8da314cb640fa7f89534b972383f1cf80fc"
 dependencies = [
  "embedded-hal 0.2.7",
- "embedded-io",
+ "embedded-io 0.6.1",
  "nb 1.1.0",
  "usb-device",
 ]
@@ -1280,9 +1556,9 @@ checksum = "77439c1b53d2303b20d9459b1ade71a83c716e3f9c34f3228c00e6f185d6c002"
 
 [[package]]
 name = "version_check"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "void"
@@ -1442,6 +1718,7 @@ dependencies = [
  "wasefire-slice-cell",
  "wasefire-store",
  "wasefire-sync",
+ "wasmtime",
 ]
 
 [[package]]
@@ -1482,6 +1759,261 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasmparser"
+version = "0.237.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d2a40ca0d2bdf4b0bf36c13a737d0b2c58e4c8aaefe1c57f336dd75369ca250"
+dependencies = [
+ "bitflags 2.9.4",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver 1.0.26",
+ "serde",
+]
+
+[[package]]
+name = "wasmtime"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bitflags 2.9.4",
+ "bumpalo",
+ "cc",
+ "cfg-if",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "libc",
+ "log",
+ "mach2",
+ "memfd",
+ "object",
+ "postcard",
+ "pulley-interpreter",
+ "serde",
+ "serde_derive",
+ "smallvec",
+ "target-lexicon",
+ "wasmparser",
+ "wasmtime-environ",
+ "wasmtime-internal-asm-macros",
+ "wasmtime-internal-component-macro",
+ "wasmtime-internal-fiber",
+ "wasmtime-internal-math",
+ "wasmtime-internal-slab",
+ "wasmtime-internal-unwinder",
+ "wasmtime-internal-versioned-export-macros",
+ "windows-sys",
+]
+
+[[package]]
+name = "wasmtime-environ"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "anyhow",
+ "cranelift-bitset",
+ "cranelift-entity",
+ "gimli",
+ "indexmap",
+ "log",
+ "object",
+ "postcard",
+ "serde",
+ "serde_derive",
+ "smallvec",
+ "target-lexicon",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmtime-internal-asm-macros"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "wasmtime-internal-component-macro"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "anyhow",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+ "wasmtime-internal-component-util",
+ "wasmtime-internal-wit-bindgen",
+ "wit-parser",
+]
+
+[[package]]
+name = "wasmtime-internal-component-util"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+
+[[package]]
+name = "wasmtime-internal-fiber"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "anyhow",
+ "cc",
+ "cfg-if",
+ "libc",
+ "rustix",
+ "wasmtime-internal-asm-macros",
+ "wasmtime-internal-versioned-export-macros",
+ "windows-sys",
+]
+
+[[package]]
+name = "wasmtime-internal-math"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "libm",
+]
+
+[[package]]
+name = "wasmtime-internal-slab"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+
+[[package]]
+name = "wasmtime-internal-unwinder"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "log",
+ "object",
+]
+
+[[package]]
+name = "wasmtime-internal-versioned-export-macros"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "wasmtime-internal-wit-bindgen"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "anyhow",
+ "bitflags 2.9.4",
+ "heck",
+ "indexmap",
+ "wit-parser",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+
+[[package]]
+name = "wit-parser"
+version = "0.237.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2596a5bc7c24cc965b56ad6ff9e32394c4e401764f89620a888519c6e849ab"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver 1.0.26",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1493,11 +2025,11 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.35"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
 dependencies = [
- "zerocopy-derive 0.7.35",
+ "zerocopy-derive 0.8.26",
 ]
 
 [[package]]
@@ -1513,9 +2045,9 @@ dependencies = [
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.35"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1524,6 +2056,6 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.7.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"

--- a/crates/runner-nordic/Cargo.toml
+++ b/crates/runner-nordic/Cargo.toml
@@ -117,6 +117,7 @@ debug = [
 release = ["dep:panic-abort"]
 # Exactly one is enabled by xtask.
 native = ["wasefire-scheduler/native"]
+pulley = ["wasefire-scheduler/pulley"]
 wasm = ["dep:wasefire-interpreter", "wasefire-scheduler/wasm"]
 # Internal features.
 _crypto = []

--- a/crates/runner-nordic/board-devkit.x
+++ b/crates/runner-nordic/board-devkit.x
@@ -1,12 +1,12 @@
 /* nrf52840-devkit */
 
 /* RAM */
-_rstack = 0x20000000; /* 64KiB */
-_rheap  = 0x20010000; /* data and heap 192KiB */
+_rstack = 0x20000000; /* 32KiB */
+_rheap  = 0x20008000; /* data and heap 224KiB */
 _rlimit = 0x20040000;
 
 /* FLASH */
-_platform = 0x00010000; /* A and B 320KiB each */
-_applet   = 0x000b0000; /* 256KiB */
-_store    = 0x000f0000; /* 64KiB */
+_platform = 0x00010000; /* A and B 336KiB each */
+_applet   = 0x000b8000; /* 264KiB */
+_store    = 0x000fa000; /* 24KiB */
 _limit    = 0x00100000;

--- a/crates/runner-nordic/board-dongle.x
+++ b/crates/runner-nordic/board-dongle.x
@@ -1,12 +1,12 @@
 /* nrf52840-dongle */
 
 /* RAM */
-_rstack = 0x20000008; /* 64KiB - 8B */
-_rheap  = 0x20010000; /* data and heap 192KiB */
+_rstack = 0x20000008; /* 32KiB - 8B */
+_rheap  = 0x20008000; /* data and heap 224KiB */
 _rlimit = 0x20040000;
 
 /* FLASH */
 _platform = 0x00008000; /* A and B 288KiB each */
-_applet   = 0x00098000; /* 256KiB */
-_store    = 0x000d8000; /* 32KiB */
+_applet   = 0x00098000; /* 264KiB */
+_store    = 0x000da000; /* 24KiB */
 _limit    = 0x000e0000;

--- a/crates/runner-nordic/crates/header/src/lib.rs
+++ b/crates/runner-nordic/crates/header/src/lib.rs
@@ -97,7 +97,7 @@ const HEADER_LEN: u32 = 0x00000100;
 #[cfg(feature = "board-devkit")]
 const FIRMWARE_A: u32 = 0x00010000;
 #[cfg(feature = "board-devkit")]
-const FIRMWARE_B: u32 = 0x00060000;
+const FIRMWARE_B: u32 = 0x00064000;
 
 #[cfg(any(feature = "board-dongle", feature = "board-makerdiary"))]
 const FIRMWARE_A: u32 = 0x00008000;

--- a/crates/runner-nordic/src/main.rs
+++ b/crates/runner-nordic/src/main.rs
@@ -81,7 +81,7 @@ use crate::board::{Events, button, led};
 use crate::storage::Storage;
 
 exactly_one_of!["debug", "release"];
-exactly_one_of!["native", "wasm"];
+exactly_one_of!["native", "pulley", "wasm"];
 exactly_one_of!["board-devkit", "board-dongle", "board-makerdiary"];
 at_most_one_of!["fpc2534", "gpio"]; // they are incompatible
 

--- a/crates/runner-nordic/test.sh
+++ b/crates/runner-nordic/test.sh
@@ -20,7 +20,7 @@ set -e
 ensure_applet
 
 for feature in $(package_features); do
-  case $feature in _*|board-*|debug|release|native|wasm) continue ;; esac
+  case $feature in _*|board-*|debug|release|native|pulley|wasm) continue ;; esac
   x cargo clippy --bin=runner-nordic --target=thumbv7em-none-eabi \
 --features=wasm,debug,board-devkit,$feature
 done
@@ -32,6 +32,7 @@ cargo check --bin=runner-nordic --target=thumbv7em-none-eabi \
 cargo check --bin=runner-nordic --target=thumbv7em-none-eabi --features=wasm,debug,board-devkit
 DEFMT_LOG=trace cargo check --bin=runner-nordic --target=thumbv7em-none-eabi \
 --features=wasm,debug,board-devkit
+cargo check --bin=runner-nordic --target=thumbv7em-none-eabi --features=pulley,debug,board-devkit
 cargo check --bin=runner-nordic --target=thumbv7em-none-eabi --features=wasm,release,board-dongle
 cargo check --bin=runner-nordic --target=thumbv7em-none-eabi --features=native,release,board-dongle
 cargo check --bin=runner-nordic --target=thumbv7em-none-eabi \

--- a/crates/scheduler/CHANGELOG.md
+++ b/crates/scheduler/CHANGELOG.md
@@ -201,4 +201,4 @@
 
 ## 0.1.0
 
-<!-- Increment to skip CHANGELOG.md test: 13 -->
+<!-- Increment to skip CHANGELOG.md test: 14 -->

--- a/crates/scheduler/CHANGELOG.md
+++ b/crates/scheduler/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Minor
 
+- Add `pulley` feature for Pulley platform
 - Support the removal of the `radio` module
 - Support `vendor` module
 - Use `Trap`, `Failure`, and `AppletMemory{,Ext}` from `wasefire-board-api`
@@ -200,4 +201,4 @@
 
 ## 0.1.0
 
-<!-- Increment to skip CHANGELOG.md test: 12 -->
+<!-- Increment to skip CHANGELOG.md test: 13 -->

--- a/crates/scheduler/Cargo.lock
+++ b/crates/scheduler/Cargo.lock
@@ -39,14 +39,31 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
  "once_cell",
  "version_check",
  "zerocopy",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.99"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -68,6 +85,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitflags"
+version = "2.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -75,6 +98,12 @@ checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
+
+[[package]]
+name = "bumpalo"
+version = "3.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "bytemuck"
@@ -112,6 +141,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cc"
+version = "1.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "590f9024a68a8c40351881787f1934dc11afd69090f5edb6831464694d836ea3"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "ccm"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -125,9 +164,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
 
 [[package]]
 name = "cipher"
@@ -140,6 +179,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -147,11 +195,30 @@ checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.12"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "cranelift-bitset"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
+name = "cranelift-entity"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "cranelift-bitset",
+ "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -234,7 +301,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -252,7 +319,7 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "548d977b6da32fa1d1fda2876453da1e7df63ad0304c8b3dae4dbe7b96f39b78"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "defmt-macros",
 ]
 
@@ -280,9 +347,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.7.8"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fffa369a668c8af7dbf8b5e56c9f744fbd399949ed171606040001947de40b1c"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid",
  "zeroize",
@@ -376,6 +443,12 @@ dependencies = [
 
 [[package]]
 name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
@@ -387,10 +460,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
-name = "ff"
-version = "0.13.0"
+name = "equivalent"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
  "rand_core",
  "subtle",
@@ -401,6 +490,18 @@ name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e178e4fba8a2726903f6ba98a6d221e76f9c12c650d5dc0e6afdc50677b49650"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "generic-array"
@@ -415,13 +516,19 @@ dependencies = [
 
 [[package]]
 name = "ghash"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d930750de5717d2dd0b8c0d42c076c0e884c81a73e6cab859bbd2339c71e3e40"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
 dependencies = [
  "opaque-debug",
  "polyval",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.32.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6298e594375a7fead9efd5568f0a46e6a154fb6a9bdcbe3c06946ffd81a5f6"
 
 [[package]]
 name = "group"
@@ -453,6 +560,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+ "serde",
+]
+
+[[package]]
 name = "heapless"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -461,6 +578,12 @@ dependencies = [
  "hash32",
  "stable_deref_trait",
 ]
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hmac"
@@ -472,25 +595,84 @@ dependencies = [
 ]
 
 [[package]]
-name = "inout"
-version = "0.1.3"
+name = "id-arena"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
+checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
+
+[[package]]
+name = "indexmap"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2481980430f9f78649238835720ddccc57e52df14ffce1c6f37391d61b563e9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.15.5",
+ "serde",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "generic-array",
 ]
 
 [[package]]
-name = "libc"
-version = "0.2.152"
+name = "itoa"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13e3bf6590cbc649f4d1a3eefc9d5d6eb746f5200ffb04e5e142700b8faa56e7"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "libc"
+version = "0.2.175"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
+
+[[package]]
+name = "libm"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+
+[[package]]
+name = "mach2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "memchr"
+version = "2.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+
+[[package]]
+name = "memfd"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad38eb12aea514a0466ea40a80fd8cc83637065948eb4a426e4aa46261175227"
+dependencies = [
+ "rustix",
+]
 
 [[package]]
 name = "nb"
@@ -529,16 +711,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "once_cell"
-version = "1.20.3"
+name = "object"
+version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "opaque-debug"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "p256"
@@ -572,9 +763,9 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "polyval"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52cff9d1d4dee5fe6d03729099f4a310a41179e0a10dbf542039873f2e826fb"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -587,6 +778,18 @@ name = "portable-atomic"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+
+[[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "serde",
+]
 
 [[package]]
 name = "primeorder"
@@ -629,6 +832,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "pulley-interpreter"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "cranelift-bitset",
+ "log",
+ "pulley-macros",
+ "wasmtime-internal-math",
+]
+
+[[package]]
+name = "pulley-macros"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -663,10 +887,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustversion"
-version = "1.0.21"
+name = "rustix"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
+checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
+dependencies = [
+ "bitflags 2.9.4",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "sealed"
@@ -700,22 +943,34 @@ checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 
 [[package]]
 name = "serde"
-version = "1.0.210"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.210"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.106",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.143"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -730,6 +985,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "signature"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -737,6 +998,15 @@ checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
  "rand_core",
+]
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -766,9 +1036,9 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "subtle"
-version = "2.5.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -793,19 +1063,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "thiserror"
-version = "2.0.12"
+name = "target-lexicon"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+checksum = "e502f78cdbb8ba4718f566c418c52bc729126ffd16baee5baa718cf25dd5a69a"
+
+[[package]]
+name = "thiserror"
+version = "2.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.12"
+version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+checksum = "6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -823,6 +1099,12 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "universal-hash"
@@ -874,7 +1156,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb573c76e7884035ac5e1ab4a81234c187a82b6100140af0ab45757650ccda38"
 dependencies = [
  "byteorder",
- "hashbrown",
+ "hashbrown 0.13.2",
  "log",
  "proc-macro2",
  "quote",
@@ -890,16 +1172,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "065e4eaf93db81d5adac82d9cef8f8da314cb640fa7f89534b972383f1cf80fc"
 dependencies = [
  "embedded-hal",
- "embedded-io",
+ "embedded-io 0.6.1",
  "nb 1.1.0",
  "usb-device",
 ]
 
 [[package]]
 name = "version_check"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "void"
@@ -1043,6 +1325,7 @@ dependencies = [
  "wasefire-slice-cell",
  "wasefire-store",
  "wasefire-sync",
+ "wasmtime",
 ]
 
 [[package]]
@@ -1083,19 +1366,274 @@ dependencies = [
 ]
 
 [[package]]
-name = "zerocopy"
-version = "0.7.35"
+name = "wasmparser"
+version = "0.237.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+checksum = "7d2a40ca0d2bdf4b0bf36c13a737d0b2c58e4c8aaefe1c57f336dd75369ca250"
+dependencies = [
+ "bitflags 2.9.4",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+ "serde",
+]
+
+[[package]]
+name = "wasmtime"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bitflags 2.9.4",
+ "bumpalo",
+ "cc",
+ "cfg-if",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "libc",
+ "log",
+ "mach2",
+ "memfd",
+ "object",
+ "postcard",
+ "pulley-interpreter",
+ "serde",
+ "serde_derive",
+ "smallvec",
+ "target-lexicon",
+ "wasmparser",
+ "wasmtime-environ",
+ "wasmtime-internal-asm-macros",
+ "wasmtime-internal-component-macro",
+ "wasmtime-internal-fiber",
+ "wasmtime-internal-math",
+ "wasmtime-internal-slab",
+ "wasmtime-internal-unwinder",
+ "wasmtime-internal-versioned-export-macros",
+ "windows-sys",
+]
+
+[[package]]
+name = "wasmtime-environ"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "anyhow",
+ "cranelift-bitset",
+ "cranelift-entity",
+ "gimli",
+ "indexmap",
+ "log",
+ "object",
+ "postcard",
+ "serde",
+ "serde_derive",
+ "smallvec",
+ "target-lexicon",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmtime-internal-asm-macros"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "wasmtime-internal-component-macro"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "anyhow",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+ "wasmtime-internal-component-util",
+ "wasmtime-internal-wit-bindgen",
+ "wit-parser",
+]
+
+[[package]]
+name = "wasmtime-internal-component-util"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+
+[[package]]
+name = "wasmtime-internal-fiber"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "anyhow",
+ "cc",
+ "cfg-if",
+ "libc",
+ "rustix",
+ "wasmtime-internal-asm-macros",
+ "wasmtime-internal-versioned-export-macros",
+ "windows-sys",
+]
+
+[[package]]
+name = "wasmtime-internal-math"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "libm",
+]
+
+[[package]]
+name = "wasmtime-internal-slab"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+
+[[package]]
+name = "wasmtime-internal-unwinder"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "log",
+ "object",
+]
+
+[[package]]
+name = "wasmtime-internal-versioned-export-macros"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "wasmtime-internal-wit-bindgen"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "anyhow",
+ "bitflags 2.9.4",
+ "heck",
+ "indexmap",
+ "wit-parser",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+
+[[package]]
+name = "wit-parser"
+version = "0.237.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2596a5bc7c24cc965b56ad6ff9e32394c4e401764f89620a888519c6e849ab"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.35"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/scheduler/Cargo.toml
+++ b/crates/scheduler/Cargo.toml
@@ -39,6 +39,14 @@ path = "../interpreter"
 features = ["toctou"]
 optional = true
 
+# TODO(wasmtime > 36.0.2): Use crates.io
+[dependencies.wasmtime]
+git = "https://github.com/bytecodealliance/wasmtime.git"
+rev = "0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+default-features = false
+features = ["async", "runtime"]
+optional = true
+
 [features]
 std = ["wasefire-board-api/std", "wasefire-store?/std"]
 # Logging features (enable at most one).
@@ -303,6 +311,7 @@ software-crypto-sha256 = ["board-api-crypto-sha256", "wasefire-board-api/softwar
 software-crypto-sha384 = ["board-api-crypto-sha384", "wasefire-board-api/software-crypto-sha384"]
 # Selects between Wasm applet or native applet (choose exactly one).
 native = ["dep:wasefire-sync"]
+pulley = ["dep:wasefire-common", "dep:wasefire-slice-cell", "dep:wasefire-sync", "dep:wasmtime"]
 wasm = ["dep:wasefire-interpreter", "dep:wasefire-slice-cell"]
 # Assume WASM modules being loaded are valid and do not validate them. This is a
 # safety invariant.

--- a/crates/scheduler/src/applet/store.rs
+++ b/crates/scheduler/src/applet/store.rs
@@ -15,8 +15,11 @@
 use wasefire_board_api::applet::Memory as AppletMemory;
 
 pub use self::impl_::Store;
+#[cfg(feature = "pulley")]
+pub use self::impl_::{PreStore, RunResult};
 
 #[cfg_attr(feature = "native", path = "store/native.rs")]
+#[cfg_attr(feature = "pulley", path = "store/pulley.rs")]
 #[cfg_attr(feature = "wasm", path = "store/wasm.rs")]
 mod impl_;
 

--- a/crates/scheduler/src/applet/store/pulley.rs
+++ b/crates/scheduler/src/applet/store/pulley.rs
@@ -1,0 +1,375 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![allow(const_item_mutation)]
+
+use alloc::boxed::Box;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::pin::Pin;
+use core::task::{Context, Poll, Waker};
+
+use wasefire_common::ptr::ExclusivePtr;
+use wasefire_error::{Code, Error};
+use wasefire_logger as log;
+use wasefire_slice_cell::SliceCell;
+use wasefire_sync::TakeCell;
+use wasmtime::{
+    AsContextMut, Caller, Config, Engine, ExternType, Func, Instance, Linker, Module,
+    Store as WtStore, StoreContextMut, Val, ValType,
+};
+
+use super::StoreApi;
+use crate::Trap;
+
+pub struct PreStore {
+    engine: Engine,
+    store: WtStore<()>,
+    linker: Linker<()>,
+}
+
+impl Default for PreStore {
+    fn default() -> Self {
+        let mut config = Config::new();
+        config.async_stack_size(16 * 1024);
+        config.async_support(true);
+        config.max_wasm_stack(8 * 1024);
+        config.memory_init_cow(false);
+        config.memory_reservation(0);
+        config.memory_reservation_for_growth(0);
+        config.wasm_relaxed_simd(false);
+        config.wasm_simd(false);
+        let engine = Engine::new(&config).unwrap();
+        let store = WtStore::new(&engine, ());
+        let linker = Linker::new(&engine);
+        PreStore { engine, store, linker }
+    }
+}
+
+impl PreStore {
+    pub fn link_func(&mut self, id: usize, name: &str, params: usize) -> Result<(), Error> {
+        let item = match params {
+            0 => Func::wrap_async(&mut self.store, move |caller, ()| call(caller, id, vec![])),
+            1 => Func::wrap_async(&mut self.store, move |caller, args: (u32,)| {
+                call(caller, id, vec![args.0])
+            }),
+            2 => Func::wrap_async(&mut self.store, move |caller, args: (u32, u32)| {
+                call(caller, id, vec![args.0, args.1])
+            }),
+            3 => Func::wrap_async(&mut self.store, move |caller, args: (u32, u32, u32)| {
+                call(caller, id, vec![args.0, args.1, args.2])
+            }),
+            4 => Func::wrap_async(&mut self.store, move |caller, args: (u32, u32, u32, u32)| {
+                call(caller, id, vec![args.0, args.1, args.2, args.3])
+            }),
+            5 => {
+                Func::wrap_async(&mut self.store, move |caller, args: (u32, u32, u32, u32, u32)| {
+                    call(caller, id, vec![args.0, args.1, args.2, args.3, args.4])
+                })
+            }
+            6 => Func::wrap_async(
+                &mut self.store,
+                move |caller, args: (u32, u32, u32, u32, u32, u32)| {
+                    call(caller, id, vec![args.0, args.1, args.2, args.3, args.4, args.5])
+                },
+            ),
+            7 => Func::wrap_async(
+                &mut self.store,
+                move |caller, args: (u32, u32, u32, u32, u32, u32, u32)| {
+                    call(caller, id, vec![args.0, args.1, args.2, args.3, args.4, args.5, args.6])
+                },
+            ),
+            8 => Func::wrap_async(
+                &mut self.store,
+                move |caller, args: (u32, u32, u32, u32, u32, u32, u32, u32)| {
+                    call(
+                        caller,
+                        id,
+                        vec![args.0, args.1, args.2, args.3, args.4, args.5, args.6, args.7],
+                    )
+                },
+            ),
+            _ => {
+                log::error!("Cannot link {} taking {} parameters.", name, params);
+                return Err(Error::internal(Code::NotImplemented));
+            }
+        };
+        self.linker.define(&mut self.store, "env", name, item).map_err(convert)?;
+        Ok(())
+    }
+
+    // Safety: the slice must outlive the store.
+    pub unsafe fn instantiate(mut self, pulley: &'static [u8], id: usize) -> Result<Store, Error> {
+        let Ok(module) = (unsafe { Module::deserialize_raw(&self.engine, pulley.into()) }) else {
+            log::warn!("Failed to deserialize pulley module.");
+            return Err(Error::user(Code::InvalidArgument));
+        };
+        'imports: for import in module.imports().filter(|x| x.module() == "env") {
+            let name = import.name();
+            let ExternType::Func(func) = import.ty() else { continue };
+            let None = self.linker.get(&mut self.store, "env", name) else { continue };
+            let mut params = 0;
+            for param in func.params() {
+                let ValType::I32 = param else { continue 'imports };
+                params += 1;
+            }
+            let Some(ValType::I32) = func.result(0) else { continue };
+            let None = func.result(1) else { continue };
+            self.link_func(id, name, params)?;
+        }
+        let instance = {
+            let mut instance = self.linker.instantiate_async(&mut self.store, &module);
+            let instance = unsafe { Pin::new_unchecked(&mut instance) };
+            match instance.poll(&mut CONTEXT) {
+                Poll::Ready(Ok(x)) => x,
+                Poll::Ready(Err(e)) => {
+                    log::warn!("{}", log::Debug2Format(&e));
+                    return Err(Error::user(Code::InvalidArgument));
+                }
+                Poll::Pending => unreachable!(),
+            }
+        };
+        if instance.get_memory(&mut self.store, "memory").is_none() {
+            log::warn!("Applet does not have a memory.");
+            return Err(Error::user(Code::NotFound));
+        }
+        Ok(Store {
+            instance,
+            store: Box::into_raw(Box::new(self.store)),
+            threads: Vec::new(),
+            calls: Vec::new(),
+        })
+    }
+}
+
+pub struct Store {
+    instance: Instance,
+    // Owned Box if threads is empty, otherwise the first thread exclusively owns it.
+    store: *mut WtStore<()>,
+    // There is either exactly as many calls as threads (the last thread is calling into a host
+    // function) or exactly one less (the last thread is running). The caller of each call is
+    // exclusively borrowed by the next thread. So the last caller is owned when there are as many
+    // callers as threads.
+    threads: Vec<Thread>,
+    calls: Vec<Call>,
+}
+
+type Thread = Pin<Box<dyn Future<Output = ThreadResult>>>;
+type ThreadResult = Result<Vec<Val>, Trap>;
+
+impl Drop for Store {
+    fn drop(&mut self) {
+        // It is important to drop the threads and calls in an interleaved manner since that's how
+        // they depend on each other.
+        loop {
+            if self.threads.len() == self.calls.len() {
+                if self.threads.is_empty() {
+                    break;
+                }
+                self.calls.pop();
+            } else {
+                assert_eq!(self.threads.len(), self.calls.len() + 1);
+                self.threads.pop();
+            }
+        }
+        drop(unsafe { Box::from_raw(self.store) });
+    }
+}
+
+pub enum RunResult {
+    Done(Vec<Val>),
+    Host,
+    Trap,
+}
+
+impl Store {
+    pub fn invoke(&mut self, name: &str, args: &[u32], nres: usize) -> Result<RunResult, Error> {
+        let mut context = self.context();
+        let Some(func) = self.instance.get_func(&mut context, name) else {
+            return Err(Error::internal(Code::NotFound));
+        };
+        let params: Vec<_> = args.iter().map(|&x| Val::I32(x as i32)).collect();
+        self.threads.push(Box::pin(async move {
+            let mut results = vec![Val::ExternRef(None); nres];
+            match func.call_async(context, &params, &mut results).await {
+                Ok(()) => Ok(results),
+                Err(_) => Err(Trap),
+            }
+        }));
+        Ok(self.execute())
+    }
+
+    pub fn resume(&mut self, result: u32) -> Result<RunResult, Error> {
+        assert_eq!(self.calls.len(), self.threads.len());
+        self.calls.pop();
+        STATE.put(State::Reply(result));
+        Ok(self.execute())
+    }
+
+    pub fn last_call(&self) -> Option<&Call> {
+        self.calls.last()
+    }
+
+    fn execute(&mut self) -> RunResult {
+        assert_eq!(self.calls.len() + 1, self.threads.len());
+        let thread = self.threads.last_mut().unwrap().as_mut();
+        match thread.poll(&mut CONTEXT) {
+            Poll::Ready(Ok(x)) => {
+                self.threads.pop();
+                RunResult::Done(x)
+            }
+            Poll::Ready(Err(Trap)) => RunResult::Trap,
+            Poll::Pending => {
+                let Some(State::Call(call)) = STATE.get() else { unreachable!() };
+                self.calls.push(call);
+                RunResult::Host
+            }
+        }
+    }
+
+    fn context(&mut self) -> StoreContextMut<'static, ()> {
+        assert_eq!(self.calls.len(), self.threads.len());
+        if self.threads.is_empty() {
+            unsafe { &mut *self.store }.as_context_mut()
+        } else {
+            unsafe { &mut *self.calls.last().unwrap().caller.0 }.as_context_mut()
+        }
+    }
+
+    fn memory(&mut self) -> &mut [u8] {
+        let mut context = self.context();
+        let memory = self.instance.get_memory(&mut context, "memory").unwrap();
+        memory.data_mut(context)
+    }
+}
+
+pub struct Call {
+    // This is an owned box. The lifetime is bound to the thread of this call (the one at the same
+    // index in the store).
+    caller: ExclusivePtr<Caller<'static, ()>>,
+    pub id: usize,
+    pub args: Vec<u32>,
+}
+
+impl Drop for Call {
+    fn drop(&mut self) {
+        drop(unsafe { Box::from_raw(self.caller.0) });
+    }
+}
+
+enum State {
+    Call(Call),
+    Reply(u32),
+}
+
+static STATE: TakeCell<State> = TakeCell::new(None);
+
+fn call(caller: Caller<'_, ()>, id: usize, args: Vec<u32>) -> Box<dyn Future<Output = u32> + Send> {
+    let mut caller =
+        Some(unsafe { core::mem::transmute::<Caller<'_, ()>, Caller<'static, ()>>(caller) });
+    let mut args = Some(args);
+    Box::new(core::future::poll_fn(move |_| match STATE.get() {
+        None => {
+            STATE.put(State::Call(Call {
+                caller: ExclusivePtr(Box::into_raw(Box::new(caller.take().unwrap()))),
+                id,
+                args: args.take().unwrap(),
+            }));
+            Poll::Pending
+        }
+        Some(State::Reply(x)) => Poll::Ready(x),
+        Some(State::Call(_)) => unreachable!(),
+    }))
+}
+
+impl StoreApi for Store {
+    type Memory<'a>
+        = Memory<'a>
+    where Self: 'a;
+
+    fn memory(&mut self) -> Memory<'_> {
+        Memory::new(self)
+    }
+}
+
+pub struct Memory<'a> {
+    store: *mut Store,
+    memory: SliceCell<'a, u8>,
+}
+
+impl<'a> Memory<'a> {
+    fn new(store: &'a mut Store) -> Self {
+        Self { store, memory: SliceCell::new(store.memory()) }
+    }
+
+    fn with_store<T>(&mut self, f: impl FnOnce(&mut Store) -> T) -> T {
+        self.memory.reset(); // only to free the internal state early
+        let store = unsafe { &mut *self.store };
+        let result = f(store);
+        *self = Memory::new(store);
+        result
+    }
+}
+
+impl wasefire_board_api::applet::Memory for Memory<'_> {
+    fn get(&self, ptr: u32, len: u32) -> Result<&[u8], Trap> {
+        let ptr = ptr as usize;
+        let len = len as usize;
+        let range = ptr .. ptr.checked_add(len).ok_or(Trap)?;
+        self.memory.get_range(range).map_err(|_| Trap)
+    }
+
+    fn get_mut(&self, ptr: u32, len: u32) -> Result<&mut [u8], Trap> {
+        let ptr = ptr as usize;
+        let len = len as usize;
+        let range = ptr .. ptr.checked_add(len).ok_or(Trap)?;
+        self.memory.get_range_mut(range).map_err(|_| Trap)
+    }
+
+    fn alloc(&mut self, size: u32, align: u32) -> Result<u32, Trap> {
+        self.with_store(|store| {
+            // TODO: We should ideally account this to the applet performance time.
+            match store.invoke("alloc", &[size, align], 1) {
+                Ok(RunResult::Done(xs)) => match xs[..] {
+                    [Val::I32(0)] => log::warn!("applet is out of memory"),
+                    [Val::I32(x)] => return Ok(x as u32),
+                    _ => log::warn!("applet returned expected type"),
+                },
+                Ok(RunResult::Host) => log::warn!("alloc called into host"),
+                Ok(RunResult::Trap) => log::warn!("alloc trapped"),
+                Err(x) => log::error!("alloc failed with {}", x),
+            }
+            Err(Trap)
+        })
+    }
+}
+
+const CONTEXT: Context<'static> = Context::from_waker(Waker::noop());
+
+fn convert<T>(_: T) -> Error {
+    Error::new(0x8a, 0)
+}
+
+// Those symbols are needed by Wasmtime.
+mod capi {
+    static mut TLS_PTR: *mut u8 = core::ptr::null_mut();
+    #[unsafe(no_mangle)]
+    extern "C" fn wasmtime_tls_get() -> *mut u8 {
+        unsafe { TLS_PTR }
+    }
+    #[unsafe(no_mangle)]
+    extern "C" fn wasmtime_tls_set(ptr: *mut u8) {
+        unsafe { TLS_PTR = ptr }
+    }
+}

--- a/crates/scheduler/src/event.rs
+++ b/crates/scheduler/src/event.rs
@@ -41,7 +41,7 @@ pub mod usb;
 pub mod vendor;
 
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg(feature = "native")]
+#[cfg(any(feature = "native", feature = "pulley"))]
 pub struct InstId;
 
 // TODO: This could be encoded into a u32 for performance/footprint.
@@ -207,6 +207,13 @@ pub fn process<B: Board>(scheduler: &mut Scheduler<B>, event: Event<B>) {
             )
         }
         Event::Impossible(x) => x.unreachable(),
+    }
+    #[allow(unreachable_code)] // when there are no events
+    #[cfg(feature = "pulley")]
+    {
+        use alloc::format;
+        let name = format!("cb{}", params.len() - 2);
+        scheduler.call(&name, &params);
     }
     #[allow(unreachable_code)] // when there are no events
     #[cfg(feature = "wasm")]

--- a/crates/scheduler/src/event.rs
+++ b/crates/scheduler/src/event.rs
@@ -210,18 +210,10 @@ pub fn process<B: Board>(scheduler: &mut Scheduler<B>, event: Event<B>) {
     }
     #[allow(unreachable_code)] // when there are no events
     #[cfg(feature = "pulley")]
-    {
-        use alloc::format;
-        let name = format!("cb{}", params.len() - 2);
-        scheduler.call(&name, &params);
-    }
+    scheduler.call(cb_name(params.len() - 2), &params);
     #[allow(unreachable_code)] // when there are no events
     #[cfg(feature = "wasm")]
-    {
-        use alloc::format;
-        let name = format!("cb{}", params.len() - 2);
-        scheduler.call(inst, &name, &params);
-    }
+    scheduler.call(inst, cb_name(params.len() - 2), &params);
     #[allow(unreachable_code)] // when there are no events
     #[cfg(feature = "native")]
     {
@@ -264,5 +256,16 @@ pub fn process<B: Board>(scheduler: &mut Scheduler<B>, event: Event<B>) {
             3 => schedule!(applet_cb3(x0, x1, x2)),
             _ => unimplemented!(),
         }
+    }
+}
+
+#[cfg(any(feature = "pulley", feature = "wasm"))]
+fn cb_name(params: usize) -> &'static str {
+    match params {
+        0 => "cb0",
+        1 => "cb1",
+        2 => "cb2",
+        3 => "cb3",
+        _ => unimplemented!(),
     }
 }

--- a/crates/scheduler/src/lib.rs
+++ b/crates/scheduler/src/lib.rs
@@ -370,6 +370,9 @@ impl<B: Board> Scheduler<B> {
                 }
             }
             self.process_applet();
+            if self.applet.get().is_none() {
+                return Ok(()); // applet trapped in process_applet()
+            }
         }
         assert!(matches!(self.applet.get().unwrap().pop(), EventAction::Reply));
         #[cfg(feature = "internal-debug")]
@@ -422,6 +425,9 @@ impl<B: Board> Scheduler<B> {
                 }
             }
             self.process_applet();
+            if self.applet.get().is_none() {
+                return Ok(()); // applet trapped in process_applet()
+            }
         }
         assert!(matches!(self.applet.get().unwrap().pop(), EventAction::Reply));
         #[cfg(feature = "internal-debug")]

--- a/crates/scheduler/src/lib.rs
+++ b/crates/scheduler/src/lib.rs
@@ -43,6 +43,8 @@ use wasefire_protocol::applet::ExitStatus;
 #[cfg(feature = "board-api-storage")]
 use wasefire_store as store;
 
+#[cfg(feature = "pulley")]
+use crate::applet::store::RunResult;
 use crate::applet::store::{Memory, Store, StoreApi};
 use crate::applet::{Applet, EventAction};
 use crate::event::InstId;
@@ -59,7 +61,7 @@ mod protocol;
 #[cfg(all(feature = "native", not(target_pointer_width = "32")))]
 compile_error!("Only 32-bits architectures support native applets.");
 
-exactly_one_of!["native", "wasm"];
+exactly_one_of!["native", "pulley", "wasm"];
 
 #[derive_where(Default)]
 pub struct Events<B: Board>(VecDeque<board::Event<B>>);
@@ -116,7 +118,7 @@ impl<B: Board> core::fmt::Debug for Scheduler<B> {
 
 struct SchedulerCallT<'a, B: Board> {
     scheduler: &'a mut Scheduler<B>,
-    #[cfg(feature = "wasm")]
+    #[cfg(any(feature = "pulley", feature = "wasm"))]
     args: Vec<u32>,
     #[cfg(feature = "native")]
     params: &'a [u32],
@@ -158,9 +160,9 @@ impl<'a, B: Board> Dispatch for DispatchSchedulerCall<'a, B> {
     }
 }
 
-impl<B: Board, T: Signature> SchedulerCall<'_, B, T> {
+impl<'a, B: Board, T: Signature> SchedulerCall<'a, B, T> {
     fn read(&self) -> T::Params {
-        #[cfg(feature = "wasm")]
+        #[cfg(any(feature = "pulley", feature = "wasm"))]
         let params = &self.erased.args;
         #[cfg(feature = "native")]
         let params = self.erased.params;
@@ -171,7 +173,7 @@ impl<B: Board, T: Signature> SchedulerCall<'_, B, T> {
     fn inst(&mut self) -> InstId {
         #[cfg(feature = "wasm")]
         let id = self.call().inst();
-        #[cfg(feature = "native")]
+        #[cfg(any(feature = "pulley", feature = "native"))]
         let id = InstId;
         id
     }
@@ -196,6 +198,15 @@ impl<B: Board, T: Signature> SchedulerCall<'_, B, T> {
                 None => return applet_trapped::<B>(self.scheduler(), Some(T::NAME)),
             },
         });
+        #[cfg(feature = "pulley")]
+        {
+            #[cfg(feature = "internal-debug")]
+            self.scheduler().perf.record(perf::Slot::Platform);
+            let result = self.store().resume(result as u32);
+            #[cfg(feature = "internal-debug")]
+            self.scheduler().perf.record(perf::Slot::Applets);
+            self.erased.scheduler.process_result(result);
+        }
         #[cfg(feature = "wasm")]
         {
             let results = [Val::I32(result as u32)];
@@ -227,7 +238,7 @@ impl<B: Board, T: Signature> SchedulerCall<'_, B, T> {
 }
 
 impl<B: Board> Scheduler<B> {
-    #[cfg(feature = "wasm")]
+    #[cfg(any(feature = "pulley", feature = "wasm"))]
     pub fn run() -> ! {
         let mut scheduler = Self::new();
         if let Err(error) = scheduler.start_applet() {
@@ -297,7 +308,7 @@ impl<B: Board> Scheduler<B> {
             host_funcs,
             #[cfg(feature = "native")]
             applet: applet::Slot::Running(Applet::default()),
-            #[cfg(feature = "wasm")]
+            #[cfg(any(feature = "pulley", feature = "wasm"))]
             applet: applet::Slot::Empty,
             #[cfg(feature = "board-api-timer")]
             timers: alloc::vec![None; board::Timer::<B>::SUPPORT],
@@ -326,6 +337,45 @@ impl<B: Board> Scheduler<B> {
                 }
             }
         }
+    }
+
+    #[cfg(feature = "pulley")]
+    fn start_applet(&mut self) -> Result<(), Error> {
+        // SAFETY: We stop the applet before installing a new one.
+        let pulley = unsafe { <board::Applet<B> as board::applet::Api>::get()? };
+        if pulley.is_empty() {
+            log::info!("No applet to start.");
+            return Ok(());
+        }
+        // TODO: Check the wasmtime version. Or is it done by wasmtime already?
+        log::info!("Starting applet.");
+        <board::Applet<B> as board::applet::Api>::notify_start();
+        let mut store = applet::store::PreStore::default();
+        for (id, f) in self.host_funcs.iter().enumerate() {
+            let d = f.descriptor();
+            store.link_func(id, d.name, d.params)?;
+        }
+        // SAFETY: TODO: The module signature (attesting this check) is verified at install.
+        let store = unsafe { store.instantiate(pulley, self.host_funcs.len()) }?;
+        self.applet = applet::Slot::Running(Applet::new(store));
+        #[cfg(feature = "internal-debug")]
+        self.perf.record(perf::Slot::Platform);
+        self.call("init", &[]);
+        while let Some(call) = self.applet.get().unwrap().store_mut().last_call() {
+            match self.host_funcs[call.id].descriptor().name {
+                "dp" => (),
+                x => {
+                    log::warn!("init called {} into host", log::Debug2Format(&x));
+                    return Ok(applet_trapped(self, Some(x)));
+                }
+            }
+            self.process_applet();
+        }
+        assert!(matches!(self.applet.get().unwrap().pop(), EventAction::Reply));
+        #[cfg(feature = "internal-debug")]
+        self.perf.record(perf::Slot::Applets);
+        self.call("main", &[]);
+        Ok(())
     }
 
     #[cfg(feature = "wasm")]
@@ -406,7 +456,7 @@ impl<B: Board> Scheduler<B> {
             match applet.pop() {
                 EventAction::Handle(event) => break event,
                 EventAction::Wait => self.wait_event(),
-                #[cfg(feature = "wasm")]
+                #[cfg(any(feature = "pulley", feature = "wasm"))]
                 EventAction::Reply => return true,
             }
         };
@@ -421,6 +471,48 @@ impl<B: Board> Scheduler<B> {
         #[cfg(feature = "internal-debug")]
         self.perf.record(perf::Slot::Waiting);
         self.triage_event(event);
+    }
+
+    #[cfg(feature = "pulley")]
+    fn process_applet(&mut self) {
+        let applet = match self.applet.get() {
+            Some(x) => x,
+            None => {
+                log::info!("There are no applets. Let's process events.");
+                while self.applet.get().is_none() {
+                    self.wait_event();
+                }
+                return;
+            }
+        };
+        let call = match applet.store_mut().last_call() {
+            Some(x) => x,
+            None => {
+                if applet.has_handlers() {
+                    // Continue processing events when main exits and at least one callback is
+                    // registered.
+                    let _ = self.process_event();
+                } else {
+                    self.stop_applet(ExitStatus::Exit);
+                }
+                return;
+            }
+        };
+        let api_id = match self.host_funcs.get(call.id) {
+            Some(x) => x.id(),
+            None => {
+                let error = Error::encode(Err(Error::world(wasefire_error::Code::NotImplemented)));
+                let result = applet.store_mut().resume(error as u32);
+                self.process_result(result);
+                return;
+            }
+        };
+        debug_assert_eq!(call.args.len(), api_id.descriptor().params);
+        let args = call.args.clone();
+        let erased = SchedulerCallT { scheduler: self, args };
+        let call = api_id.merge(erased);
+        log::debug!("Calling {}", log::Debug2Format(&call.id()));
+        call::process(call);
     }
 
     #[cfg(feature = "wasm")]
@@ -475,6 +567,18 @@ impl<B: Board> Scheduler<B> {
         Ok(())
     }
 
+    #[cfg(feature = "pulley")]
+    fn call(&mut self, name: &str, args: &[u32]) {
+        log::debug!("Schedule thread {}{:?}.", name, args);
+        #[cfg(feature = "internal-debug")]
+        self.perf.record(perf::Slot::Platform);
+        let applet = self.applet.get().unwrap();
+        let result = applet.store_mut().invoke(name, args, 0);
+        #[cfg(feature = "internal-debug")]
+        self.perf.record(perf::Slot::Applets);
+        self.process_result(result);
+    }
+
     #[cfg(feature = "wasm")]
     fn call(&mut self, inst: InstId, name: &str, args: &[u32]) {
         log::debug!("Schedule thread {}{:?}.", name, args);
@@ -486,6 +590,20 @@ impl<B: Board> Scheduler<B> {
         #[cfg(feature = "internal-debug")]
         self.perf.record(perf::Slot::Applets);
         self.process_answer(answer);
+    }
+
+    #[cfg(feature = "pulley")]
+    fn process_result(&mut self, result: Result<RunResult, Error>) {
+        match result {
+            Ok(RunResult::Done(x)) => {
+                log::debug!("Thread is done.");
+                debug_assert!(x.is_empty());
+                self.applet.get().unwrap().done();
+            }
+            Ok(RunResult::Host) => (),
+            Ok(RunResult::Trap) => applet_trapped::<B>(self, None),
+            Err(e) => log::panic!("{}", log::Debug2Format(&e)),
+        }
     }
 
     #[cfg(feature = "wasm")]

--- a/crates/scheduler/src/protocol.rs
+++ b/crates/scheduler/src/protocol.rs
@@ -23,7 +23,7 @@ use wasefire_error::{Code, Error};
 use wasefire_logger as log;
 #[cfg(feature = "applet-api-platform-protocol")]
 use wasefire_protocol::applet::AppletId;
-#[cfg(feature = "wasm")]
+#[cfg(any(feature = "pulley", feature = "wasm"))]
 use wasefire_protocol::applet::ExitStatus;
 use wasefire_protocol::{self as service, Api, ApiResult, Request, Service, VERSION};
 
@@ -122,7 +122,7 @@ fn process_event_<B: Board>(
         }
         #[cfg(feature = "native")]
         Api::AppletInstall(_) => return Err(Error::world(Code::NotImplemented)),
-        #[cfg(feature = "wasm")]
+        #[cfg(any(feature = "pulley", feature = "wasm"))]
         Api::AppletInstall(request) => {
             process_transfer::<B, service::AppletInstall>(scheduler, request)?
         }
@@ -130,7 +130,7 @@ fn process_event_<B: Board>(
             use crate::applet::Slot;
             let service::applet::AppletId = applet_id;
             let status = match scheduler.applet {
-                #[cfg(feature = "wasm")]
+                #[cfg(any(feature = "pulley", feature = "wasm"))]
                 Slot::Empty => return Err(Error::user(Code::NotFound)),
                 Slot::Running(_) => None,
                 Slot::Exited(x) => Some(x),
@@ -201,7 +201,7 @@ impl<B: Board> TransferKind<B> for service::PlatformUpdate {
     }
 }
 
-#[cfg(feature = "wasm")]
+#[cfg(any(feature = "pulley", feature = "wasm"))]
 impl<B: Board> TransferKind<B> for service::AppletInstall {
     type Api = board::applet::Install<B>;
     fn start(scheduler: &mut Scheduler<B>) {
@@ -274,7 +274,7 @@ impl TransferState {
 enum StateImpl {
     Normal {
         update: TransferState,
-        #[cfg(feature = "wasm")]
+        #[cfg(any(feature = "pulley", feature = "wasm"))]
         install: TransferState,
     },
     Locked,
@@ -290,7 +290,7 @@ impl Default for StateImpl {
     fn default() -> Self {
         Normal {
             update: TransferState::Ready,
-            #[cfg(feature = "wasm")]
+            #[cfg(any(feature = "pulley", feature = "wasm"))]
             install: TransferState::Ready,
         }
     }
@@ -304,7 +304,7 @@ impl StateImpl {
         }
     }
 
-    #[cfg(feature = "wasm")]
+    #[cfg(any(feature = "pulley", feature = "wasm"))]
     fn install(&mut self) -> &mut TransferState {
         match self {
             Normal { install, .. } => install,

--- a/crates/scheduler/test.sh
+++ b/crates/scheduler/test.sh
@@ -31,5 +31,7 @@ cargo check --lib --target=i686-unknown-linux-gnu --features=full-api,native,std
 cargo check --lib --target=i686-unknown-linux-gnu --features=full-api,native,std,log
 cargo check --lib --target=thumbv7em-none-eabi --features=full-api,wasm
 DEFMT_LOG=trace cargo check --lib --target=thumbv7em-none-eabi --features=full-api,wasm,defmt
+cargo check --lib --target=thumbv7em-none-eabi --features=full-api,pulley
+DEFMT_LOG=trace cargo check --lib --target=thumbv7em-none-eabi --features=full-api,pulley,defmt
 cargo check --lib --target=thumbv7em-none-eabi --features=full-api,native
 DEFMT_LOG=trace cargo check --lib --target=thumbv7em-none-eabi --features=full-api,native,defmt

--- a/crates/wasm-bench/Cargo.lock
+++ b/crates/wasm-bench/Cargo.lock
@@ -166,36 +166,32 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.123.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0920ef6863433fa28ece7e53925be4cd39a913adba2dc3738f4edd182f76d168"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
 dependencies = [
  "cranelift-assembler-x64-meta",
 ]
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.123.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8990a217e2529a378af1daf4f8afa889f928f07ebbde6ae2f058ae60e40e2c20"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
 dependencies = [
  "cranelift-srcgen",
 ]
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.123.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62225596b687f69a42c038485a28369badc186cb7c74bd9436eeec9f539011b1"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.123.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c23914fc4062558650a6f0d8c1846c97b541215a291fdeabc85f68bdc9bbcca3"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
 dependencies = [
  "serde",
  "serde_derive",
@@ -203,9 +199,8 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.123.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41a238b2f7e7ec077eb170145fa15fd8b3d0f36cc83d8e354e29ca550f339ca7"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
 dependencies = [
  "bumpalo",
  "cranelift-assembler-x64",
@@ -230,9 +225,8 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.123.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9315ddcc2512513a9d66455ec89bb70ae5498cb472f5ed990230536f4cd5c011"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
 dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
@@ -243,24 +237,21 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.123.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc6acea40ef860f28cb36eaad479e26556c1e538b0a66fc44598cf1b1689393d"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
 
 [[package]]
 name = "cranelift-control"
-version = "0.123.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b2af895da90761cfda4a4445960554fcec971e637882eda5a87337d993fe1b9"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.123.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e8c542c856feb50d504e4fc0526b3db3a514f882a9f68f956164531517828ab"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -269,9 +260,8 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.123.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9996dd9c20929c03360fe0c4edf3594c0cbb94525bdbfa04b6bb639ec14573c7"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -281,15 +271,13 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.123.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "928b8dccad51b9e0ffe54accbd617da900239439b13d48f0f122ab61105ca6ad"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
 
 [[package]]
 name = "cranelift-native"
-version = "0.123.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f75ef0a6a2efed3a2a14812318e28dc82c214eab5399c13d70878e2f88947b5"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -298,9 +286,8 @@ dependencies = [
 
 [[package]]
 name = "cranelift-srcgen"
-version = "0.123.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673bd6d1c83cb41d60afb140a1474ef6caf1a3e02f3820fc522aefbc93ac67d6"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
 
 [[package]]
 name = "crc32fast"
@@ -739,9 +726,8 @@ dependencies = [
 
 [[package]]
 name = "pulley-interpreter"
-version = "36.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4e2d31146038fd9e62bfa331db057aca325d5ca10451a9fe341356cead7da53"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
 dependencies = [
  "cranelift-bitset",
  "log",
@@ -751,9 +737,8 @@ dependencies = [
 
 [[package]]
 name = "pulley-macros"
-version = "36.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efb9fdafaca625f9ea8cfa793364ea1bdd32d306cff18f166b00ddaa61ecbb27"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -777,9 +762,9 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "regalloc2"
-version = "0.12.2"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5216b1837de2149f8bc8e6d5f88a9326b63b8c836ed58ce4a0a29ec736a59734"
+checksum = "68e18e1ef763167dc6718c28a5585e62f907590a21028b8e87be1318f19ef1cb"
 dependencies = [
  "allocator-api2",
  "bumpalo",
@@ -1180,9 +1165,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.236.1"
+version = "0.237.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "724fccfd4f3c24b7e589d333fc0429c68042897a7e8a5f8694f31792471841e7"
+checksum = "efe92d1321afa53ffc88a57c497bb7330c3cf84c98ffdba4a4caf6a0684fad3c"
 dependencies = [
  "leb128fmt",
  "wasmparser",
@@ -1190,9 +1175,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.236.1"
+version = "0.237.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9b1e81f3eb254cf7404a82cee6926a4a3ccc5aad80cc3d43608a070c67aa1d7"
+checksum = "7d2a40ca0d2bdf4b0bf36c13a737d0b2c58e4c8aaefe1c57f336dd75369ca250"
 dependencies = [
  "bitflags",
  "hashbrown",
@@ -1203,9 +1188,9 @@ dependencies = [
 
 [[package]]
 name = "wasmprinter"
-version = "0.236.1"
+version = "0.237.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2df225df06a6df15b46e3f73ca066ff92c2e023670969f7d50ce7d5e695abbb1"
+checksum = "d00c979bd801d8d7e4b40de564bcb27526fcbaf58e3aff15fe2df7e135f5b397"
 dependencies = [
  "anyhow",
  "termcolor",
@@ -1214,9 +1199,8 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "36.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b3e1fab634681494213138ea3a18e958e5ea99da13a4a01a4b870d51a41680b"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -1257,9 +1241,8 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "36.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6750e519977953a018fe994aada7e02510aea4babb03310aa5f5b4145b6e6577"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
 dependencies = [
  "anyhow",
  "cranelift-bitset",
@@ -1280,18 +1263,16 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-asm-macros"
-version = "36.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdbf38adac6e81d5c0326e8fd25f80450e3038f2fc103afd3c5cc8b83d5dd78b"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "wasmtime-internal-component-macro"
-version = "36.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26a578a474e3b7ddce063cd169ced292b5185013341457522891b10e989aa42a"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -1304,15 +1285,13 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-util"
-version = "36.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edc23d46ec1b1cd42b6f73205eb80498ed94b47098ec53456c0b18299405b158"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
 
 [[package]]
 name = "wasmtime-internal-cranelift"
-version = "36.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d85b8ba128525bff91b89ac8a97755136a4fb0fb59df5ffb7539dd646455d441"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -1332,14 +1311,14 @@ dependencies = [
  "wasmparser",
  "wasmtime-environ",
  "wasmtime-internal-math",
+ "wasmtime-internal-unwinder",
  "wasmtime-internal-versioned-export-macros",
 ]
 
 [[package]]
 name = "wasmtime-internal-fiber"
-version = "36.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c566f5137de1f55339df8a236a5ec89698b466a3d33f9cc07823a58a3f85e16"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
 dependencies = [
  "anyhow",
  "cc",
@@ -1353,9 +1332,8 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-debug"
-version = "36.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e03f0b11f8fe4d456feac11e7e9dc6f02ddb34d4f6a1912775dbc63c5bdd5670"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
 dependencies = [
  "cc",
  "wasmtime-internal-versioned-export-macros",
@@ -1363,9 +1341,8 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-icache-coherence"
-version = "36.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71aeb74f9b3fd9225319c723e59832a77a674b0c899ba9795f9b2130a6d1b167"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -1375,24 +1352,21 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-math"
-version = "36.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31d5dad8a609c6cc47a5f265f13b52e347e893450a69641af082b8a276043fa7"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
 dependencies = [
  "libm",
 ]
 
 [[package]]
 name = "wasmtime-internal-slab"
-version = "36.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d152a7b875d62e395bfe0ae7d12e7b47cd332eb380353cce3eb831f9843731d"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
 
 [[package]]
 name = "wasmtime-internal-unwinder"
-version = "36.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aaacc0fea00293f7af7e6c25cef74b7d213ebbe7560c86305eec15fc318fab8"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -1403,9 +1377,8 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-versioned-export-macros"
-version = "36.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61c7f75326434944cc5f3b75409a063fa37e537f6247f00f0f733679f0be406"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1414,9 +1387,8 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-wit-bindgen"
-version = "36.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "169042d58002f16da149ab7d608b71164411abd1fc5140f48f4c200b44bb5565"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -1582,9 +1554,9 @@ checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "wit-parser"
-version = "0.236.1"
+version = "0.237.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16e4833a20cd6e85d6abfea0e63a399472d6f88c6262957c17f546879a80ba15"
+checksum = "ce2596a5bc7c24cc965b56ad6ff9e32394c4e401764f89620a888519c6e849ab"
 dependencies = [
  "anyhow",
  "id-arena",

--- a/crates/wasm-bench/Cargo.toml
+++ b/crates/wasm-bench/Cargo.toml
@@ -16,8 +16,10 @@ riscv-rt = { version = "0.15.0", optional = true }
 semihosting = { version = "0.1.20", features = ["panic-handler", "stdio"], optional = true }
 wasefire-sync = { version = "0.1.2-git", path = "../sync", optional = true }
 
+# TODO(wasmtime > 36.0.2): Use crates.io
 [dependencies.wasmtime]
-version = "36.0.2"
+git = "https://github.com/bytecodealliance/wasmtime.git"
+rev = "0744262f79e235b172331f5ba1a2c43b5aedcbfb"
 default-features = false
 features = ["async", "runtime"]
 optional = true
@@ -27,8 +29,10 @@ path = "../interpreter"
 features = ["float-types"]
 optional = true
 
+# TODO(wasmtime > 36.0.2): Use crates.io
 [build-dependencies.wasmtime]
-version = "36.0.2"
+git = "https://github.com/bytecodealliance/wasmtime.git"
+rev = "0744262f79e235b172331f5ba1a2c43b5aedcbfb"
 default-features = false
 features = ["cranelift", "pulley"]
 optional = true

--- a/crates/xtask/Cargo.lock
+++ b/crates/xtask/Cargo.lock
@@ -8,7 +8,16 @@ version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
 dependencies = [
- "gimli",
+ "gimli 0.31.1",
+]
+
+[[package]]
+name = "addr2line"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9acbfca36652500c911ddb767ed433e3ed99b032b5d935be73c6923662db1d43"
+dependencies = [
+ "gimli 0.32.2",
 ]
 
 [[package]]
@@ -25,6 +34,12 @@ checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "anstream"
@@ -83,6 +98,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -100,7 +121,7 @@ version = "0.3.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
 dependencies = [
- "addr2line",
+ "addr2line 0.24.2",
  "cfg-if",
  "libc",
  "miniz_oxide",
@@ -132,6 +153,9 @@ name = "bumpalo"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+dependencies = [
+ "allocator-api2",
+]
 
 [[package]]
 name = "bytemuck"
@@ -256,6 +280,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -300,6 +333,131 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cranelift-assembler-x64"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "cranelift-assembler-x64-meta",
+]
+
+[[package]]
+name = "cranelift-assembler-x64-meta"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "cranelift-srcgen",
+]
+
+[[package]]
+name = "cranelift-bforest"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "cranelift-entity",
+]
+
+[[package]]
+name = "cranelift-bitset"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
+name = "cranelift-codegen"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "bumpalo",
+ "cranelift-assembler-x64",
+ "cranelift-bforest",
+ "cranelift-bitset",
+ "cranelift-codegen-meta",
+ "cranelift-codegen-shared",
+ "cranelift-control",
+ "cranelift-entity",
+ "cranelift-isle",
+ "gimli 0.32.2",
+ "hashbrown",
+ "log",
+ "pulley-interpreter",
+ "regalloc2",
+ "rustc-hash",
+ "serde",
+ "smallvec",
+ "target-lexicon",
+ "wasmtime-internal-math",
+]
+
+[[package]]
+name = "cranelift-codegen-meta"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "cranelift-assembler-x64-meta",
+ "cranelift-codegen-shared",
+ "cranelift-srcgen",
+ "heck",
+ "pulley-interpreter",
+]
+
+[[package]]
+name = "cranelift-codegen-shared"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+
+[[package]]
+name = "cranelift-control"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "arbitrary",
+]
+
+[[package]]
+name = "cranelift-entity"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "cranelift-bitset",
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
+name = "cranelift-frontend"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "cranelift-codegen",
+ "log",
+ "smallvec",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-isle"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+
+[[package]]
+name = "cranelift-native"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "cranelift-codegen",
+ "libc",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-srcgen"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -335,6 +493,24 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "encode_unicode"
@@ -398,6 +574,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
 name = "fastrand"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -430,6 +612,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foreign-types"
@@ -512,6 +700,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
+name = "gimli"
+version = "0.32.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6298e594375a7fead9efd5568f0a46e6a154fb6a9bdcbe3c06946ffd81a5f6"
+dependencies = [
+ "fallible-iterator",
+ "indexmap",
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "h2"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -544,6 +743,10 @@ name = "hashbrown"
 version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
+dependencies = [
+ "foldhash",
+ "serde",
+]
 
 [[package]]
 name = "heapless"
@@ -799,6 +1002,7 @@ checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
  "hashbrown",
+ "serde",
 ]
 
 [[package]]
@@ -857,6 +1061,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -903,10 +1116,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "libc"
 version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
+
+[[package]]
+name = "libm"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "libredox"
@@ -956,6 +1181,12 @@ name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "litemap"
@@ -1087,7 +1318,10 @@ version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
 dependencies = [
+ "crc32fast",
  "flate2",
+ "hashbrown",
+ "indexmap",
  "memchr",
  "ruzstd",
 ]
@@ -1220,6 +1454,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "serde",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1238,6 +1484,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "pulley-interpreter"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "cranelift-bitset",
+ "log",
+ "pulley-macros",
+ "wasmtime-internal-math",
+]
+
+[[package]]
+name = "pulley-macros"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1253,6 +1520,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
 dependencies = [
  "bitflags 2.9.4",
+]
+
+[[package]]
+name = "regalloc2"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68e18e1ef763167dc6718c28a5585e62f907590a21028b8e87be1318f19ef1cb"
+dependencies = [
+ "allocator-api2",
+ "bumpalo",
+ "hashbrown",
+ "log",
+ "rustc-hash",
+ "smallvec",
 ]
 
 [[package]]
@@ -1353,6 +1634,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
 name = "rustix"
 version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1361,7 +1648,20 @@ dependencies = [
  "bitflags 2.9.4",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
+dependencies = [
+ "bitflags 2.9.4",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.9.4",
  "windows-sys 0.52.0",
 ]
 
@@ -1591,6 +1891,9 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "socket2"
@@ -1703,6 +2006,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "target-lexicon"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e502f78cdbb8ba4718f566c418c52bc729126ffd16baee5baa718cf25dd5a69a"
+
+[[package]]
 name = "tempfile"
 version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1711,8 +2020,17 @@ dependencies = [
  "cfg-if",
  "fastrand",
  "once_cell",
- "rustix",
+ "rustix 0.38.44",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -2095,6 +2413,7 @@ dependencies = [
  "wasefire-protocol-tokio",
  "wasefire-protocol-usb",
  "wasefire-wire",
+ "wasmtime",
 ]
 
 [[package]]
@@ -2279,6 +2598,195 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.237.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efe92d1321afa53ffc88a57c497bb7330c3cf84c98ffdba4a4caf6a0684fad3c"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.237.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d2a40ca0d2bdf4b0bf36c13a737d0b2c58e4c8aaefe1c57f336dd75369ca250"
+dependencies = [
+ "bitflags 2.9.4",
+ "hashbrown",
+ "indexmap",
+ "semver",
+ "serde",
+]
+
+[[package]]
+name = "wasmprinter"
+version = "0.237.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d00c979bd801d8d7e4b40de564bcb27526fcbaf58e3aff15fe2df7e135f5b397"
+dependencies = [
+ "anyhow",
+ "termcolor",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmtime"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "addr2line 0.25.0",
+ "anyhow",
+ "bitflags 2.9.4",
+ "bumpalo",
+ "cfg-if",
+ "hashbrown",
+ "indexmap",
+ "libc",
+ "log",
+ "object 0.37.3",
+ "once_cell",
+ "postcard",
+ "pulley-interpreter",
+ "rustix 1.0.8",
+ "serde",
+ "serde_derive",
+ "target-lexicon",
+ "wasmparser",
+ "wasmtime-environ",
+ "wasmtime-internal-cranelift",
+ "wasmtime-internal-fiber",
+ "wasmtime-internal-jit-debug",
+ "wasmtime-internal-jit-icache-coherence",
+ "wasmtime-internal-math",
+ "wasmtime-internal-unwinder",
+ "wasmtime-internal-versioned-export-macros",
+]
+
+[[package]]
+name = "wasmtime-environ"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "anyhow",
+ "cranelift-bitset",
+ "cranelift-entity",
+ "gimli 0.32.2",
+ "indexmap",
+ "log",
+ "object 0.37.3",
+ "postcard",
+ "serde",
+ "serde_derive",
+ "smallvec",
+ "target-lexicon",
+ "wasm-encoder",
+ "wasmparser",
+ "wasmprinter",
+]
+
+[[package]]
+name = "wasmtime-internal-asm-macros"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "wasmtime-internal-cranelift"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "cranelift-codegen",
+ "cranelift-control",
+ "cranelift-entity",
+ "cranelift-frontend",
+ "cranelift-native",
+ "gimli 0.32.2",
+ "itertools",
+ "log",
+ "object 0.37.3",
+ "pulley-interpreter",
+ "smallvec",
+ "target-lexicon",
+ "thiserror",
+ "wasmparser",
+ "wasmtime-environ",
+ "wasmtime-internal-math",
+ "wasmtime-internal-unwinder",
+ "wasmtime-internal-versioned-export-macros",
+]
+
+[[package]]
+name = "wasmtime-internal-fiber"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "anyhow",
+ "cc",
+ "cfg-if",
+ "libc",
+ "rustix 1.0.8",
+ "wasmtime-internal-asm-macros",
+ "wasmtime-internal-versioned-export-macros",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "wasmtime-internal-jit-debug"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "cc",
+ "wasmtime-internal-versioned-export-macros",
+]
+
+[[package]]
+name = "wasmtime-internal-jit-icache-coherence"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "libc",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "wasmtime-internal-math"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "libm",
+]
+
+[[package]]
+name = "wasmtime-internal-unwinder"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "cranelift-codegen",
+ "log",
+ "object 0.37.3",
+]
+
+[[package]]
+name = "wasmtime-internal-versioned-export-macros"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2313,6 +2821,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0978bf7171b3d90bac376700cb56d606feb40f251a475a5d6634613564460b22"
+dependencies = [
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/examples/rust/exercises/client/Cargo.lock
+++ b/examples/rust/exercises/client/Cargo.lock
@@ -8,7 +8,16 @@ version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
 dependencies = [
- "gimli",
+ "gimli 0.31.1",
+]
+
+[[package]]
+name = "addr2line"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9acbfca36652500c911ddb767ed433e3ed99b032b5d935be73c6923662db1d43"
+dependencies = [
+ "gimli 0.32.2",
 ]
 
 [[package]]
@@ -16,6 +25,12 @@ name = "adler2"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "anstream"
@@ -74,6 +89,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -91,11 +112,11 @@ version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
 dependencies = [
- "addr2line",
+ "addr2line 0.24.2",
  "cfg-if",
  "libc",
  "miniz_oxide",
- "object",
+ "object 0.36.7",
  "rustc-demangle",
  "windows-targets 0.52.6",
 ]
@@ -144,6 +165,9 @@ name = "bumpalo"
 version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+dependencies = [
+ "allocator-api2",
+]
 
 [[package]]
 name = "bytemuck"
@@ -347,6 +371,131 @@ dependencies = [
 ]
 
 [[package]]
+name = "cranelift-assembler-x64"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "cranelift-assembler-x64-meta",
+]
+
+[[package]]
+name = "cranelift-assembler-x64-meta"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "cranelift-srcgen",
+]
+
+[[package]]
+name = "cranelift-bforest"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "cranelift-entity",
+]
+
+[[package]]
+name = "cranelift-bitset"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
+name = "cranelift-codegen"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "bumpalo",
+ "cranelift-assembler-x64",
+ "cranelift-bforest",
+ "cranelift-bitset",
+ "cranelift-codegen-meta",
+ "cranelift-codegen-shared",
+ "cranelift-control",
+ "cranelift-entity",
+ "cranelift-isle",
+ "gimli 0.32.2",
+ "hashbrown",
+ "log",
+ "pulley-interpreter",
+ "regalloc2",
+ "rustc-hash",
+ "serde",
+ "smallvec",
+ "target-lexicon",
+ "wasmtime-internal-math",
+]
+
+[[package]]
+name = "cranelift-codegen-meta"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "cranelift-assembler-x64-meta",
+ "cranelift-codegen-shared",
+ "cranelift-srcgen",
+ "heck",
+ "pulley-interpreter",
+]
+
+[[package]]
+name = "cranelift-codegen-shared"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+
+[[package]]
+name = "cranelift-control"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "arbitrary",
+]
+
+[[package]]
+name = "cranelift-entity"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "cranelift-bitset",
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
+name = "cranelift-frontend"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "cranelift-codegen",
+ "log",
+ "smallvec",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-isle"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+
+[[package]]
+name = "cranelift-native"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "cranelift-codegen",
+ "libc",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-srcgen"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+
+[[package]]
 name = "crc32fast"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -443,6 +592,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
 name = "elliptic-curve"
 version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -513,6 +668,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -555,6 +716,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foreign-types"
@@ -660,6 +827,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
+name = "gimli"
+version = "0.32.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6298e594375a7fead9efd5568f0a46e6a154fb6a9bdcbe3c06946ffd81a5f6"
+dependencies = [
+ "fallible-iterator",
+ "indexmap",
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -703,6 +881,10 @@ name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+dependencies = [
+ "foldhash",
+ "serde",
+]
 
 [[package]]
 name = "heapless"
@@ -999,6 +1181,7 @@ checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
 dependencies = [
  "equivalent",
  "hashbrown",
+ "serde",
 ]
 
 [[package]]
@@ -1065,6 +1248,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1081,10 +1273,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "libc"
 version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+
+[[package]]
+name = "libm"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "libredox"
@@ -1114,6 +1318,12 @@ name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "litemap"
@@ -1226,6 +1436,18 @@ version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "crc32fast",
+ "hashbrown",
+ "indexmap",
  "memchr",
 ]
 
@@ -1395,6 +1617,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "pulley-interpreter"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "cranelift-bitset",
+ "log",
+ "pulley-macros",
+ "wasmtime-internal-math",
+]
+
+[[package]]
+name = "pulley-macros"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1454,6 +1697,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b8c0c260b63a8219631167be35e6a988e9554dbd323f8bd08439c8ed1302bd1"
 dependencies = [
  "bitflags 2.9.1",
+]
+
+[[package]]
+name = "regalloc2"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68e18e1ef763167dc6718c28a5585e62f907590a21028b8e87be1318f19ef1cb"
+dependencies = [
+ "allocator-api2",
+ "bumpalo",
+ "hashbrown",
+ "log",
+ "rustc-hash",
+ "smallvec",
 ]
 
 [[package]]
@@ -1535,6 +1792,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
 name = "rustix"
 version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1543,7 +1806,20 @@ dependencies = [
  "bitflags 2.9.1",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
+dependencies = [
+ "bitflags 2.9.1",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.9.4",
  "windows-sys 0.52.0",
 ]
 
@@ -1801,6 +2077,9 @@ name = "smallvec"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "socket2"
@@ -1911,6 +2190,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "target-lexicon"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e502f78cdbb8ba4718f566c418c52bc729126ffd16baee5baa718cf25dd5a69a"
+
+[[package]]
 name = "tempfile"
 version = "3.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1920,8 +2205,17 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.3",
  "once_cell",
- "rustix",
+ "rustix 0.38.44",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -2333,6 +2627,7 @@ dependencies = [
  "wasefire-protocol-tokio",
  "wasefire-protocol-usb",
  "wasefire-wire",
+ "wasmtime",
 ]
 
 [[package]]
@@ -2527,6 +2822,195 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.237.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efe92d1321afa53ffc88a57c497bb7330c3cf84c98ffdba4a4caf6a0684fad3c"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.237.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d2a40ca0d2bdf4b0bf36c13a737d0b2c58e4c8aaefe1c57f336dd75369ca250"
+dependencies = [
+ "bitflags 2.9.1",
+ "hashbrown",
+ "indexmap",
+ "semver",
+ "serde",
+]
+
+[[package]]
+name = "wasmprinter"
+version = "0.237.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d00c979bd801d8d7e4b40de564bcb27526fcbaf58e3aff15fe2df7e135f5b397"
+dependencies = [
+ "anyhow",
+ "termcolor",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmtime"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "addr2line 0.25.0",
+ "anyhow",
+ "bitflags 2.9.1",
+ "bumpalo",
+ "cfg-if",
+ "hashbrown",
+ "indexmap",
+ "libc",
+ "log",
+ "object 0.37.3",
+ "once_cell",
+ "postcard",
+ "pulley-interpreter",
+ "rustix 1.0.8",
+ "serde",
+ "serde_derive",
+ "target-lexicon",
+ "wasmparser",
+ "wasmtime-environ",
+ "wasmtime-internal-cranelift",
+ "wasmtime-internal-fiber",
+ "wasmtime-internal-jit-debug",
+ "wasmtime-internal-jit-icache-coherence",
+ "wasmtime-internal-math",
+ "wasmtime-internal-unwinder",
+ "wasmtime-internal-versioned-export-macros",
+]
+
+[[package]]
+name = "wasmtime-environ"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "anyhow",
+ "cranelift-bitset",
+ "cranelift-entity",
+ "gimli 0.32.2",
+ "indexmap",
+ "log",
+ "object 0.37.3",
+ "postcard",
+ "serde",
+ "serde_derive",
+ "smallvec",
+ "target-lexicon",
+ "wasm-encoder",
+ "wasmparser",
+ "wasmprinter",
+]
+
+[[package]]
+name = "wasmtime-internal-asm-macros"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "wasmtime-internal-cranelift"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "cranelift-codegen",
+ "cranelift-control",
+ "cranelift-entity",
+ "cranelift-frontend",
+ "cranelift-native",
+ "gimli 0.32.2",
+ "itertools",
+ "log",
+ "object 0.37.3",
+ "pulley-interpreter",
+ "smallvec",
+ "target-lexicon",
+ "thiserror 2.0.12",
+ "wasmparser",
+ "wasmtime-environ",
+ "wasmtime-internal-math",
+ "wasmtime-internal-unwinder",
+ "wasmtime-internal-versioned-export-macros",
+]
+
+[[package]]
+name = "wasmtime-internal-fiber"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "anyhow",
+ "cc",
+ "cfg-if",
+ "libc",
+ "rustix 1.0.8",
+ "wasmtime-internal-asm-macros",
+ "wasmtime-internal-versioned-export-macros",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "wasmtime-internal-jit-debug"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "cc",
+ "wasmtime-internal-versioned-export-macros",
+]
+
+[[package]]
+name = "wasmtime-internal-jit-icache-coherence"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "libc",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "wasmtime-internal-math"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "libm",
+]
+
+[[package]]
+name = "wasmtime-internal-unwinder"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "cranelift-codegen",
+ "log",
+ "object 0.37.3",
+]
+
+[[package]]
+name = "wasmtime-internal-versioned-export-macros"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2561,6 +3045,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0978bf7171b3d90bac376700cb56d606feb40f251a475a5d6634613564460b22"
+dependencies = [
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/examples/rust/hsm/host/Cargo.lock
+++ b/examples/rust/hsm/host/Cargo.lock
@@ -8,7 +8,16 @@ version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
 dependencies = [
- "gimli",
+ "gimli 0.31.1",
+]
+
+[[package]]
+name = "addr2line"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9acbfca36652500c911ddb767ed433e3ed99b032b5d935be73c6923662db1d43"
+dependencies = [
+ "gimli 0.32.2",
 ]
 
 [[package]]
@@ -25,6 +34,12 @@ checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "anstream"
@@ -83,6 +98,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -100,11 +121,11 @@ version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
 dependencies = [
- "addr2line",
+ "addr2line 0.24.2",
  "cfg-if",
  "libc",
  "miniz_oxide",
- "object",
+ "object 0.36.7",
  "rustc-demangle",
  "windows-targets 0.52.6",
 ]
@@ -132,6 +153,9 @@ name = "bumpalo"
 version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+dependencies = [
+ "allocator-api2",
+]
 
 [[package]]
 name = "bytemuck"
@@ -256,6 +280,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror 2.0.16",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -307,6 +340,131 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cranelift-assembler-x64"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "cranelift-assembler-x64-meta",
+]
+
+[[package]]
+name = "cranelift-assembler-x64-meta"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "cranelift-srcgen",
+]
+
+[[package]]
+name = "cranelift-bforest"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "cranelift-entity",
+]
+
+[[package]]
+name = "cranelift-bitset"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
+name = "cranelift-codegen"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "bumpalo",
+ "cranelift-assembler-x64",
+ "cranelift-bforest",
+ "cranelift-bitset",
+ "cranelift-codegen-meta",
+ "cranelift-codegen-shared",
+ "cranelift-control",
+ "cranelift-entity",
+ "cranelift-isle",
+ "gimli 0.32.2",
+ "hashbrown",
+ "log",
+ "pulley-interpreter",
+ "regalloc2",
+ "rustc-hash",
+ "serde",
+ "smallvec",
+ "target-lexicon",
+ "wasmtime-internal-math",
+]
+
+[[package]]
+name = "cranelift-codegen-meta"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "cranelift-assembler-x64-meta",
+ "cranelift-codegen-shared",
+ "cranelift-srcgen",
+ "heck",
+ "pulley-interpreter",
+]
+
+[[package]]
+name = "cranelift-codegen-shared"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+
+[[package]]
+name = "cranelift-control"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "arbitrary",
+]
+
+[[package]]
+name = "cranelift-entity"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "cranelift-bitset",
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
+name = "cranelift-frontend"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "cranelift-codegen",
+ "log",
+ "smallvec",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-isle"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+
+[[package]]
+name = "cranelift-native"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "cranelift-codegen",
+ "libc",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-srcgen"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+
+[[package]]
 name = "crc32fast"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -342,6 +500,24 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "encode_unicode"
@@ -405,6 +581,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -437,6 +619,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foreign-types"
@@ -531,6 +719,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
+name = "gimli"
+version = "0.32.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6298e594375a7fead9efd5568f0a46e6a154fb6a9bdcbe3c06946ffd81a5f6"
+dependencies = [
+ "fallible-iterator",
+ "indexmap",
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "h2"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -563,6 +762,10 @@ name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+dependencies = [
+ "foldhash",
+ "serde",
+]
 
 [[package]]
 name = "heapless"
@@ -862,6 +1065,7 @@ checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
 dependencies = [
  "equivalent",
  "hashbrown",
+ "serde",
 ]
 
 [[package]]
@@ -920,6 +1124,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -960,10 +1173,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "libc"
 version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+
+[[package]]
+name = "libm"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "libredox"
@@ -993,6 +1218,12 @@ name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "litemap"
@@ -1109,6 +1340,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "crc32fast",
+ "hashbrown",
+ "indexmap",
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1213,12 +1456,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "serde",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "pulley-interpreter"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "cranelift-bitset",
+ "log",
+ "pulley-macros",
+ "wasmtime-internal-math",
+]
+
+[[package]]
+name = "pulley-macros"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1237,6 +1513,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b8c0c260b63a8219631167be35e6a988e9554dbd323f8bd08439c8ed1302bd1"
 dependencies = [
  "bitflags 2.9.0",
+]
+
+[[package]]
+name = "regalloc2"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68e18e1ef763167dc6718c28a5585e62f907590a21028b8e87be1318f19ef1cb"
+dependencies = [
+ "allocator-api2",
+ "bumpalo",
+ "hashbrown",
+ "log",
+ "rustc-hash",
+ "smallvec",
 ]
 
 [[package]]
@@ -1337,6 +1627,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
 name = "rustix"
 version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1345,7 +1641,20 @@ dependencies = [
  "bitflags 2.9.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
+dependencies = [
+ "bitflags 2.9.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.9.4",
  "windows-sys 0.52.0",
 ]
 
@@ -1568,6 +1877,9 @@ name = "smallvec"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "socket2"
@@ -1668,6 +1980,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "target-lexicon"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e502f78cdbb8ba4718f566c418c52bc729126ffd16baee5baa718cf25dd5a69a"
+
+[[package]]
 name = "tempfile"
 version = "3.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1677,8 +1995,17 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.1",
  "once_cell",
- "rustix",
+ "rustix 0.38.44",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -2078,6 +2405,7 @@ dependencies = [
  "wasefire-protocol-tokio",
  "wasefire-protocol-usb",
  "wasefire-wire",
+ "wasmtime",
 ]
 
 [[package]]
@@ -2272,6 +2600,195 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.237.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efe92d1321afa53ffc88a57c497bb7330c3cf84c98ffdba4a4caf6a0684fad3c"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.237.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d2a40ca0d2bdf4b0bf36c13a737d0b2c58e4c8aaefe1c57f336dd75369ca250"
+dependencies = [
+ "bitflags 2.9.0",
+ "hashbrown",
+ "indexmap",
+ "semver",
+ "serde",
+]
+
+[[package]]
+name = "wasmprinter"
+version = "0.237.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d00c979bd801d8d7e4b40de564bcb27526fcbaf58e3aff15fe2df7e135f5b397"
+dependencies = [
+ "anyhow",
+ "termcolor",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmtime"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "addr2line 0.25.0",
+ "anyhow",
+ "bitflags 2.9.0",
+ "bumpalo",
+ "cfg-if",
+ "hashbrown",
+ "indexmap",
+ "libc",
+ "log",
+ "object 0.37.3",
+ "once_cell",
+ "postcard",
+ "pulley-interpreter",
+ "rustix 1.0.8",
+ "serde",
+ "serde_derive",
+ "target-lexicon",
+ "wasmparser",
+ "wasmtime-environ",
+ "wasmtime-internal-cranelift",
+ "wasmtime-internal-fiber",
+ "wasmtime-internal-jit-debug",
+ "wasmtime-internal-jit-icache-coherence",
+ "wasmtime-internal-math",
+ "wasmtime-internal-unwinder",
+ "wasmtime-internal-versioned-export-macros",
+]
+
+[[package]]
+name = "wasmtime-environ"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "anyhow",
+ "cranelift-bitset",
+ "cranelift-entity",
+ "gimli 0.32.2",
+ "indexmap",
+ "log",
+ "object 0.37.3",
+ "postcard",
+ "serde",
+ "serde_derive",
+ "smallvec",
+ "target-lexicon",
+ "wasm-encoder",
+ "wasmparser",
+ "wasmprinter",
+]
+
+[[package]]
+name = "wasmtime-internal-asm-macros"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "wasmtime-internal-cranelift"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "cranelift-codegen",
+ "cranelift-control",
+ "cranelift-entity",
+ "cranelift-frontend",
+ "cranelift-native",
+ "gimli 0.32.2",
+ "itertools",
+ "log",
+ "object 0.37.3",
+ "pulley-interpreter",
+ "smallvec",
+ "target-lexicon",
+ "thiserror 2.0.16",
+ "wasmparser",
+ "wasmtime-environ",
+ "wasmtime-internal-math",
+ "wasmtime-internal-unwinder",
+ "wasmtime-internal-versioned-export-macros",
+]
+
+[[package]]
+name = "wasmtime-internal-fiber"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "anyhow",
+ "cc",
+ "cfg-if",
+ "libc",
+ "rustix 1.0.8",
+ "wasmtime-internal-asm-macros",
+ "wasmtime-internal-versioned-export-macros",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "wasmtime-internal-jit-debug"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "cc",
+ "wasmtime-internal-versioned-export-macros",
+]
+
+[[package]]
+name = "wasmtime-internal-jit-icache-coherence"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "libc",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "wasmtime-internal-math"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "libm",
+]
+
+[[package]]
+name = "wasmtime-internal-unwinder"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "cranelift-codegen",
+ "log",
+ "object 0.37.3",
+]
+
+[[package]]
+name = "wasmtime-internal-versioned-export-macros"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2306,6 +2823,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0978bf7171b3d90bac376700cb56d606feb40f251a475a5d6634613564460b22"
+dependencies = [
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/examples/rust/opensk/README.md
+++ b/examples/rust/opensk/README.md
@@ -58,7 +58,18 @@ replacing `--native` with `--pulley` and:
 - For the first run, removing everything between `applet` (included) and `runner` (excluded).
 - For the second run, replacing everything after `runner` (included) with `install`.
 
-See the host platform below for an example.
+For example, if the native command is:
+
+```shell
+cargo xtask --native applet rust opensk $APPLET_FEATURES runner foo $PLATFORM_FEATURES flash
+```
+
+Then the 2 pulley commands (respectively for the platform and the applet) would be:
+
+```shell
+cargo xtask --pulley runner foo $PLATFORM_FEATURES flash
+cargo xtask --pulley applet rust opensk $APPLET_FEATURES install
+```
 
 ### Host
 

--- a/examples/rust/opensk/README.md
+++ b/examples/rust/opensk/README.md
@@ -11,11 +11,6 @@ The applet provides a few customization features (all disabled by default):
 - `ed25519` enables support for Ed25519 (the applet always implements ECDSA P-256)
 - `fingerprint` enables support for fingerprints
 
-## Limitations
-
-The applet can only be compiled natively with a platform. It cannot be compiled as a Web-Assembly
-applet at this time. This limitation will be lifted in the future.
-
 ## Platforms
 
 The applet needs the platform to implement the following features of the board API:
@@ -52,6 +47,19 @@ features to enable if it does.
 
 Note that you may need to run `./scripts/setup.sh` if any command fails.
 
+## Targets
+
+Only native and pulley applets are supported, due to the size and complexity of the applet. It is
+not possible to use a wasm applet at this time. This limitation may be lifted in the future.
+
+The commands below are given for native applets. For pulley applets, the command must be run twice,
+replacing `--native` with `--pulley` and:
+
+- For the first run, removing everything between `applet` (included) and `runner` (excluded).
+- For the second run, replacing everything after `runner` (included) with `install`.
+
+See the host platform below for an example.
+
 ### Host
 
 #### Feature: ctap1
@@ -66,13 +74,25 @@ The applet feature `ed25519` is supported and doesn't need any platform feature.
 
 The applet feature `fingerprint` is not supported.
 
-#### Board
+#### Target: native
 
 ```shell
-cargo xtask --native \
-  applet rust opensk $APPLET_FEATURES \
-  runner host $PLATFORM_FEATURES \
-  flash --reset-flash --usb-ctap --interface=web
+cargo xtask --native applet rust opensk $APPLET_FEATURES \
+  runner host flash --reset-flash --usb-ctap --interface=web
+```
+
+#### Target: pulley
+
+Start the platform in its own terminal:
+
+```shell
+cargo xtask --pulley runner host flash --reset-flash --usb-ctap --interface=web
+```
+
+Install the applet from another terminal:
+
+```shell
+cargo xtask --pulley applet rust opensk $APPLET_FEATURES install
 ```
 
 ### nRF52840

--- a/examples/rust/protocol/host/Cargo.lock
+++ b/examples/rust/protocol/host/Cargo.lock
@@ -8,7 +8,16 @@ version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
 dependencies = [
- "gimli",
+ "gimli 0.31.1",
+]
+
+[[package]]
+name = "addr2line"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9acbfca36652500c911ddb767ed433e3ed99b032b5d935be73c6923662db1d43"
+dependencies = [
+ "gimli 0.32.2",
 ]
 
 [[package]]
@@ -25,6 +34,12 @@ checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "anstream"
@@ -83,6 +98,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -100,11 +121,11 @@ version = "0.3.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
 dependencies = [
- "addr2line",
+ "addr2line 0.24.2",
  "cfg-if",
  "libc",
  "miniz_oxide",
- "object",
+ "object 0.36.7",
  "rustc-demangle",
  "windows-targets 0.52.6",
 ]
@@ -132,6 +153,9 @@ name = "bumpalo"
 version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+dependencies = [
+ "allocator-api2",
+]
 
 [[package]]
 name = "bytemuck"
@@ -256,6 +280,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror 2.0.12",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -300,6 +333,131 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cranelift-assembler-x64"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "cranelift-assembler-x64-meta",
+]
+
+[[package]]
+name = "cranelift-assembler-x64-meta"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "cranelift-srcgen",
+]
+
+[[package]]
+name = "cranelift-bforest"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "cranelift-entity",
+]
+
+[[package]]
+name = "cranelift-bitset"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
+name = "cranelift-codegen"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "bumpalo",
+ "cranelift-assembler-x64",
+ "cranelift-bforest",
+ "cranelift-bitset",
+ "cranelift-codegen-meta",
+ "cranelift-codegen-shared",
+ "cranelift-control",
+ "cranelift-entity",
+ "cranelift-isle",
+ "gimli 0.32.2",
+ "hashbrown",
+ "log",
+ "pulley-interpreter",
+ "regalloc2",
+ "rustc-hash",
+ "serde",
+ "smallvec",
+ "target-lexicon",
+ "wasmtime-internal-math",
+]
+
+[[package]]
+name = "cranelift-codegen-meta"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "cranelift-assembler-x64-meta",
+ "cranelift-codegen-shared",
+ "cranelift-srcgen",
+ "heck",
+ "pulley-interpreter",
+]
+
+[[package]]
+name = "cranelift-codegen-shared"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+
+[[package]]
+name = "cranelift-control"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "arbitrary",
+]
+
+[[package]]
+name = "cranelift-entity"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "cranelift-bitset",
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
+name = "cranelift-frontend"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "cranelift-codegen",
+ "log",
+ "smallvec",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-isle"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+
+[[package]]
+name = "cranelift-native"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "cranelift-codegen",
+ "libc",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-srcgen"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+
+[[package]]
 name = "crc32fast"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -335,6 +493,24 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "encode_unicode"
@@ -398,6 +574,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -430,6 +612,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foreign-types"
@@ -512,6 +700,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
+name = "gimli"
+version = "0.32.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6298e594375a7fead9efd5568f0a46e6a154fb6a9bdcbe3c06946ffd81a5f6"
+dependencies = [
+ "fallible-iterator",
+ "indexmap",
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "h2"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -544,6 +743,10 @@ name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+dependencies = [
+ "foldhash",
+ "serde",
+]
 
 [[package]]
 name = "heapless"
@@ -846,6 +1049,7 @@ checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
 dependencies = [
  "equivalent",
  "hashbrown",
+ "serde",
 ]
 
 [[package]]
@@ -904,6 +1108,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -944,10 +1157,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "libc"
 version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+
+[[package]]
+name = "libm"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "libredox"
@@ -977,6 +1202,12 @@ name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "litemap"
@@ -1099,6 +1330,18 @@ version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "crc32fast",
+ "hashbrown",
+ "indexmap",
  "memchr",
 ]
 
@@ -1230,12 +1473,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "serde",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "pulley-interpreter"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "cranelift-bitset",
+ "log",
+ "pulley-macros",
+ "wasmtime-internal-math",
+]
+
+[[package]]
+name = "pulley-macros"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1254,6 +1530,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
 dependencies = [
  "bitflags 2.9.1",
+]
+
+[[package]]
+name = "regalloc2"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68e18e1ef763167dc6718c28a5585e62f907590a21028b8e87be1318f19ef1cb"
+dependencies = [
+ "allocator-api2",
+ "bumpalo",
+ "hashbrown",
+ "log",
+ "rustc-hash",
+ "smallvec",
 ]
 
 [[package]]
@@ -1354,6 +1644,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
 name = "rustix"
 version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1362,7 +1658,20 @@ dependencies = [
  "bitflags 2.9.1",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
+dependencies = [
+ "bitflags 2.9.1",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.9.4",
  "windows-sys 0.52.0",
 ]
 
@@ -1582,6 +1891,9 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "socket2"
@@ -1682,6 +1994,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "target-lexicon"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e502f78cdbb8ba4718f566c418c52bc729126ffd16baee5baa718cf25dd5a69a"
+
+[[package]]
 name = "tempfile"
 version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1690,8 +2008,17 @@ dependencies = [
  "cfg-if",
  "fastrand",
  "once_cell",
- "rustix",
+ "rustix 0.38.34",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -2092,6 +2419,7 @@ dependencies = [
  "wasefire-protocol-tokio",
  "wasefire-protocol-usb",
  "wasefire-wire",
+ "wasmtime",
 ]
 
 [[package]]
@@ -2277,6 +2605,195 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.237.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efe92d1321afa53ffc88a57c497bb7330c3cf84c98ffdba4a4caf6a0684fad3c"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.237.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d2a40ca0d2bdf4b0bf36c13a737d0b2c58e4c8aaefe1c57f336dd75369ca250"
+dependencies = [
+ "bitflags 2.9.1",
+ "hashbrown",
+ "indexmap",
+ "semver",
+ "serde",
+]
+
+[[package]]
+name = "wasmprinter"
+version = "0.237.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d00c979bd801d8d7e4b40de564bcb27526fcbaf58e3aff15fe2df7e135f5b397"
+dependencies = [
+ "anyhow",
+ "termcolor",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmtime"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "addr2line 0.25.0",
+ "anyhow",
+ "bitflags 2.9.1",
+ "bumpalo",
+ "cfg-if",
+ "hashbrown",
+ "indexmap",
+ "libc",
+ "log",
+ "object 0.37.3",
+ "once_cell",
+ "postcard",
+ "pulley-interpreter",
+ "rustix 1.0.8",
+ "serde",
+ "serde_derive",
+ "target-lexicon",
+ "wasmparser",
+ "wasmtime-environ",
+ "wasmtime-internal-cranelift",
+ "wasmtime-internal-fiber",
+ "wasmtime-internal-jit-debug",
+ "wasmtime-internal-jit-icache-coherence",
+ "wasmtime-internal-math",
+ "wasmtime-internal-unwinder",
+ "wasmtime-internal-versioned-export-macros",
+]
+
+[[package]]
+name = "wasmtime-environ"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "anyhow",
+ "cranelift-bitset",
+ "cranelift-entity",
+ "gimli 0.32.2",
+ "indexmap",
+ "log",
+ "object 0.37.3",
+ "postcard",
+ "serde",
+ "serde_derive",
+ "smallvec",
+ "target-lexicon",
+ "wasm-encoder",
+ "wasmparser",
+ "wasmprinter",
+]
+
+[[package]]
+name = "wasmtime-internal-asm-macros"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "wasmtime-internal-cranelift"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "cranelift-codegen",
+ "cranelift-control",
+ "cranelift-entity",
+ "cranelift-frontend",
+ "cranelift-native",
+ "gimli 0.32.2",
+ "itertools",
+ "log",
+ "object 0.37.3",
+ "pulley-interpreter",
+ "smallvec",
+ "target-lexicon",
+ "thiserror 2.0.12",
+ "wasmparser",
+ "wasmtime-environ",
+ "wasmtime-internal-math",
+ "wasmtime-internal-unwinder",
+ "wasmtime-internal-versioned-export-macros",
+]
+
+[[package]]
+name = "wasmtime-internal-fiber"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "anyhow",
+ "cc",
+ "cfg-if",
+ "libc",
+ "rustix 1.0.8",
+ "wasmtime-internal-asm-macros",
+ "wasmtime-internal-versioned-export-macros",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "wasmtime-internal-jit-debug"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "cc",
+ "wasmtime-internal-versioned-export-macros",
+]
+
+[[package]]
+name = "wasmtime-internal-jit-icache-coherence"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "libc",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "wasmtime-internal-math"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "libm",
+]
+
+[[package]]
+name = "wasmtime-internal-unwinder"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "cranelift-codegen",
+ "log",
+ "object 0.37.3",
+]
+
+[[package]]
+name = "wasmtime-internal-versioned-export-macros"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2311,6 +2828,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0978bf7171b3d90bac376700cb56d606feb40f251a475a5d6634613564460b22"
+dependencies = [
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/examples/rust/update/host/Cargo.lock
+++ b/examples/rust/update/host/Cargo.lock
@@ -8,7 +8,16 @@ version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
 dependencies = [
- "gimli",
+ "gimli 0.31.1",
+]
+
+[[package]]
+name = "addr2line"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9acbfca36652500c911ddb767ed433e3ed99b032b5d935be73c6923662db1d43"
+dependencies = [
+ "gimli 0.32.2",
 ]
 
 [[package]]
@@ -25,6 +34,12 @@ checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "anstream"
@@ -83,6 +98,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -100,11 +121,11 @@ version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
 dependencies = [
- "addr2line",
+ "addr2line 0.24.2",
  "cfg-if",
  "libc",
  "miniz_oxide",
- "object",
+ "object 0.36.7",
  "rustc-demangle",
  "windows-targets 0.52.6",
 ]
@@ -132,6 +153,9 @@ name = "bumpalo"
 version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+dependencies = [
+ "allocator-api2",
+]
 
 [[package]]
 name = "bytemuck"
@@ -256,6 +280,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror 2.0.12",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -300,6 +333,131 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cranelift-assembler-x64"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "cranelift-assembler-x64-meta",
+]
+
+[[package]]
+name = "cranelift-assembler-x64-meta"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "cranelift-srcgen",
+]
+
+[[package]]
+name = "cranelift-bforest"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "cranelift-entity",
+]
+
+[[package]]
+name = "cranelift-bitset"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
+name = "cranelift-codegen"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "bumpalo",
+ "cranelift-assembler-x64",
+ "cranelift-bforest",
+ "cranelift-bitset",
+ "cranelift-codegen-meta",
+ "cranelift-codegen-shared",
+ "cranelift-control",
+ "cranelift-entity",
+ "cranelift-isle",
+ "gimli 0.32.2",
+ "hashbrown",
+ "log",
+ "pulley-interpreter",
+ "regalloc2",
+ "rustc-hash",
+ "serde",
+ "smallvec",
+ "target-lexicon",
+ "wasmtime-internal-math",
+]
+
+[[package]]
+name = "cranelift-codegen-meta"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "cranelift-assembler-x64-meta",
+ "cranelift-codegen-shared",
+ "cranelift-srcgen",
+ "heck",
+ "pulley-interpreter",
+]
+
+[[package]]
+name = "cranelift-codegen-shared"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+
+[[package]]
+name = "cranelift-control"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "arbitrary",
+]
+
+[[package]]
+name = "cranelift-entity"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "cranelift-bitset",
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
+name = "cranelift-frontend"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "cranelift-codegen",
+ "log",
+ "smallvec",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-isle"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+
+[[package]]
+name = "cranelift-native"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "cranelift-codegen",
+ "libc",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-srcgen"
+version = "0.124.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+
+[[package]]
 name = "crc32fast"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -335,6 +493,24 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "encode_unicode"
@@ -398,6 +574,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -430,6 +612,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foreign-types"
@@ -524,6 +712,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
+name = "gimli"
+version = "0.32.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6298e594375a7fead9efd5568f0a46e6a154fb6a9bdcbe3c06946ffd81a5f6"
+dependencies = [
+ "fallible-iterator",
+ "indexmap",
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "h2"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -556,6 +755,10 @@ name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+dependencies = [
+ "foldhash",
+ "serde",
+]
 
 [[package]]
 name = "heapless"
@@ -854,6 +1057,7 @@ checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
 dependencies = [
  "equivalent",
  "hashbrown",
+ "serde",
 ]
 
 [[package]]
@@ -912,6 +1116,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -952,10 +1165,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "libc"
 version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+
+[[package]]
+name = "libm"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "libredox"
@@ -985,6 +1210,12 @@ name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "litemap"
@@ -1101,6 +1332,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "crc32fast",
+ "hashbrown",
+ "indexmap",
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1205,12 +1448,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "serde",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "pulley-interpreter"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "cranelift-bitset",
+ "log",
+ "pulley-macros",
+ "wasmtime-internal-math",
+]
+
+[[package]]
+name = "pulley-macros"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1229,6 +1505,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b8c0c260b63a8219631167be35e6a988e9554dbd323f8bd08439c8ed1302bd1"
 dependencies = [
  "bitflags 2.9.0",
+]
+
+[[package]]
+name = "regalloc2"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68e18e1ef763167dc6718c28a5585e62f907590a21028b8e87be1318f19ef1cb"
+dependencies = [
+ "allocator-api2",
+ "bumpalo",
+ "hashbrown",
+ "log",
+ "rustc-hash",
+ "smallvec",
 ]
 
 [[package]]
@@ -1329,6 +1619,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
 name = "rustix"
 version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1337,7 +1633,20 @@ dependencies = [
  "bitflags 2.9.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
+dependencies = [
+ "bitflags 2.9.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.9.4",
  "windows-sys 0.52.0",
 ]
 
@@ -1560,6 +1869,9 @@ name = "smallvec"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "socket2"
@@ -1660,6 +1972,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "target-lexicon"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e502f78cdbb8ba4718f566c418c52bc729126ffd16baee5baa718cf25dd5a69a"
+
+[[package]]
 name = "tempfile"
 version = "3.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1669,8 +1987,17 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.1",
  "once_cell",
- "rustix",
+ "rustix 0.38.44",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -2070,6 +2397,7 @@ dependencies = [
  "wasefire-protocol-tokio",
  "wasefire-protocol-usb",
  "wasefire-wire",
+ "wasmtime",
 ]
 
 [[package]]
@@ -2264,6 +2592,195 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.237.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efe92d1321afa53ffc88a57c497bb7330c3cf84c98ffdba4a4caf6a0684fad3c"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.237.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d2a40ca0d2bdf4b0bf36c13a737d0b2c58e4c8aaefe1c57f336dd75369ca250"
+dependencies = [
+ "bitflags 2.9.0",
+ "hashbrown",
+ "indexmap",
+ "semver",
+ "serde",
+]
+
+[[package]]
+name = "wasmprinter"
+version = "0.237.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d00c979bd801d8d7e4b40de564bcb27526fcbaf58e3aff15fe2df7e135f5b397"
+dependencies = [
+ "anyhow",
+ "termcolor",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmtime"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "addr2line 0.25.0",
+ "anyhow",
+ "bitflags 2.9.0",
+ "bumpalo",
+ "cfg-if",
+ "hashbrown",
+ "indexmap",
+ "libc",
+ "log",
+ "object 0.37.3",
+ "once_cell",
+ "postcard",
+ "pulley-interpreter",
+ "rustix 1.0.8",
+ "serde",
+ "serde_derive",
+ "target-lexicon",
+ "wasmparser",
+ "wasmtime-environ",
+ "wasmtime-internal-cranelift",
+ "wasmtime-internal-fiber",
+ "wasmtime-internal-jit-debug",
+ "wasmtime-internal-jit-icache-coherence",
+ "wasmtime-internal-math",
+ "wasmtime-internal-unwinder",
+ "wasmtime-internal-versioned-export-macros",
+]
+
+[[package]]
+name = "wasmtime-environ"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "anyhow",
+ "cranelift-bitset",
+ "cranelift-entity",
+ "gimli 0.32.2",
+ "indexmap",
+ "log",
+ "object 0.37.3",
+ "postcard",
+ "serde",
+ "serde_derive",
+ "smallvec",
+ "target-lexicon",
+ "wasm-encoder",
+ "wasmparser",
+ "wasmprinter",
+]
+
+[[package]]
+name = "wasmtime-internal-asm-macros"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "wasmtime-internal-cranelift"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "cranelift-codegen",
+ "cranelift-control",
+ "cranelift-entity",
+ "cranelift-frontend",
+ "cranelift-native",
+ "gimli 0.32.2",
+ "itertools",
+ "log",
+ "object 0.37.3",
+ "pulley-interpreter",
+ "smallvec",
+ "target-lexicon",
+ "thiserror 2.0.12",
+ "wasmparser",
+ "wasmtime-environ",
+ "wasmtime-internal-math",
+ "wasmtime-internal-unwinder",
+ "wasmtime-internal-versioned-export-macros",
+]
+
+[[package]]
+name = "wasmtime-internal-fiber"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "anyhow",
+ "cc",
+ "cfg-if",
+ "libc",
+ "rustix 1.0.8",
+ "wasmtime-internal-asm-macros",
+ "wasmtime-internal-versioned-export-macros",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "wasmtime-internal-jit-debug"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "cc",
+ "wasmtime-internal-versioned-export-macros",
+]
+
+[[package]]
+name = "wasmtime-internal-jit-icache-coherence"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "libc",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "wasmtime-internal-math"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "libm",
+]
+
+[[package]]
+name = "wasmtime-internal-unwinder"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "cranelift-codegen",
+ "log",
+ "object 0.37.3",
+]
+
+[[package]]
+name = "wasmtime-internal-versioned-export-macros"
+version = "37.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime.git?rev=0744262f79e235b172331f5ba1a2c43b5aedcbfb#0744262f79e235b172331f5ba1a2c43b5aedcbfb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2298,6 +2815,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0978bf7171b3d90bac376700cb56d606feb40f251a475a5d6634613564460b22"
+dependencies = [
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/scripts/ci-applets.sh
+++ b/scripts/ci-applets.sh
@@ -25,7 +25,11 @@ for lang in $(ls examples); do
     [ $lang = assemblyscript -a $name = node_modules ] && continue
     [ $lang = assemblyscript -a $name = api.ts ] && continue
     [ $lang = rust -a $name = exercises ] && continue
-    [ $lang = rust -a $name = opensk ] && continue
+    if [ $lang = rust -a $name = opensk ]; then
+      x cargo xtask --pulley applet $lang $name
+      x cargo xtask --pulley --release applet $lang $name
+      continue
+    fi
     x cargo xtask applet $lang $name
     x cargo xtask --release applet $lang $name
   done


### PR DESCRIPTION
The pulley platform is able to run the OpenSK applet and the BLE advertisement sniffer applet on Nordic. However, the footprint is significative and extremely close to the maximum, which has been increased:
- The platform stack size has been reduced from 64KiB to 32KiB so the data and heap can be increased from 192KiB to 224KiB (otherwise Wasmtime OOMs on the OpenSK applet).
- The platform image size has been increased from 320KiB to 336KiB which is actually reached by a pulley platform for the opensk applet (i.e. with all the relevant software crypto).
- The applet image size has been increased from 256KiB to 264KiB which is actually reached by the opensk applet compiled to pulley.
- Consequently, the store size has been reduced from 64KiB to 24KiB but that much wasn't needed anyway.

From the 303.5KiB `.text` size of the pulley platform, we have 84.2KiB for wasmtime, 59.2KiB for wasefire-scheduler, 53.5KiB for pulley-interpreter, 18.2KiB for core, and the rest is smaller than 11KiB each for a remaining size of 88.4KiB. The opensk applet is 262.1KiB.

For comparison, from the 146.4KiB `.text` size of the native opensk platform, we have 54.4KiB for opensk, 22.7KiB for wasefire-scheduler, 9.9KiB for core, and the rest is smaller than 8KiB each for a remaining size of 59.4KiB. But this comparison is unfair because much more dead code can be eliminated with a native applet.

Instead we can compare with the 128.5KiB `.text` size of the wasm platform, where we 40.8KiB for the wasefire-scheduler, 31.9KiB for the wasefire-interpreter, and the rest is smaller than 8KiB each for a remaining size of 55.8KiB.

Regarding RAM, the pulley platform (with opensk applet) peaks at 163.4KiB. The native platform peaks at 3.7KiB. At least 64KiB are due to the applet memory. We also have 16KiB for async stack and 8KiB for wasm stack configurations of Wasmtime.

Timings between native and pulley on CTAP1 register and authenticate is very similar (within noise levels): 1.3760 and 0.7201 respectively for native and 1.3638 and 0.7240 for pulley. This might be somewhat expected since most of the time should be spent in software crypto which is native.

Timings between wasm and pulley for the BLE advertisement applet is significative. The pulley applet doesn't drop any package in a somewhat BLE noisy environment, while the wasm applet is constantly dropping applets. The expected performance improvement is a factor 20 based on the wasm-bench tests (minimal coremark).

Fixes #458