### PR TITLE
Enable unreachable_pub lint in the interpreter

### DIFF
--- a/crates/interpreter/CHANGELOG.md
+++ b/crates/interpreter/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Patch
 
+- Enable `unreachable_pub` lint
 - Update dependencies
 
 ## 0.5.0

--- a/crates/interpreter/Cargo.toml
+++ b/crates/interpreter/Cargo.toml
@@ -35,4 +35,5 @@ vector-types = []
 clippy.mod_module_files = "warn"
 clippy.uninlined_format_args = "allow"
 clippy.unit_arg = "allow"
+rust.unreachable_pub = "warn"
 rust.unused_crate_dependencies = "warn"

--- a/crates/interpreter/src/cursor.rs
+++ b/crates/interpreter/src/cursor.rs
@@ -19,21 +19,21 @@ use derive_where::derive_where;
 use crate::toctou::*;
 
 #[derive(Debug, Default, Copy, Clone, PartialEq, Eq)]
-pub struct CursorState {
+pub(crate) struct CursorState {
     start: usize,
     end: usize,
 }
 
 impl CursorState {
-    pub fn from_range(range: Range<usize>) -> Self {
+    pub(crate) fn from_range(range: Range<usize>) -> Self {
         CursorState { start: range.start, end: range.end }
     }
 
-    pub fn start(self) -> usize {
+    pub(crate) fn start(self) -> usize {
         self.start
     }
 
-    pub fn end(self) -> usize {
+    pub(crate) fn end(self) -> usize {
         self.end
     }
 
@@ -56,40 +56,40 @@ impl CursorState {
 
 #[derive(Debug)]
 #[derive_where(Default, Clone)]
-pub struct Cursor<'a, T> {
+pub(crate) struct Cursor<'a, T> {
     slice: &'a [T],
     state: CursorState, // within bounds
 }
 
 impl<'a, T> Cursor<'a, T> {
-    pub fn new(slice: &'a [T]) -> Self {
+    pub(crate) fn new(slice: &'a [T]) -> Self {
         Cursor { slice, state: CursorState::new(slice.len()) }
     }
 
-    pub fn shrink(&mut self) {
+    pub(crate) fn shrink(&mut self) {
         self.slice = &self.slice[self.state.range()];
         self.state.start = 0;
         self.state.end = self.slice.len();
     }
 
-    pub fn save(&self) -> CursorState {
+    pub(crate) fn save(&self) -> CursorState {
         self.state
     }
 
     // Safety: Must be a previously saved state.
-    pub unsafe fn restore(&mut self, state: CursorState) {
+    pub(crate) unsafe fn restore(&mut self, state: CursorState) {
         self.state = state;
     }
 
-    pub fn is_empty(&self) -> bool {
+    pub(crate) fn is_empty(&self) -> bool {
         self.state.is_empty()
     }
 
-    pub fn get(&self, index: usize) -> &'a T {
+    pub(crate) fn get(&self, index: usize) -> &'a T {
         unwrap(unwrap(self.slice.get(self.state.range())).get(index))
     }
 
-    pub fn split<M: Mode>(&mut self, len: usize) -> MResult<Cursor<'a, T>, M> {
+    pub(crate) fn split<M: Mode>(&mut self, len: usize) -> MResult<Cursor<'a, T>, M> {
         M::check(|| len <= self.state.len())?;
         let mut result = self.clone();
         #[cfg(feature = "toctou")]
@@ -100,11 +100,11 @@ impl<'a, T> Cursor<'a, T> {
         Ok(result)
     }
 
-    pub fn consume(self) -> &'a [T] {
+    pub(crate) fn consume(self) -> &'a [T] {
         unwrap(self.slice.get(self.state.range()))
     }
 
-    pub fn adjust_start(&mut self, off: isize) {
+    pub(crate) fn adjust_start(&mut self, off: isize) {
         let new_start = self.state.start.strict_add_signed(off);
         assert!(new_start <= self.state.end);
         self.state.start = new_start;

--- a/crates/interpreter/src/error.rs
+++ b/crates/interpreter/src/error.rs
@@ -61,37 +61,37 @@ pub enum Unsupported {
 }
 
 #[cfg(feature = "debug")]
-pub fn print_backtrace() {
+pub(crate) fn print_backtrace() {
     let backtrace = std::backtrace::Backtrace::capture();
     if matches!(backtrace.status(), std::backtrace::BacktraceStatus::Captured) {
         println!("{backtrace}");
     }
 }
 
-pub fn invalid() -> Error {
+pub(crate) fn invalid() -> Error {
     #[cfg(feature = "debug")]
     print_backtrace();
     Error::Invalid
 }
 
-pub fn not_found() -> Error {
+pub(crate) fn not_found() -> Error {
     #[cfg(feature = "debug")]
     print_backtrace();
     Error::NotFound
 }
 
-pub fn unsupported(reason: Unsupported) -> Error {
+pub(crate) fn unsupported(reason: Unsupported) -> Error {
     #[cfg(feature = "debug")]
     print_backtrace();
     Error::Unsupported(reason)
 }
 
-pub fn trap() -> Error {
+pub(crate) fn trap() -> Error {
     #[cfg(feature = "debug")]
     print_backtrace();
     Error::Trap
 }
 
-pub fn check(cond: bool) -> Result<(), Error> {
+pub(crate) fn check(cond: bool) -> Result<(), Error> {
     if cond { Ok(()) } else { Err(invalid()) }
 }

--- a/crates/interpreter/src/format.rs
+++ b/crates/interpreter/src/format.rs
@@ -14,7 +14,7 @@
 
 use alloc::vec::Vec;
 
-pub fn leb128(wasm: &mut Vec<u8>, mut x: usize) {
+pub(crate) fn leb128(wasm: &mut Vec<u8>, mut x: usize) {
     assert!(x <= u32::MAX as usize);
     while x > 127 {
         wasm.push(0x80 | (x & 0x7f) as u8);
@@ -23,7 +23,7 @@ pub fn leb128(wasm: &mut Vec<u8>, mut x: usize) {
     wasm.push(x as u8);
 }
 
-pub fn custom_section(wasm: &mut Vec<u8>, name: &str, content: &[u8]) {
+pub(crate) fn custom_section(wasm: &mut Vec<u8>, name: &str, content: &[u8]) {
     assert!(name.len() < 128);
     wasm.push(0);
     leb128(wasm, 1 + name.len() + content.len());

--- a/crates/interpreter/src/module.rs
+++ b/crates/interpreter/src/module.rs
@@ -31,7 +31,7 @@ pub struct Module<'m> {
 }
 
 impl<'m> Import<'m> {
-    pub fn type_(&self, module: &Module<'m>) -> ExternType<'m> {
+    pub(crate) fn type_(&self, module: &Module<'m>) -> ExternType<'m> {
         self.desc.type_(module)
     }
 }
@@ -90,7 +90,7 @@ impl<'m> Module<'m> {
     }
 }
 
-pub type Parser<'m> = parser::Parser<'m, Use>;
+pub(crate) type Parser<'m> = parser::Parser<'m, Use>;
 
 impl<'m> Module<'m> {
     pub(crate) fn section(&self, expected_id: SectionId) -> Option<Parser<'m>> {

--- a/crates/interpreter/src/parser.rs
+++ b/crates/interpreter/src/parser.rs
@@ -23,64 +23,64 @@ use crate::syntax::*;
 use crate::toctou::*;
 
 #[derive(Debug, Default, Clone)]
-pub struct Parser<'m, M: Mode> {
+pub(crate) struct Parser<'m, M: Mode> {
     data: Cursor<'m, u8>,
     mode: PhantomData<M>,
 }
 
 impl<'m> Parser<'m, Check> {
-    pub fn new(data: &'m [u8]) -> Self {
+    pub(crate) fn new(data: &'m [u8]) -> Self {
         Self::internal_new(data)
     }
 }
 
 impl<'m> Parser<'m, Use> {
     // Safety: The data must have been previously parsed in Check mode.
-    pub unsafe fn new(data: &'m [u8]) -> Self {
+    pub(crate) unsafe fn new(data: &'m [u8]) -> Self {
         Self::internal_new(data)
     }
 }
 
 impl<'m, M: Mode> Parser<'m, M> {
-    pub fn shrink(&mut self) {
+    pub(crate) fn shrink(&mut self) {
         self.data.shrink()
     }
 
-    pub fn remaining(self) -> &'m [u8] {
+    pub(crate) fn remaining(self) -> &'m [u8] {
         self.data.consume()
     }
 
-    pub fn save(&self) -> CursorState {
+    pub(crate) fn save(&self) -> CursorState {
         self.data.save()
     }
 
     // Safety: The data must have been saved in a similar state.
-    pub unsafe fn restore(&mut self, state: CursorState) {
+    pub(crate) unsafe fn restore(&mut self, state: CursorState) {
         unsafe { self.data.restore(state) };
     }
 
-    pub fn update(&mut self, offset: isize) {
+    pub(crate) fn update(&mut self, offset: isize) {
         self.data.adjust_start(offset);
     }
 
-    pub fn is_empty(&self) -> bool {
+    pub(crate) fn is_empty(&self) -> bool {
         self.data.is_empty()
     }
 
-    pub fn parse_bytes(&mut self, len: usize) -> MResult<&'m [u8], M> {
+    pub(crate) fn parse_bytes(&mut self, len: usize) -> MResult<&'m [u8], M> {
         Ok(self.data.split::<M>(len)?.consume())
     }
 
-    pub fn split_at(&mut self, len: usize) -> MResult<Parser<'m, M>, M> {
+    pub(crate) fn split_at(&mut self, len: usize) -> MResult<Parser<'m, M>, M> {
         let data = self.data.split::<M>(len)?;
         Ok(Parser { data, mode: self.mode })
     }
 
-    pub fn parse_byte(&mut self) -> MResult<u8, M> {
+    pub(crate) fn parse_byte(&mut self) -> MResult<u8, M> {
         Ok(self.parse_bytes(1)?[0])
     }
 
-    pub fn parse_leb128(&mut self, signed: bool, bits: u8) -> MResult<u64, M> {
+    pub(crate) fn parse_leb128(&mut self, signed: bool, bits: u8) -> MResult<u64, M> {
         debug_assert!(bits <= 64);
         let mut val: u64 = 0;
         let mut len = bits;
@@ -106,72 +106,72 @@ impl<'m, M: Mode> Parser<'m, M> {
         Ok(val)
     }
 
-    pub fn parse_u32(&mut self) -> MResult<u32, M> {
+    pub(crate) fn parse_u32(&mut self) -> MResult<u32, M> {
         Ok(self.parse_leb128(false, 32)? as u32)
     }
 
-    pub fn parse_s32(&mut self) -> MResult<i32, M> {
+    pub(crate) fn parse_s32(&mut self) -> MResult<i32, M> {
         Ok(self.parse_leb128(true, 32)? as i32)
     }
 
-    pub fn parse_i32(&mut self) -> MResult<u32, M> {
+    pub(crate) fn parse_i32(&mut self) -> MResult<u32, M> {
         Ok(self.parse_s32()? as u32)
     }
 
-    pub fn parse_s64(&mut self) -> MResult<i64, M> {
+    pub(crate) fn parse_s64(&mut self) -> MResult<i64, M> {
         Ok(self.parse_leb128(true, 64)? as i64)
     }
 
-    pub fn parse_i64(&mut self) -> MResult<u64, M> {
+    pub(crate) fn parse_i64(&mut self) -> MResult<u64, M> {
         Ok(self.parse_s64()? as u64)
     }
 
-    pub fn parse_typeidx(&mut self) -> MResult<TypeIdx, M> {
+    pub(crate) fn parse_typeidx(&mut self) -> MResult<TypeIdx, M> {
         self.parse_u32()
     }
 
-    pub fn parse_funcidx(&mut self) -> MResult<TypeIdx, M> {
+    pub(crate) fn parse_funcidx(&mut self) -> MResult<TypeIdx, M> {
         self.parse_u32()
     }
 
-    pub fn parse_tableidx(&mut self) -> MResult<TypeIdx, M> {
+    pub(crate) fn parse_tableidx(&mut self) -> MResult<TypeIdx, M> {
         self.parse_u32()
     }
 
-    pub fn parse_memidx(&mut self) -> MResult<TypeIdx, M> {
+    pub(crate) fn parse_memidx(&mut self) -> MResult<TypeIdx, M> {
         self.parse_u32()
     }
 
-    pub fn parse_globalidx(&mut self) -> MResult<TypeIdx, M> {
+    pub(crate) fn parse_globalidx(&mut self) -> MResult<TypeIdx, M> {
         self.parse_u32()
     }
 
-    pub fn parse_elemidx(&mut self) -> MResult<TypeIdx, M> {
+    pub(crate) fn parse_elemidx(&mut self) -> MResult<TypeIdx, M> {
         self.parse_u32()
     }
 
-    pub fn parse_dataidx(&mut self) -> MResult<TypeIdx, M> {
+    pub(crate) fn parse_dataidx(&mut self) -> MResult<TypeIdx, M> {
         self.parse_u32()
     }
 
-    pub fn parse_localidx(&mut self) -> MResult<TypeIdx, M> {
+    pub(crate) fn parse_localidx(&mut self) -> MResult<TypeIdx, M> {
         self.parse_u32()
     }
 
-    pub fn parse_labelidx(&mut self) -> MResult<TypeIdx, M> {
+    pub(crate) fn parse_labelidx(&mut self) -> MResult<TypeIdx, M> {
         self.parse_u32()
     }
 
-    pub fn parse_section_id(&mut self) -> MResult<SectionId, M> {
+    pub(crate) fn parse_section_id(&mut self) -> MResult<SectionId, M> {
         byte_enum::<M, _>(self.parse_byte()?)
     }
 
-    pub fn split_section(&mut self) -> MResult<Parser<'m, M>, M> {
+    pub(crate) fn split_section(&mut self) -> MResult<Parser<'m, M>, M> {
         let n = self.parse_u32()? as usize;
         self.split_at(n)
     }
 
-    pub fn parse_name(&mut self) -> MResult<&'m str, M> {
+    pub(crate) fn parse_name(&mut self) -> MResult<&'m str, M> {
         let n = self.parse_u32()? as usize;
         let xs = self.parse_bytes(n)?;
         M::choose(
@@ -180,17 +180,17 @@ impl<'m, M: Mode> Parser<'m, M> {
         )
     }
 
-    pub fn parse_vec(&mut self) -> MResult<usize, M> {
+    pub(crate) fn parse_vec(&mut self) -> MResult<usize, M> {
         Ok(self.parse_u32()? as usize)
     }
 
-    pub fn parse_valtype(&mut self) -> MResult<ValType, M> {
+    pub(crate) fn parse_valtype(&mut self) -> MResult<ValType, M> {
         let byte = self.parse_byte()?;
         M::check_support(|| ValType::is_unsupported(byte))?;
         byte_enum::<M, _>(byte)
     }
 
-    pub fn parse_resulttype(&mut self) -> MResult<ResultType<'m>, M> {
+    pub(crate) fn parse_resulttype(&mut self) -> MResult<ResultType<'m>, M> {
         let n = self.parse_vec()?;
         let xs = self.parse_bytes(n)?;
         M::check_support(|| xs.iter().find_map(|&x| ValType::is_unsupported(x)))?;
@@ -200,7 +200,7 @@ impl<'m, M: Mode> Parser<'m, M> {
         Ok(unsafe { core::slice::from_raw_parts(ptr, n) }.into())
     }
 
-    pub fn parse_functype(&mut self) -> MResult<FuncType<'m>, M> {
+    pub(crate) fn parse_functype(&mut self) -> MResult<FuncType<'m>, M> {
         let byte = self.parse_byte()?;
         M::check_support(|| {
             matches!(byte, 0x4e | 0x4f | 0x50 | 0x5e | 0x5f)
@@ -212,13 +212,13 @@ impl<'m, M: Mode> Parser<'m, M> {
         Ok(FuncType { params, results })
     }
 
-    pub fn parse_reftype(&mut self) -> MResult<RefType, M> {
+    pub(crate) fn parse_reftype(&mut self) -> MResult<RefType, M> {
         let byte = self.parse_byte()?;
         M::check_support(|| RefType::is_unsupported(byte))?;
         byte_enum::<M, _>(byte)
     }
 
-    pub fn parse_limits(&mut self, mut max: u32) -> MResult<Limits, M> {
+    pub(crate) fn parse_limits(&mut self, mut max: u32) -> MResult<Limits, M> {
         let has_max = byte_enum::<M, bool>(self.parse_byte()?)?;
         let min = self.parse_u32()?;
         if has_max {
@@ -227,27 +227,27 @@ impl<'m, M: Mode> Parser<'m, M> {
         Ok(Limits { min, max })
     }
 
-    pub fn parse_tabletype(&mut self) -> MResult<TableType, M> {
+    pub(crate) fn parse_tabletype(&mut self) -> MResult<TableType, M> {
         let item = self.parse_reftype()?;
         let limits = self.parse_limits(TABLE_MAX)?;
         Ok(TableType { limits, item })
     }
 
-    pub fn parse_memtype(&mut self) -> MResult<MemType, M> {
+    pub(crate) fn parse_memtype(&mut self) -> MResult<MemType, M> {
         self.parse_limits(MEM_MAX)
     }
 
-    pub fn parse_mut(&mut self) -> MResult<Mut, M> {
+    pub(crate) fn parse_mut(&mut self) -> MResult<Mut, M> {
         byte_enum::<M, _>(self.parse_byte()?)
     }
 
-    pub fn parse_globaltype(&mut self) -> MResult<GlobalType, M> {
+    pub(crate) fn parse_globaltype(&mut self) -> MResult<GlobalType, M> {
         let value = self.parse_valtype()?;
         let mutable = self.parse_mut()?;
         Ok(GlobalType { mutable, value })
     }
 
-    pub fn parse_importdesc(&mut self) -> MResult<ImportDesc, M> {
+    pub(crate) fn parse_importdesc(&mut self) -> MResult<ImportDesc, M> {
         Ok(match self.parse_byte()? {
             0 => ImportDesc::Func(self.parse_typeidx()?),
             1 => ImportDesc::Table(self.parse_tabletype()?),
@@ -258,7 +258,7 @@ impl<'m, M: Mode> Parser<'m, M> {
         })
     }
 
-    pub fn parse_exportdesc(&mut self) -> MResult<ExportDesc, M> {
+    pub(crate) fn parse_exportdesc(&mut self) -> MResult<ExportDesc, M> {
         Ok(match self.parse_byte()? {
             0 => ExportDesc::Func(self.parse_funcidx()?),
             1 => ExportDesc::Table(self.parse_tableidx()?),
@@ -268,13 +268,13 @@ impl<'m, M: Mode> Parser<'m, M> {
         })
     }
 
-    pub fn parse_memarg(&mut self) -> MResult<MemArg, M> {
+    pub(crate) fn parse_memarg(&mut self) -> MResult<MemArg, M> {
         let align = self.parse_u32()?;
         let offset = self.parse_u32()?;
         Ok(MemArg { align, offset })
     }
 
-    pub fn parse_blocktype(&mut self) -> MResult<BlockType, M> {
+    pub(crate) fn parse_blocktype(&mut self) -> MResult<BlockType, M> {
         let x = self.parse_leb128(true, 33)?;
         if x & 0x100000000 == 0 {
             return Ok(BlockType::Index(x as TypeIdx));
@@ -284,13 +284,13 @@ impl<'m, M: Mode> Parser<'m, M> {
         Ok(if x == 0x40 { BlockType::None } else { BlockType::Type(byte_enum::<M, _>(x)?) })
     }
 
-    pub fn parse_br_table(&mut self) -> MResult<Instr<'m>, M> {
+    pub(crate) fn parse_br_table(&mut self) -> MResult<Instr<'m>, M> {
         let labels =
             (0 .. self.parse_u32()?).map(|_| self.parse_labelidx()).collect::<Result<_, _>>()?;
         Ok(Instr::BrTable(labels, self.parse_labelidx()?))
     }
 
-    pub fn parse_instr_fc(&mut self) -> MResult<Instr<'m>, M> {
+    pub(crate) fn parse_instr_fc(&mut self) -> MResult<Instr<'m>, M> {
         Ok(match self.parse_u32()? {
             x @ 0 ..= 7 => support_if!(
                 "float-types"[x],
@@ -330,7 +330,7 @@ impl<'m, M: Mode> Parser<'m, M> {
         })
     }
 
-    pub fn parse_instr(&mut self) -> MResult<Instr<'m>, M> {
+    pub(crate) fn parse_instr(&mut self) -> MResult<Instr<'m>, M> {
         Ok(match self.parse_byte()? {
             0x00 => Instr::Unreachable,
             0x01 => Instr::Nop,
@@ -488,7 +488,7 @@ impl<'m, M: Mode> Parser<'m, M> {
         })
     }
 
-    pub fn parse_locals(&mut self, locals: &mut Vec<ValType>) -> MResult<(), M> {
+    pub(crate) fn parse_locals(&mut self, locals: &mut Vec<ValType>) -> MResult<(), M> {
         let mut total = locals.len() as u32;
         for _ in 0 .. self.parse_vec()? {
             let len = self.parse_u32()?;
@@ -501,7 +501,7 @@ impl<'m, M: Mode> Parser<'m, M> {
         if total <= MAX_LOCALS { Ok(()) } else { M::unsupported(if_debug!(Unsupported::MaxLocals)) }
     }
 
-    pub fn parse_elem(&mut self, user: &mut impl ParseElem<'m, M>) -> MResult<(), M> {
+    pub(crate) fn parse_elem(&mut self, user: &mut impl ParseElem<'m, M>) -> MResult<(), M> {
         // A <---- B ----> <- C --> <--- D ---->
         // 0          expr          vec(funcidx)
         // 1               elemkind vec(funcidx)
@@ -549,7 +549,7 @@ impl<'m, M: Mode> Parser<'m, M> {
         Ok(())
     }
 
-    pub fn parse_data(&mut self, user: &mut impl ParseData<'m, M>) -> MResult<(), M> {
+    pub(crate) fn parse_data(&mut self, user: &mut impl ParseData<'m, M>) -> MResult<(), M> {
         // A < B -> <C > <-- D -->
         // 0        expr vec(byte)
         // 1             vec(byte)
@@ -571,7 +571,7 @@ impl<'m, M: Mode> Parser<'m, M> {
         user.init(self.parse_bytes(len)?)
     }
 
-    pub fn parse_side_table(&mut self) -> MResult<SideTableView<'m>, M> {
+    pub(crate) fn parse_side_table(&mut self) -> MResult<SideTableView<'m>, M> {
         let id = self.parse_section_id()?;
         M::check(|| id == SectionId::Custom)?;
         let mut parser = self.split_section()?;
@@ -584,7 +584,7 @@ impl<'m, M: Mode> Parser<'m, M> {
         Ok(SideTableView { indices, metadata })
     }
 
-    pub fn skip_to_end(&mut self, l: LabelIdx) -> MResult<(), M> {
+    pub(crate) fn skip_to_end(&mut self, l: LabelIdx) -> MResult<(), M> {
         let mut depth = l as usize + 1;
         while depth > 0 {
             match self.parse_instr()? {
@@ -599,7 +599,7 @@ impl<'m, M: Mode> Parser<'m, M> {
     }
 }
 
-pub trait ParseElem<'m, M: Mode> {
+pub(crate) trait ParseElem<'m, M: Mode> {
     // Must read an expr from the parser.
     fn mode(&mut self, mode: ElemMode<'_, 'm, M>) -> MResult<(), M> {
         match mode {
@@ -623,17 +623,17 @@ pub trait ParseElem<'m, M: Mode> {
 }
 
 #[derive(Debug)]
-pub enum ElemMode<'a, 'm, M: Mode> {
+pub(crate) enum ElemMode<'a, 'm, M: Mode> {
     Passive,
     Active { table: TableIdx, offset: &'a mut Parser<'m, M> },
     Declarative,
 }
 
-pub struct SkipElem;
+pub(crate) struct SkipElem;
 
 impl<M: Mode> ParseElem<'_, M> for SkipElem {}
 
-pub trait ParseData<'m, M: Mode> {
+pub(crate) trait ParseData<'m, M: Mode> {
     // Must read an expr from the parser.
     fn mode(&mut self, mode: DataMode<'_, 'm, M>) -> MResult<(), M> {
         match mode {
@@ -648,12 +648,12 @@ pub trait ParseData<'m, M: Mode> {
 }
 
 #[derive(Debug)]
-pub enum DataMode<'a, 'm, M: Mode> {
+pub(crate) enum DataMode<'a, 'm, M: Mode> {
     Passive,
     Active { memory: MemIdx, offset: &'a mut Parser<'m, M> },
 }
 
-pub struct SkipData;
+pub(crate) struct SkipData;
 
 impl<M: Mode> ParseData<'_, M> for SkipData {}
 
@@ -677,7 +677,7 @@ mod tests {
     use crate::Error;
 
     #[test]
-    pub fn parse_leb128_is_correct() {
+    fn parse_leb128_is_correct() {
         #[track_caller]
         fn test(signed: bool, bits: u8, data: &[u8], result: Result<u64, Error>) {
             let mut parser = <Parser<Check>>::new(data);

--- a/crates/interpreter/src/side_table.rs
+++ b/crates/interpreter/src/side_table.rs
@@ -18,16 +18,16 @@ use crate::cursor::*;
 use crate::error::*;
 use crate::toctou::*;
 
-pub const SECTION_NAME: &str = "wasefire-sidetable";
+pub(crate) const SECTION_NAME: &str = "wasefire-sidetable";
 
 #[derive(Debug, Clone, Copy)]
-pub struct SideTableView<'m> {
+pub(crate) struct SideTableView<'m> {
     pub indices: &'m [u8], // including 0 and the length of metadata_array
     pub metadata: &'m [u8],
 }
 
 impl<'m> SideTableView<'m> {
-    pub fn metadata<M: Mode>(&self, func_idx: usize) -> MResult<Metadata<'m>, M> {
+    pub(crate) fn metadata<M: Mode>(&self, func_idx: usize) -> MResult<Metadata<'m>, M> {
         let start_idx = M::open(|| func_idx.checked_mul(2))?;
         let end_idx = M::open(|| start_idx.checked_add(2))?;
         let start = parse_u16::<M>(self.indices, start_idx)? as usize;
@@ -37,14 +37,14 @@ impl<'m> SideTableView<'m> {
 }
 
 #[derive(Debug, Copy, Clone)]
-pub struct Metadata<'m>(&'m [u8]);
+pub(crate) struct Metadata<'m>(&'m [u8]);
 
 impl<'m> Metadata<'m> {
-    pub fn type_idx<M: Mode>(&self) -> MResult<usize, M> {
+    pub(crate) fn type_idx<M: Mode>(&self) -> MResult<usize, M> {
         parse_u16::<M>(self.0, 0).map(|x| x as usize)
     }
 
-    pub fn branch_table<M: Mode>(&self) -> MResult<&'m [BranchTableEntry], M> {
+    pub(crate) fn branch_table<M: Mode>(&self) -> MResult<&'m [BranchTableEntry], M> {
         let entry_size = size_of::<BranchTableEntry>();
         let branch_table = M::open(|| self.0.get(10 ..))?;
         M::check(|| branch_table.len().is_multiple_of(entry_size))?;
@@ -56,7 +56,7 @@ impl<'m> Metadata<'m> {
         })
     }
 
-    pub fn parser_state<M: Mode>(&self) -> MResult<CursorState, M> {
+    pub(crate) fn parser_state<M: Mode>(&self) -> MResult<CursorState, M> {
         let start = parse_u32::<M>(self.0, 2).map(|x| x as usize)?;
         let end = parse_u32::<M>(self.0, 6).map(|x| x as usize)?;
         Ok(CursorState::from_range(start .. end))
@@ -64,13 +64,13 @@ impl<'m> Metadata<'m> {
 }
 
 #[derive(Default, Debug)]
-pub struct MetadataEntry {
+pub(crate) struct MetadataEntry {
     pub type_idx: usize,
     pub parser_state: CursorState,
     pub branch_table: Vec<BranchTableEntry>,
 }
 
-pub fn serialize(side_table: &[MetadataEntry]) -> Result<Vec<u8>, Error> {
+pub(crate) fn serialize(side_table: &[MetadataEntry]) -> Result<Vec<u8>, Error> {
     let mut res = Vec::new();
     let num_funcs = try_from::<u16>("length of MetadataEntry", side_table.len())?;
     res.extend_from_slice(&num_funcs.to_le_bytes());
@@ -101,10 +101,10 @@ pub fn serialize(side_table: &[MetadataEntry]) -> Result<Vec<u8>, Error> {
 
 #[derive(Copy, Clone, Debug)]
 #[repr(transparent)]
-pub struct BranchTableEntry([u8; 6]); // 48 bits
+pub(crate) struct BranchTableEntry([u8; 6]); // 48 bits
 
 #[derive(Debug)]
-pub struct BranchTableEntryView {
+pub(crate) struct BranchTableEntryView {
     /// The amount to adjust the instruction pointer by if the branch is taken.
     pub delta_ip: i32, // 19 bits
     /// The amount to adjust the side-table pointer by if the branch is taken.
@@ -116,7 +116,7 @@ pub struct BranchTableEntryView {
 }
 
 impl BranchTableEntry {
-    pub fn new(view: BranchTableEntryView) -> Result<Self, Error> {
+    pub(crate) fn new(view: BranchTableEntryView) -> Result<Self, Error> {
         debug_assert!([0, -1].contains(&(view.delta_ip >> 18)), "{view:?}");
         debug_assert!([0, -1].contains(&(view.delta_stp >> 12)), "{view:?}");
         debug_assert!(view.val_cnt <= 0xf);
@@ -134,7 +134,7 @@ impl BranchTableEntry {
         ]))
     }
 
-    pub fn view<M: Mode>(self) -> MResult<BranchTableEntryView, M> {
+    pub(crate) fn view<M: Mode>(self) -> MResult<BranchTableEntryView, M> {
         let mut delta_ip = parse_u16::<M>(&self.0, 0)? as u32;
         let delta_stp = parse_u16::<M>(&self.0, 2)?;
         let pop_val_counts = parse_u16::<M>(&self.0, 4)?;
@@ -149,11 +149,11 @@ impl BranchTableEntry {
         })
     }
 
-    pub fn is_invalid(self) -> bool {
+    pub(crate) fn is_invalid(self) -> bool {
         self.0 == [0; 6]
     }
 
-    pub fn invalid() -> Self {
+    pub(crate) fn invalid() -> Self {
         BranchTableEntry([0; 6])
     }
 }

--- a/crates/interpreter/src/syntax.rs
+++ b/crates/interpreter/src/syntax.rs
@@ -31,7 +31,7 @@ pub enum NumType {
 #[allow(dead_code)] // TODO: Remove when we support them.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, TryFromPrimitive, UnsafeFromPrimitive)]
 #[repr(u8)]
-pub enum VecType {
+pub(crate) enum VecType {
     V128 = 0x7b,
 }
 
@@ -87,8 +87,8 @@ pub struct Limits {
     pub max: u32,
 }
 
-pub const TABLE_MAX: u32 = u32::MAX;
-pub const MEM_MAX: u32 = 0x10000;
+pub(crate) const TABLE_MAX: u32 = u32::MAX;
+pub(crate) const MEM_MAX: u32 = 0x10000;
 
 impl Limits {
     pub fn valid(&self, k: u32) -> bool {
@@ -100,7 +100,7 @@ impl Limits {
     }
 }
 
-pub type MemType = Limits;
+pub(crate) type MemType = Limits;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct TableType {
@@ -122,7 +122,7 @@ pub struct GlobalType {
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub enum Sx {
+pub(crate) enum Sx {
     U,
     S,
 }
@@ -143,12 +143,12 @@ pub enum Bx {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum ITestOp {
+pub(crate) enum ITestOp {
     Eqz,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum IRelOp {
+pub(crate) enum IRelOp {
     Eq,
     Ne,
     Lt(Sx),
@@ -158,14 +158,14 @@ pub enum IRelOp {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum IUnOp {
+pub(crate) enum IUnOp {
     Clz,
     Ctz,
     PopCnt,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum IBinOp {
+pub(crate) enum IBinOp {
     Add,
     Sub,
     Mul,
@@ -182,7 +182,7 @@ pub enum IBinOp {
 
 #[cfg(feature = "float-types")]
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum FRelOp {
+pub(crate) enum FRelOp {
     Eq,
     Ne,
     Lt,
@@ -193,7 +193,7 @@ pub enum FRelOp {
 
 #[cfg(feature = "float-types")]
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum FUnOp {
+pub(crate) enum FUnOp {
     Abs,
     Neg,
     Ceil,
@@ -205,7 +205,7 @@ pub enum FUnOp {
 
 #[cfg(feature = "float-types")]
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum FBinOp {
+pub(crate) enum FBinOp {
     Add,
     Sub,
     Mul,
@@ -216,7 +216,7 @@ pub enum FBinOp {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum CvtOp {
+pub(crate) enum CvtOp {
     Wrap,
     Extend(Sx),
     #[cfg(feature = "float-types")]
@@ -236,7 +236,7 @@ pub enum CvtOp {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum Instr<'m> {
+pub(crate) enum Instr<'m> {
     Unreachable,
     Nop,
     Block(BlockType),
@@ -302,18 +302,18 @@ pub enum Instr<'m> {
     TableFill(TableIdx),
 }
 
-pub type TypeIdx = u32;
-pub type FuncIdx = u32;
-pub type TableIdx = u32;
-pub type MemIdx = u32;
-pub type GlobalIdx = u32;
-pub type ElemIdx = u32;
-pub type DataIdx = u32;
-pub type LocalIdx = u32;
-pub type LabelIdx = u32;
+pub(crate) type TypeIdx = u32;
+pub(crate) type FuncIdx = u32;
+pub(crate) type TableIdx = u32;
+pub(crate) type MemIdx = u32;
+pub(crate) type GlobalIdx = u32;
+pub(crate) type ElemIdx = u32;
+pub(crate) type DataIdx = u32;
+pub(crate) type LocalIdx = u32;
+pub(crate) type LabelIdx = u32;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum ExportDesc {
+pub(crate) enum ExportDesc {
     Func(FuncIdx),
     Table(TableIdx),
     Mem(MemIdx),
@@ -329,7 +329,7 @@ pub enum ImportDesc {
 }
 
 #[derive(Debug, Clone)]
-pub struct Import<'m> {
+pub(crate) struct Import<'m> {
     pub module: &'m str,
     pub name: &'m str,
     pub desc: ImportDesc,
@@ -359,21 +359,21 @@ impl<'m> ExternType<'m> {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum BlockType {
+pub(crate) enum BlockType {
     None,
     Type(ValType),
     Index(TypeIdx),
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub struct MemArg {
+pub(crate) struct MemArg {
     pub align: u32,
     pub offset: u32,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, TryFromPrimitive, UnsafeFromPrimitive)]
 #[repr(u8)]
-pub enum SectionId {
+pub(crate) enum SectionId {
     Custom = 0,
     Type = 1,
     Import = 2,
@@ -475,7 +475,7 @@ impl From<Bx> for usize {
 }
 
 impl CvtOp {
-    pub fn dst(&self) -> NumType {
+    pub(crate) fn dst(&self) -> NumType {
         match *self {
             CvtOp::Wrap => NumType::I32,
             CvtOp::Extend(_) => NumType::I64,
@@ -496,7 +496,7 @@ impl CvtOp {
         }
     }
 
-    pub fn src(&self) -> NumType {
+    pub(crate) fn src(&self) -> NumType {
         match *self {
             CvtOp::Wrap => NumType::I64,
             CvtOp::Extend(_) => NumType::I32,
@@ -521,7 +521,7 @@ impl CvtOp {
 macro_rules! impl_op {
     ($n:ident, $u:ident, $i:ident, $f:ident) => {
         impl ITestOp {
-            pub fn $n(&self, x: $u) -> bool {
+            pub(crate) fn $n(&self, x: $u) -> bool {
                 match self {
                     ITestOp::Eqz => x == 0,
                 }
@@ -529,7 +529,7 @@ macro_rules! impl_op {
         }
 
         impl IRelOp {
-            pub fn $n(&self, x: $u, y: $u) -> bool {
+            pub(crate) fn $n(&self, x: $u, y: $u) -> bool {
                 match self {
                     IRelOp::Eq => x == y,
                     IRelOp::Ne => x != y,
@@ -546,7 +546,7 @@ macro_rules! impl_op {
         }
 
         impl IUnOp {
-            pub fn $n(&self, x: $u) -> Option<$u> {
+            pub(crate) fn $n(&self, x: $u) -> Option<$u> {
                 Some(match self {
                     IUnOp::Clz => x.leading_zeros(),
                     IUnOp::Ctz => x.trailing_zeros(),
@@ -556,7 +556,7 @@ macro_rules! impl_op {
         }
 
         impl IBinOp {
-            pub fn $n(&self, x: $u, y: $u) -> Option<$u> {
+            pub(crate) fn $n(&self, x: $u, y: $u) -> Option<$u> {
                 match self {
                     IBinOp::Add => Some(x.wrapping_add(y)),
                     IBinOp::Sub => Some(x.wrapping_sub(y)),
@@ -580,7 +580,7 @@ macro_rules! impl_op {
 
         #[cfg(feature = "float-types")]
         impl FRelOp {
-            pub fn $n(&self, x: $u, y: $u) -> bool {
+            pub(crate) fn $n(&self, x: $u, y: $u) -> bool {
                 let x = $f::from_bits(x);
                 let y = $f::from_bits(y);
                 match self {
@@ -596,7 +596,7 @@ macro_rules! impl_op {
 
         #[cfg(feature = "float-types")]
         impl FUnOp {
-            pub fn $n(&self, x: $u) -> $u {
+            pub(crate) fn $n(&self, x: $u) -> $u {
                 let x = $f::from_bits(x);
                 let z = match self {
                     FUnOp::Abs => float::$f::abs(x),
@@ -625,7 +625,7 @@ macro_rules! impl_op {
 
         #[cfg(feature = "float-types")]
         impl FBinOp {
-            pub fn $n(&self, x_: $u, y_: $u) -> $u {
+            pub(crate) fn $n(&self, x_: $u, y_: $u) -> $u {
                 let x = $f::from_bits(x_);
                 let y = $f::from_bits(y_);
                 let z = match self {
@@ -651,22 +651,22 @@ impl_op!(n64, u64, i64, f64);
 #[cfg(feature = "float-types")]
 #[allow(non_upper_case_globals)]
 mod float {
-    pub mod f32 {
-        pub const abs: fn(f32) -> f32 = libm::fabsf;
-        pub const ceil: fn(f32) -> f32 = libm::ceilf;
-        pub const floor: fn(f32) -> f32 = libm::floorf;
-        pub const round: fn(f32) -> f32 = libm::roundf;
-        pub const sqrt: fn(f32) -> f32 = libm::sqrtf;
-        pub const trunc: fn(f32) -> f32 = libm::truncf;
+    pub(crate) mod f32 {
+        pub(crate) const abs: fn(f32) -> f32 = libm::fabsf;
+        pub(crate) const ceil: fn(f32) -> f32 = libm::ceilf;
+        pub(crate) const floor: fn(f32) -> f32 = libm::floorf;
+        pub(crate) const round: fn(f32) -> f32 = libm::roundf;
+        pub(crate) const sqrt: fn(f32) -> f32 = libm::sqrtf;
+        pub(crate) const trunc: fn(f32) -> f32 = libm::truncf;
     }
 
-    pub mod f64 {
-        pub const abs: fn(f64) -> f64 = libm::fabs;
-        pub const ceil: fn(f64) -> f64 = libm::ceil;
-        pub const floor: fn(f64) -> f64 = libm::floor;
-        pub const round: fn(f64) -> f64 = libm::round;
-        pub const sqrt: fn(f64) -> f64 = libm::sqrt;
-        pub const trunc: fn(f64) -> f64 = libm::trunc;
+    pub(crate) mod f64 {
+        pub(crate) const abs: fn(f64) -> f64 = libm::fabs;
+        pub(crate) const ceil: fn(f64) -> f64 = libm::ceil;
+        pub(crate) const floor: fn(f64) -> f64 = libm::floor;
+        pub(crate) const round: fn(f64) -> f64 = libm::round;
+        pub(crate) const sqrt: fn(f64) -> f64 = libm::sqrt;
+        pub(crate) const trunc: fn(f64) -> f64 = libm::trunc;
     }
 }
 
@@ -796,7 +796,7 @@ impl From<u8> for FBinOp {
 }
 
 impl SectionId {
-    pub fn order(self) -> u8 {
+    pub(crate) fn order(self) -> u8 {
         // DataCount is actually between Element and Code.
         match self as u8 {
             x @ 0 ..= 5 => x,
@@ -809,11 +809,11 @@ impl SectionId {
     }
 }
 
-pub trait TryFromByte: Sized {
+pub(crate) trait TryFromByte: Sized {
     fn try_from_byte(byte: u8) -> Option<Self>;
 }
 
-pub trait UnsafeFromByte {
+pub(crate) trait UnsafeFromByte {
     // Safety: The byte must be a valid representation.
     unsafe fn from_byte_unchecked(byte: u8) -> Self;
 }

--- a/crates/interpreter/src/toctou.rs
+++ b/crates/interpreter/src/toctou.rs
@@ -15,7 +15,7 @@
 use crate::error::*;
 use crate::syntax::*;
 
-pub trait Mode {
+pub(crate) trait Mode {
     type Error;
 
     fn invalid<T>() -> Result<T, Self::Error>;
@@ -34,7 +34,7 @@ pub trait Mode {
 }
 
 #[derive(Debug, Default, Clone)]
-pub struct Check;
+pub(crate) struct Check;
 
 impl Mode for Check {
     type Error = Error;
@@ -70,7 +70,7 @@ impl Mode for Check {
 }
 
 #[derive(Debug, Default, Clone)]
-pub struct Use;
+pub(crate) struct Use;
 
 impl Mode for Use {
     type Error = !;
@@ -116,19 +116,19 @@ impl Mode for Use {
     }
 }
 
-pub type MResult<T, M> = Result<T, <M as Mode>::Error>;
+pub(crate) type MResult<T, M> = Result<T, <M as Mode>::Error>;
 
-pub fn byte_enum<M: Mode, T: Copy + TryFromByte + UnsafeFromByte>(x: u8) -> MResult<T, M> {
+pub(crate) fn byte_enum<M: Mode, T: Copy + TryFromByte + UnsafeFromByte>(x: u8) -> MResult<T, M> {
     M::choose(|| T::try_from_byte(x), || unsafe { T::from_byte_unchecked(x) })
 }
 
 #[cfg(feature = "toctou")]
-pub fn unwrap<T>(x: Option<T>) -> T {
+pub(crate) fn unwrap<T>(x: Option<T>) -> T {
     x.unwrap()
 }
 
 #[cfg(not(feature = "toctou"))]
-pub fn unwrap<T>(x: Option<T>) -> T {
+pub(crate) fn unwrap<T>(x: Option<T>) -> T {
     unsafe { x.unwrap_unchecked() }
 }
 

--- a/crates/interpreter/src/valid.rs
+++ b/crates/interpreter/src/valid.rs
@@ -38,7 +38,7 @@ pub fn prepare(binary: &[u8]) -> Result<Vec<u8>, Error> {
 }
 
 /// Checks whether a WASM module with the side table in binary format is valid.
-pub fn verify(binary: &[u8]) -> Result<(), Error> {
+pub(crate) fn verify(binary: &[u8]) -> Result<(), Error> {
     validate::<Verify>(binary)
 }
 
@@ -205,7 +205,7 @@ impl<'m> BranchTableApi<'m> for MetadataView<'m> {
     }
 }
 
-pub type Parser<'m> = parser::Parser<'m, Check>;
+pub(crate) type Parser<'m> = parser::Parser<'m, Check>;
 type CheckResult = MResult<(), Check>;
 
 #[derive(Default)]

--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -37,7 +37,7 @@ for dir in $(find crates examples/rust -name Cargo.toml -printf '%h\n' | sort); 
   esac
   # TODO: Enable for all crates.
   case $crate in
-    interpreter|runner-*|scheduler|xtask|*/fuzz) ;;
+    runner-*|scheduler|xtask|*/fuzz) ;;
     examples/rust/exercises/part-*) ;;
     *) add_lint $file warn rust.unreachable_pub ;;
   esac


### PR DESCRIPTION
Fixes #823.

This enables the `unreachable_pub` lint for the interpreter crate as suggested in the issue:

- Remove `interpreter` from the exemption list in `scripts/sync.sh`.
- Regenerate the `[lints]` section of `crates/interpreter/Cargo.toml` (adds `rust.unreachable_pub = "warn"`).
- Fix all 142 `unreachable_pub` warnings by narrowing the visibility of internal items to `pub(crate)` (the lint suggestions), and removing the unnecessary `pub` on the `parse_leb128_is_correct` test.

No public API is affected: only items already re-exported from `lib.rs` remain `pub`. Verified with the commands run by the crate's `test.sh` (via `test-helper.sh`): `cargo check --lib` and clippy equivalents compile warning-free for the default, `debug,toctou`, `float-types,vector-types`, and all-features configurations, for the `thumbv7em-none-eabi` and `riscv32imc-unknown-none-elf` targets, and for the `hello` example and the spec test target. `cargo test --lib --features=debug,toctou` passes and `cargo fmt -- --check` is clean.