### PR TITLE
Fix callbacks accessing memory when main exits

### DIFF
--- a/crates/interpreter/CHANGELOG.md
+++ b/crates/interpreter/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.4.1-git
 
+### Minor
+
+- Add `Store::memory()` to access the memory of a given instance
+
 ### Patch
 
 - Update dependencies

--- a/crates/interpreter/src/exec.rs
+++ b/crates/interpreter/src/exec.rs
@@ -304,6 +304,12 @@ impl<'m> Store<'m> {
     pub fn last_call(&mut self) -> Option<Call<'_, 'm>> {
         if self.threads.is_empty() { None } else { Some(Call { store: self }) }
     }
+
+    /// Returns the memory of the given instance.
+    pub fn memory(&mut self, inst: InstId) -> Result<&mut [u8], Error> {
+        check(self.id == inst.store_id)?;
+        Ok(self.mem(inst.inst_id, 0).data)
+    }
 }
 
 impl<'a, 'm> Call<'a, 'm> {

--- a/crates/scheduler/CHANGELOG.md
+++ b/crates/scheduler/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Patch
 
+- Fix callbacks accessing memory when no threads are running
 - Update dependencies
 
 ## 0.5.0

--- a/crates/scheduler/src/applet.rs
+++ b/crates/scheduler/src/applet.rs
@@ -32,6 +32,7 @@ use crate::event::{Handler, Key};
 
 pub mod store;
 
+#[allow(clippy::large_enum_variant)]
 pub enum Slot<B: Board> {
     #[cfg(any(feature = "pulley", feature = "wasm"))]
     Empty,


### PR DESCRIPTION
The scheduler panics when trying to access the memory of an applet when no threads are running. This only affects wasm and not pulley.