### PR TITLE
Enable unreachable_pub lint in xtask

### DIFF
--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -24,4 +24,5 @@ wasefire-protocol = { path = "../protocol", features = ["host"] }
 clippy.mod_module_files = "warn"
 clippy.uninlined_format_args = "allow"
 clippy.unit_arg = "allow"
+rust.unreachable_pub = "warn"
 rust.unused_crate_dependencies = "warn"

--- a/crates/xtask/src/footprint.rs
+++ b/crates/xtask/src/footprint.rs
@@ -35,11 +35,11 @@ struct Row {
     value: HashMap<String, usize>,
 }
 
-pub async fn update_applet(config: &str, value: usize) -> Result<()> {
+pub(crate) async fn update_applet(config: &str, value: usize) -> Result<()> {
     update("applet", config, value).await
 }
 
-pub async fn update_runner(config: &str, value: usize) -> Result<()> {
+pub(crate) async fn update_runner(config: &str, value: usize) -> Result<()> {
     update("runner", config, value).await
 }
 
@@ -65,7 +65,7 @@ async fn update(key: &str, config: &str, value: usize) -> Result<()> {
     Ok(())
 }
 
-pub async fn compare(output: &str) -> Result<()> {
+pub(crate) async fn compare(output: &str) -> Result<()> {
     let mut output = OpenOptions::new().create(true).append(true).open(output)?;
     let base = Footprint::read("footprint-push.toml").await;
     let head = Footprint::read("footprint-pull_request.toml").await;
@@ -109,7 +109,7 @@ pub async fn compare(output: &str) -> Result<()> {
 }
 
 /// Returns the sum of the .text and .data size.
-pub async fn rust_size(elf: &str) -> Result<usize> {
+pub(crate) async fn rust_size(elf: &str) -> Result<usize> {
     let mut size = wrap_command().await?;
     size.args(["rust-size", elf]);
     let output = String::from_utf8(cmd::output(&mut size).await?.stdout)?;

--- a/crates/xtask/src/opentitan.rs
+++ b/crates/xtask/src/opentitan.rs
@@ -24,10 +24,10 @@ use wasefire_cli_tools::{cmd, fs};
 
 use crate::{AttachOptions, MainOptions, ensure_command, wrap_command};
 
-pub const APPKEY: &str = "gb00-app-key-prod-0";
-pub const PATH: &str = "third_party/lowRISC/opentitan";
+pub(crate) const APPKEY: &str = "gb00-app-key-prod-0";
+pub(crate) const PATH: &str = "third_party/lowRISC/opentitan";
 
-pub async fn build(elf: &str) -> Result<String> {
+pub(crate) async fn build(elf: &str) -> Result<String> {
     let prov_exts_dir = std::env::var("PROV_EXTS_DIR")
         .context("PROV_EXTS_DIR must be set to ot-provisioning-google-skus/skus")?;
 
@@ -129,7 +129,7 @@ pub async fn build(elf: &str) -> Result<String> {
     Ok(img)
 }
 
-pub async fn truncate(img_path: &str) -> Result<()> {
+pub(crate) async fn truncate(img_path: &str) -> Result<()> {
     let mut img_file = File::options().read(true).write(true).open(img_path).await?;
     img_file.seek(std::io::SeekFrom::Start(0x340)).await?;
     let mut length = [0; 4];
@@ -138,7 +138,9 @@ pub async fn truncate(img_path: &str) -> Result<()> {
     Ok(())
 }
 
-pub async fn execute(main: &MainOptions, attach_options: &AttachOptions, elf: &str) -> Result<!> {
+pub(crate) async fn execute(
+    main: &MainOptions, attach_options: &AttachOptions, elf: &str,
+) -> Result<!> {
     // Build the image.
     let img = build(elf).await?;
 
@@ -155,7 +157,7 @@ pub async fn execute(main: &MainOptions, attach_options: &AttachOptions, elf: &s
     attach(Some(input), main, attach_options, elf).await
 }
 
-pub async fn attach(
+pub(crate) async fn attach(
     input: Option<Box<dyn SerialPort>>, main: &MainOptions, options: &AttachOptions, elf: &str,
 ) -> Result<!> {
     let (wait, mut input) = match input {

--- a/crates/xtask/src/textreview.rs
+++ b/crates/xtask/src/textreview.rs
@@ -18,7 +18,7 @@ use anyhow::{Context, Result, ensure};
 use tokio::process::Command;
 use wasefire_cli_tools::cmd;
 
-pub async fn execute() -> Result<()> {
+pub(crate) async fn execute() -> Result<()> {
     let paths = cmd::output(Command::new("git").args(["ls-files", ":(attr:textreview)"])).await?;
     let mut errors = Vec::new();
     for path in paths.stdout.lines() {

--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -37,7 +37,7 @@ for dir in $(find crates examples/rust -name Cargo.toml -printf '%h\n' | sort); 
   esac
   # TODO: Enable for all crates.
   case $crate in
-    runner-*|scheduler|xtask|*/fuzz) ;;
+    runner-*|scheduler|*/fuzz) ;;
     examples/rust/exercises/part-*) ;;
     *) add_lint $file warn rust.unreachable_pub ;;
   esac


### PR DESCRIPTION
## What

Enables the `rust.unreachable_pub` lint for the `xtask` crate:

- Removes `xtask` from the `unreachable_pub` exclusion list in `scripts/sync.sh`.
- Adds `rust.unreachable_pub = "warn"` to `crates/xtask/Cargo.toml` (matching the ordering `sync.sh` generates).
- Restricts binary-internal items to `pub(crate)` across `footprint.rs`, `opentitan.rs`, and `textreview.rs`.

## Why

Continues the incremental work of #565 ("Fix all lints currently disabled in scripts/sync.sh"), following #1139 which enabled the same lint for the interpreter. `xtask` is a host binary, so none of these items were ever reachable outside the crate.

## Verification

Ran on host (`aarch64-apple-darwin`):

- `cargo check` — clean, 0 warnings
- `cargo clippy` — clean
- `cargo fmt --check` — clean

Note: the full Linux CI suite (`scripts/ci.sh`) was not run locally.