### PR TITLE
Generalize UART console support for OpenTitan

### DIFF
--- a/crates/xtask/src/opentitan.rs
+++ b/crates/xtask/src/opentitan.rs
@@ -245,9 +245,9 @@ pub async fn attach(
 }
 
 async fn connect() -> Result<Box<dyn SerialPort>> {
-    let serial = std::env::var("CONSOLE_SERIAL")
-        .context("CONSOLE_SERIAL must be set to a serial for the console UART")?;
-    ensure!(fs::exists(&serial).await, "{serial} not found");
+    let port = std::env::var("CONSOLE_PORT")
+        .context("CONSOLE_PORT must be set to the path of the console UART port")?;
+    ensure!(fs::exists(&port).await, "{port} not found");
     ensure_command(&["defmt-print"]).await?;
-    Ok(serialport::new(&serial, 115200).timeout(Duration::from_secs(3600)).open()?)
+    Ok(serialport::new(&port, 115200).timeout(Duration::from_secs(3600)).open()?)
 }

--- a/crates/xtask/src/opentitan.rs
+++ b/crates/xtask/src/opentitan.rs
@@ -245,10 +245,9 @@ pub async fn attach(
 }
 
 async fn connect() -> Result<Box<dyn SerialPort>> {
-    let serial = std::env::var("HYPERDEBUG_SERIAL")
-        .context("HYPERDEBUG_SERIAL must be set to a HyperDebug serial")?;
-    let port = format!("/dev/serial/by-id/usb-Google_LLC_HyperDebug_CMSIS-DAP_{serial}-if03-port0");
-    ensure!(fs::exists(&port).await, "HyperDebug {serial} not found. Is it connected?");
+    let serial = std::env::var("CONSOLE_SERIAL")
+        .context("CONSOLE_SERIAL must be set to a serial for the console UART")?;
+    ensure!(fs::exists(&serial).await, "{serial} not found");
     ensure_command(&["defmt-print"]).await?;
-    Ok(serialport::new(&port, 115200).timeout(Duration::from_secs(3600)).open()?)
+    Ok(serialport::new(&serial, 115200).timeout(Duration::from_secs(3600)).open()?)
 }


### PR DESCRIPTION
We don't always have a HyperDebug probe. We can instead use the `uart_usb` applet, thus using the USB serial port of Wasefire.