### PR TITLE
Remove --reset-flash and always erase the device

### DIFF
--- a/examples/rust/opensk/README.md
+++ b/examples/rust/opensk/README.md
@@ -104,7 +104,7 @@ The applet feature `fingerprint` is not supported.
 
 ```shell
 cargo xtask --native applet rust opensk $APPLET_FEATURES \
-  runner host flash --reset-flash --usb-ctap --interface=web
+  runner host flash --usb-ctap --interface=web
 ```
 
 #### Target: pulley
@@ -112,7 +112,7 @@ cargo xtask --native applet rust opensk $APPLET_FEATURES \
 Start the platform in its own terminal:
 
 ```shell
-cargo xtask --pulley runner host flash --reset-flash --usb-ctap --interface=web
+cargo xtask --pulley runner host flash --usb-ctap --interface=web
 ```
 
 Install the applet from another terminal:
@@ -148,7 +148,7 @@ cargo xtask --release --native \
   runner nordic --opt-level=z --features=usb-ctap $PLATFORM_FEATURES \
     --features=software-crypto-aes256-cbc,software-crypto-hmac-sha256 \
     --features=software-crypto-p256-ecdh,software-crypto-p256-ecdsa \
-  flash --reset-flash
+  flash
 ```
 
 #### Board: Dongle

--- a/scripts/hwci.sh
+++ b/scripts/hwci.sh
@@ -79,7 +79,7 @@ full() {
   trap "trap 'exit 1' TERM && kill -- -$$" EXIT
   cargo wasefire platform-lock --timeout=200ms $protocol 2>/dev/null || true
   for release in '' --release; do
-    y cargo xtask --setsid $release runner "$@" flash --reset-flash $FLASH_ARGS
+    y cargo xtask --setsid $release runner "$@" flash $FLASH_ARGS
     pid=$!
     x cargo xtask wait-platform $protocol
     run $protocol "$release"


### PR DESCRIPTION
The `xtask runner flash` command should only be used for fresh installs, where we want the flash to be erased. Otherwise the `xtask runner update` command can be used. We can't always easily erase the device (like those flashed through DFU), but this is an independent problem.