### PR TITLE
Return an error code with --help for host runner

### DIFF
--- a/crates/runner-host/src/main.rs
+++ b/crates/runner-host/src/main.rs
@@ -57,6 +57,8 @@ fn with_state<R>(f: impl FnOnce(&mut board::State) -> R) -> R {
 }
 
 #[derive(Parser)]
+// We disable the default help behavior of Clap because we want to exit with an error to avoid an
+// infinite loop when the CLI is invoked as `wasefire host -- --help`.
 #[command(disable_help_flag = true)]
 struct Flags {
     /// Path of the directory containing the platform files.

--- a/crates/runner-host/src/main.rs
+++ b/crates/runner-host/src/main.rs
@@ -101,8 +101,9 @@ struct Flags {
     serial: Option<String>,
 
     /// Print help.
-    #[arg(long, action = clap::ArgAction::Help)]
-    help: bool,
+    // TODO(https://github.com/clap-rs/clap/issues/4367): Simplify.
+    #[arg(long, action = clap::ArgAction::Help, value_parser = clap::value_parser!(bool))]
+    help: (),
 }
 
 #[test]


### PR DESCRIPTION
This is to avoid infinite loop when invoking the host runner from the CLI.