### PR TITLE
Group dependabot security updates for cargo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,10 @@ updates:
       - "/crates/**/*"
       - "/examples/rust/**/*"
     schedule: { interval: "monthly" }
-    groups: { all: { patterns: ["*"] } }
+    groups:
+      all:
+        applies-to: security-updates
+        patterns: ["*"]
     labels: []
     # Version updates are done with ./scripts/upgrade.sh.
     open-pull-requests-limit: 0


### PR DESCRIPTION
By default groups applies to version updates.