### PR TITLE
Remove perf feature of OpenSK

### DIFF
--- a/examples/rust/opensk/Cargo.toml
+++ b/examples/rust/opensk/Cargo.toml
@@ -39,7 +39,6 @@ debug = ["opensk-lib/debug_ctap"]
 ed25519 = ["opensk-lib/ed25519", "wasefire/api-crypto-ed25519"]
 fingerprint = ["dep:wasefire-common", "opensk-lib/fingerprint", "wasefire/api-fingerprint-matcher"]
 led-1 = []
-perf = []
 test = ["opensk-lib/std", "wasefire/test"]
 
 [lints]

--- a/examples/rust/opensk/src/lib.rs
+++ b/examples/rust/opensk/src/lib.rs
@@ -30,23 +30,6 @@ mod env;
 mod touch;
 
 fn main() -> ! {
-    #[cfg(feature = "perf")]
-    {
-        struct Us(u64);
-        impl core::fmt::Display for Us {
-            fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-                write!(f, "{}.{:06}", self.0 / 1_000_000, self.0 % 1_000_000)
-            }
-        }
-        let prev = core::cell::Cell::new(debug::perf());
-        let timer = timer::Timer::new(move || {
-            let next = debug::perf();
-            let diff = next - prev.replace(next);
-            debug!("Perf: P={} A={} W={}", Us(diff.platform), Us(diff.applets), Us(diff.waiting));
-        });
-        timer.start_ms(timer::Periodic, 5_000);
-        timer.leak()
-    }
     let mut opensk_ctap = opensk_lib::Ctap::new(env::init());
     let mut wink: Option<blink::Blink> = None;
     #[cfg(feature = "ctap1")]

--- a/examples/rust/opensk/test.sh
+++ b/examples/rust/opensk/test.sh
@@ -25,5 +25,4 @@ cargo check --lib --target=wasm32-unknown-unknown --features=debug
 cargo check --lib --target=wasm32-unknown-unknown --features=ed25519
 cargo check --lib --target=wasm32-unknown-unknown --features=fingerprint
 cargo check --lib --target=wasm32-unknown-unknown --features=led-1
-cargo check --lib --target=wasm32-unknown-unknown --features=perf
 cargo test --lib --features=test


### PR DESCRIPTION
It only works in debug mode. Instead we rely on external measurements (e.g. using tcpdump with usbmon). It is enough to measure GetInfo so no need to bypass user interaction.