### PR TITLE
Remove TODO for using the KDFs crate

### DIFF
--- a/crates/scheduler/CHANGELOG.md
+++ b/crates/scheduler/CHANGELOG.md
@@ -214,4 +214,4 @@
 
 ## 0.1.0
 
-<!-- Increment to skip CHANGELOG.md test: 9 -->
+<!-- Increment to skip CHANGELOG.md test: 10 -->

--- a/crates/scheduler/src/call/crypto/hash.rs
+++ b/crates/scheduler/src/call/crypto/hash.rs
@@ -214,7 +214,6 @@ fn hkdf_expand<B: Board>(mut call: SchedulerCall<B, api::hkdf_expand::Sig>) {
     call.reply(result);
 }
 
-// TODO(https://github.com/RustCrypto/KDFs/issues/80): We should ideally use the hkdf crate.
 #[allow(dead_code)]
 #[cfg(feature = "applet-api-crypto-hkdf")]
 fn hkdf<H: KeyInit + Update + FixedOutput>(


### PR DESCRIPTION
It requires the HmacImpl to be Copy. Not necessarily a big issue, but if we want to touch HKDF then we should probably make it its own board API since the OpenTitan crypto library provides this functionality and we would want to use it.