### PR TITLE
Clear timers when applet exits

### DIFF
--- a/crates/scheduler/CHANGELOG.md
+++ b/crates/scheduler/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Minor
 
+- Fix timers being leaked on applet exit
 - Support `fingerprint::{register,unregister}()` functions
 - Fix panic when the applet crashes during init
 - Fix callbacks accessing memory when no threads are running

--- a/crates/scheduler/src/lib.rs
+++ b/crates/scheduler/src/lib.rs
@@ -327,6 +327,8 @@ impl<B: Board> Scheduler<B> {
         <board::Applet<B> as board::applet::Api>::notify_exit(status);
         applet.free();
         self.applet = applet::Slot::Exited(status);
+        #[cfg(feature = "board-api-timer")]
+        self.timers.iter_mut().for_each(|x| *x = None); // TODO: filter by AppletId
         #[cfg(feature = "native")]
         {
             log::debug!("Applet stopped, executing protocol events only.");


### PR DESCRIPTION
We were leaking timers that were not freed by applets.