### PR TITLE
Increase the CI timeout from 15 to 30 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
         with:
           check: ${{ matrix.check }}
           token: ${{ secrets.GITHUB_TOKEN }}
-        timeout-minutes: 15
+        timeout-minutes: 30
   ubuntu:
     runs-on: ubuntu-latest
     needs: matrix


### PR DESCRIPTION
We sometimes exceed 15 minutes due to at least 2 factors:
- Sometimes `apt-get install` takes too much time for downloads
- Sometimes the first 20 jobs of the matrix (due to maximum parallelism limit of free tier) that start running don't contain all the longest ones

The timeout is just here to catch infinite loops. It's better to wait 30 minutes in those rare cases, than have to restart failed tasks due to timeout (which is more frequent now).