### PR TITLE
Enable unreachable_pub lint in the scheduler

### DIFF
--- a/crates/scheduler/CHANGELOG.md
+++ b/crates/scheduler/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Patch
 
+- Enable `unreachable_pub` lint
 - Disable `unused-features` lint
 - Use heterogeneous try blocks when needed
 - Update dependencies

--- a/crates/scheduler/Cargo.toml
+++ b/crates/scheduler/Cargo.toml
@@ -346,4 +346,5 @@ internal-hash-context = []
 clippy.mod_module_files = "warn"
 clippy.uninlined_format_args = "allow"
 clippy.unit_arg = "allow"
+rust.unreachable_pub = "warn"
 rust.unused_crate_dependencies = "warn"

--- a/crates/scheduler/src/applet.rs
+++ b/crates/scheduler/src/applet.rs
@@ -30,10 +30,10 @@ use crate::Trap;
 use crate::event::InstId;
 use crate::event::{Handler, Key};
 
-pub mod store;
+pub(crate) mod store;
 
 #[allow(clippy::large_enum_variant)]
-pub enum Slot<B: Board> {
+pub(crate) enum Slot<B: Board> {
     #[cfg(any(feature = "pulley", feature = "wasm"))]
     Empty,
     Running(Applet<B>),
@@ -41,7 +41,7 @@ pub enum Slot<B: Board> {
 }
 
 impl<B: Board> Slot<B> {
-    pub fn get(&mut self) -> Option<&mut Applet<B>> {
+    pub(crate) fn get(&mut self) -> Option<&mut Applet<B>> {
         match self {
             Slot::Running(x) => Some(x),
             _ => None,
@@ -50,7 +50,7 @@ impl<B: Board> Slot<B> {
 }
 
 #[cfg_attr(not(feature = "pulley"), derive_where(Default))]
-pub struct Applet<B: Board> {
+pub(crate) struct Applet<B: Board> {
     pub store: self::store::Store,
     pub events: Events<B>,
 
@@ -67,7 +67,7 @@ pub struct Applet<B: Board> {
 }
 
 #[derive_where(Default)]
-pub struct Events<B: Board> {
+pub(crate) struct Events<B: Board> {
     /// Pending events.
     pending: VecDeque<Event<B>>,
 
@@ -76,7 +76,7 @@ pub struct Events<B: Board> {
 }
 
 #[cfg(feature = "board-api-vendor")]
-pub struct Handlers<'a, B: Board> {
+pub(crate) struct Handlers<'a, B: Board> {
     inst: Option<InstId>,
     events: &'a mut Events<B>,
 }
@@ -93,7 +93,7 @@ enum Protocol {
 
 /// Currently alive hash contexts.
 #[cfg(feature = "internal-hash-context")]
-pub struct AppletHashes<B: Board>([Option<HashContext<B>>; 4]);
+pub(crate) struct AppletHashes<B: Board>([Option<HashContext<B>>; 4]);
 
 // We have to implement manually because derive is not able to find the correct bounds.
 #[cfg(feature = "internal-hash-context")]
@@ -104,7 +104,7 @@ impl<B: Board> Default for AppletHashes<B> {
 }
 
 #[cfg(feature = "internal-hash-context")]
-pub enum HashContext<B: Board> {
+pub(crate) enum HashContext<B: Board> {
     #[cfg(feature = "board-api-crypto-sha256")]
     Sha256(board::crypto::HashApi<board::crypto::Sha256<B>>),
     #[cfg(feature = "board-api-crypto-sha384")]
@@ -118,17 +118,17 @@ pub enum HashContext<B: Board> {
 
 #[cfg(feature = "internal-hash-context")]
 impl<B: Board> AppletHashes<B> {
-    pub fn insert(&mut self, hash: HashContext<B>) -> Result<usize, Trap> {
+    pub(crate) fn insert(&mut self, hash: HashContext<B>) -> Result<usize, Trap> {
         let id = self.0.iter().position(|x| x.is_none()).ok_or(Trap)?;
         self.0[id] = Some(hash);
         Ok(id)
     }
 
-    pub fn get_mut(&mut self, id: usize) -> Result<&mut HashContext<B>, Trap> {
+    pub(crate) fn get_mut(&mut self, id: usize) -> Result<&mut HashContext<B>, Trap> {
         self.0.get_mut(id).ok_or(Trap)?.as_mut().ok_or(Trap)
     }
 
-    pub fn take(&mut self, id: usize) -> Result<HashContext<B>, Trap> {
+    pub(crate) fn take(&mut self, id: usize) -> Result<HashContext<B>, Trap> {
         self.0.get_mut(id).ok_or(Trap)?.take().ok_or(Trap)
     }
 }
@@ -157,7 +157,7 @@ impl<B: Board> Events<B> {
     }
 
     #[cfg(feature = "board-api-vendor")]
-    pub fn handlers(&mut self, inst: Option<InstId>) -> Handlers<'_, B> {
+    pub(crate) fn handlers(&mut self, inst: Option<InstId>) -> Handlers<'_, B> {
         Handlers { inst, events: self }
     }
 }
@@ -178,7 +178,7 @@ impl<'a, B: Board> board::applet::Handlers<board::vendor::Key<B>> for Handlers<'
 
 impl<B: Board> Applet<B> {
     #[cfg(feature = "pulley")]
-    pub fn new(store: self::store::Store) -> Self {
+    pub(crate) fn new(store: self::store::Store) -> Self {
         Applet {
             store,
             events: Events::default(),
@@ -190,16 +190,16 @@ impl<B: Board> Applet<B> {
         }
     }
 
-    pub fn store_mut(&mut self) -> &mut Store {
+    pub(crate) fn store_mut(&mut self) -> &mut Store {
         &mut self.store
     }
 
     #[allow(dead_code)] // in case no API uses memory
-    pub fn memory(&mut self) -> Memory<'_> {
+    pub(crate) fn memory(&mut self) -> Memory<'_> {
         self.store.memory()
     }
 
-    pub fn push(&mut self, event: Event<B>) {
+    pub(crate) fn push(&mut self, event: Event<B>) {
         const MAX_EVENTS: usize = 5;
         #[allow(clippy::if_same_then_else)]
         if !self.events.handlers.contains(&Key::from(&event)) {
@@ -217,7 +217,7 @@ impl<B: Board> Applet<B> {
     }
 
     /// Returns the next event action.
-    pub fn pop(&mut self) -> EventAction<B> {
+    pub(crate) fn pop(&mut self) -> EventAction<B> {
         #[cfg(any(feature = "pulley", feature = "wasm"))]
         if core::mem::replace(&mut self.done, false) {
             return EventAction::Reply;
@@ -229,27 +229,27 @@ impl<B: Board> Applet<B> {
     }
 
     #[cfg(any(feature = "pulley", feature = "wasm"))]
-    pub fn done(&mut self) {
+    pub(crate) fn done(&mut self) {
         self.done = true;
     }
 
     #[allow(dead_code)] // in case there are no events
-    pub fn enable(&mut self, handler: Handler<B>) -> Result<(), Trap> {
+    pub(crate) fn enable(&mut self, handler: Handler<B>) -> Result<(), Trap> {
         self.events.enable(handler)
     }
 
-    pub fn disable(&mut self, key: Key<B>) -> Result<(), Trap> {
+    pub(crate) fn disable(&mut self, key: Key<B>) -> Result<(), Trap> {
         self.events.disable(key)
     }
 
     #[cfg_attr(not(feature = "board-api-fingerprint-matcher"), allow(dead_code))]
-    pub fn disable_noerror(&mut self, key: Key<B>) {
+    pub(crate) fn disable_noerror(&mut self, key: Key<B>) {
         if self.disable(key).is_err() {
             log::warn!("Failed disabling {:?}", key);
         }
     }
 
-    pub fn free(&mut self) {
+    pub(crate) fn free(&mut self) {
         self.events.pending.clear();
         for &Handler { key, .. } in &self.events.handlers {
             if let Err(error) = key.disable() {
@@ -258,21 +258,21 @@ impl<B: Board> Applet<B> {
         }
     }
 
-    pub fn get(&self, key: Key<B>) -> Option<&Handler<B>> {
+    pub(crate) fn get(&self, key: Key<B>) -> Option<&Handler<B>> {
         self.events.handlers.get(&key)
     }
 
     #[cfg(any(feature = "pulley", feature = "wasm"))]
-    pub fn has_handlers(&self) -> bool {
+    pub(crate) fn has_handlers(&self) -> bool {
         !self.events.handlers.is_empty()
     }
 
-    pub fn len(&self) -> usize {
+    pub(crate) fn len(&self) -> usize {
         self.events.pending.len()
     }
 
     #[cfg(feature = "applet-api-platform-protocol")]
-    pub fn put_request(&mut self, event: Event<B>, request: &[u8]) -> Result<(), Error> {
+    pub(crate) fn put_request(&mut self, event: Event<B>, request: &[u8]) -> Result<(), Error> {
         self.get(Key::from(&event)).ok_or(Error::world(Code::InvalidState))?;
         // If the applet is processing a request, we'll send the event when they respond.
         if !matches!(self.protocol, Protocol::Processing) {
@@ -284,7 +284,7 @@ impl<B: Board> Applet<B> {
     }
 
     #[cfg(feature = "applet-api-platform-protocol")]
-    pub fn get_request(&mut self) -> Result<Option<Box<[u8]>>, Error> {
+    pub(crate) fn get_request(&mut self) -> Result<Option<Box<[u8]>>, Error> {
         let (update, result) = match core::mem::take(&mut self.protocol) {
             x @ (Protocol::Empty | Protocol::Response(_)) => (x, Ok(None)),
             Protocol::Request(x) => (Protocol::Processing, Ok(Some(x))),
@@ -295,7 +295,7 @@ impl<B: Board> Applet<B> {
     }
 
     #[cfg(feature = "applet-api-platform-protocol")]
-    pub fn put_response(&mut self, response: Box<[u8]>) -> Result<(), Error> {
+    pub(crate) fn put_response(&mut self, response: Box<[u8]>) -> Result<(), Error> {
         match &self.protocol {
             Protocol::Processing => self.protocol = Protocol::Response(response),
             // We use World:InvalidState to know that there is a new request.
@@ -306,7 +306,7 @@ impl<B: Board> Applet<B> {
     }
 
     #[cfg(feature = "applet-api-platform-protocol")]
-    pub fn get_response(&mut self) -> Result<Option<Box<[u8]>>, Error> {
+    pub(crate) fn get_response(&mut self) -> Result<Option<Box<[u8]>>, Error> {
         let (update, result) = match core::mem::take(&mut self.protocol) {
             x @ (Protocol::Processing | Protocol::Request(_)) => (x, Ok(None)),
             Protocol::Response(x) => (Protocol::Empty, Ok(Some(x))),
@@ -319,7 +319,7 @@ impl<B: Board> Applet<B> {
 
 /// Action when waiting for callbacks.
 #[derive(Debug)]
-pub enum EventAction<B: Board> {
+pub(crate) enum EventAction<B: Board> {
     /// Should handle the event.
     Handle(Event<B>),
 

--- a/crates/scheduler/src/applet/store.rs
+++ b/crates/scheduler/src/applet/store.rs
@@ -14,18 +14,18 @@
 
 use wasefire_board_api::applet::Memory as AppletMemory;
 
-pub use self::impl_::Store;
+pub(crate) use self::impl_::Store;
 #[cfg(feature = "pulley")]
-pub use self::impl_::{PreStore, RunResult};
+pub(crate) use self::impl_::{PreStore, RunResult};
 
 #[cfg_attr(feature = "native", path = "store/native.rs")]
 #[cfg_attr(feature = "pulley", path = "store/pulley.rs")]
 #[cfg_attr(feature = "wasm", path = "store/wasm.rs")]
 mod impl_;
 
-pub type Memory<'a> = <Store as StoreApi>::Memory<'a>;
+pub(crate) type Memory<'a> = <Store as StoreApi>::Memory<'a>;
 
-pub trait StoreApi {
+pub(crate) trait StoreApi {
     type Memory<'a>: AppletMemory
     where Self: 'a;
 

--- a/crates/scheduler/src/applet/store/native.rs
+++ b/crates/scheduler/src/applet/store/native.rs
@@ -20,9 +20,9 @@ use super::StoreApi;
 use crate::Trap;
 
 #[derive(Debug, Default)]
-pub struct Store(());
+pub(crate) struct Store(());
 
-pub struct Memory;
+pub(crate) struct Memory;
 
 impl StoreApi for Store {
     type Memory<'a>

--- a/crates/scheduler/src/applet/store/pulley.rs
+++ b/crates/scheduler/src/applet/store/pulley.rs
@@ -33,7 +33,7 @@ use wasmtime::{
 use super::StoreApi;
 use crate::Trap;
 
-pub struct PreStore {
+pub(crate) struct PreStore {
     engine: Engine,
     store: WtStore<()>,
     linker: Linker<()>,
@@ -57,7 +57,7 @@ impl Default for PreStore {
 }
 
 impl PreStore {
-    pub fn link_func(&mut self, id: usize, name: &str, params: usize) -> Result<(), Error> {
+    pub(crate) fn link_func(&mut self, id: usize, name: &str, params: usize) -> Result<(), Error> {
         let item = match params {
             0 => Func::wrap_async(&mut self.store, move |caller, ()| call(caller, id, vec![])),
             1 => Func::wrap_async(&mut self.store, move |caller, args: (u32,)| {
@@ -109,7 +109,9 @@ impl PreStore {
     }
 
     // Safety: the slice must outlive the store.
-    pub unsafe fn instantiate(mut self, pulley: &'static [u8], id: usize) -> Result<Store, Error> {
+    pub(crate) unsafe fn instantiate(
+        mut self, pulley: &'static [u8], id: usize,
+    ) -> Result<Store, Error> {
         let Ok(module) = (unsafe { Module::deserialize_raw(&self.engine, pulley.into()) }) else {
             log::warn!("Failed to deserialize pulley module.");
             return Err(Error::user(Code::InvalidArgument));
@@ -154,7 +156,7 @@ impl PreStore {
     }
 }
 
-pub struct Store {
+pub(crate) struct Store {
     instance: Instance,
     // Owned Box if threads is empty, otherwise the first thread exclusively owns it.
     store: *mut WtStore<()>,
@@ -188,14 +190,16 @@ impl Drop for Store {
     }
 }
 
-pub enum RunResult {
+pub(crate) enum RunResult {
     Done(Vec<Val>),
     Host,
     Trap,
 }
 
 impl Store {
-    pub fn invoke(&mut self, name: &str, args: &[u32], nres: usize) -> Result<RunResult, Error> {
+    pub(crate) fn invoke(
+        &mut self, name: &str, args: &[u32], nres: usize,
+    ) -> Result<RunResult, Error> {
         let mut context = self.context();
         let Some(func) = self.instance.get_func(&mut context, name) else {
             return Err(Error::internal(Code::NotFound));
@@ -211,14 +215,14 @@ impl Store {
         Ok(self.execute())
     }
 
-    pub fn resume(&mut self, result: u32) -> Result<RunResult, Error> {
+    pub(crate) fn resume(&mut self, result: u32) -> Result<RunResult, Error> {
         assert_eq!(self.calls.len(), self.threads.len());
         self.calls.pop();
         STATE.put(State::Reply(result));
         Ok(self.execute())
     }
 
-    pub fn last_call(&self) -> Option<&Call> {
+    pub(crate) fn last_call(&self) -> Option<&Call> {
         self.calls.last()
     }
 
@@ -255,7 +259,7 @@ impl Store {
     }
 }
 
-pub struct Call {
+pub(crate) struct Call {
     // This is an owned box. The lifetime is bound to the thread of this call (the one at the same
     // index in the store).
     caller: ExclusivePtr<Caller<'static, ()>>,
@@ -304,7 +308,7 @@ impl StoreApi for Store {
     }
 }
 
-pub struct Memory<'a> {
+pub(crate) struct Memory<'a> {
     store: *mut Store,
     memory: SliceCell<'a, u8>,
 }

--- a/crates/scheduler/src/applet/store/wasm.rs
+++ b/crates/scheduler/src/applet/store/wasm.rs
@@ -26,13 +26,13 @@ use super::StoreApi;
 use crate::Trap;
 
 #[derive(Debug, Default)]
-pub struct Store {
+pub(crate) struct Store {
     inst: Option<InstId>,
     store: InterpreterStore<'static>,
 }
 
 impl Store {
-    pub fn instantiate(
+    pub(crate) fn instantiate(
         &mut self, module: Module<'static>, memory: &'static mut [u8],
     ) -> Result<InstId, Error> {
         // We assume a single module per applet.
@@ -42,23 +42,23 @@ impl Store {
         Ok(inst)
     }
 
-    pub fn link_func(
+    pub(crate) fn link_func(
         &mut self, module: &'static str, name: &'static str, params: usize, results: usize,
     ) -> Result<(), Error> {
         self.store.link_func(module, name, params, results)
     }
 
-    pub fn link_func_default(&mut self, module: &'static str) -> Result<(), Error> {
+    pub(crate) fn link_func_default(&mut self, module: &'static str) -> Result<(), Error> {
         self.store.link_func_default(module)
     }
 
-    pub fn invoke<'a>(
+    pub(crate) fn invoke<'a>(
         &'a mut self, inst: InstId, name: &str, args: Vec<Val>,
     ) -> Result<RunResult<'a, 'static>, Error> {
         self.store.invoke(inst, name, args)
     }
 
-    pub fn last_call(&mut self) -> Option<Call<'_, 'static>> {
+    pub(crate) fn last_call(&mut self) -> Option<Call<'_, 'static>> {
         self.store.last_call()
     }
 }
@@ -76,7 +76,7 @@ impl StoreApi for Store {
     }
 }
 
-pub struct Memory<'a> {
+pub(crate) struct Memory<'a> {
     store: *mut Store,
     memory: SliceCell<'a, u8>,
 }

--- a/crates/scheduler/src/call.rs
+++ b/crates/scheduler/src/call.rs
@@ -76,7 +76,7 @@ mod usb;
 #[cfg(feature = "applet-api-vendor")]
 mod vendor;
 
-pub fn process<B: Board>(call: Api<DispatchSchedulerCall<B>>) {
+pub(crate) fn process<B: Board>(call: Api<DispatchSchedulerCall<B>>) {
     match call {
         #[cfg(feature = "applet-api-button")]
         Api::Button(call) => button::process(call),

--- a/crates/scheduler/src/call/button.rs
+++ b/crates/scheduler/src/call/button.rs
@@ -23,7 +23,7 @@ use wasefire_error::{Code, Error};
 use crate::event::{Handler, button::Key};
 use crate::{DispatchSchedulerCall, SchedulerCall};
 
-pub fn process<B: Board>(call: Api<DispatchSchedulerCall<B>>) {
+pub(super) fn process<B: Board>(call: Api<DispatchSchedulerCall<B>>) {
     match call {
         Api::Count(call) => count(call),
         Api::Register(call) => or_fail!("board-api-button", register(call)),

--- a/crates/scheduler/src/call/clock.rs
+++ b/crates/scheduler/src/call/clock.rs
@@ -25,7 +25,7 @@ use crate::DispatchSchedulerCall;
 #[cfg(feature = "board-api-clock")]
 use crate::SchedulerCall;
 
-pub fn process<B: Board>(call: Api<DispatchSchedulerCall<B>>) {
+pub(super) fn process<B: Board>(call: Api<DispatchSchedulerCall<B>>) {
     match call {
         Api::UptimeUs(call) => or_fail!("board-api-clock", uptime_us(call)),
     }

--- a/crates/scheduler/src/call/crypto.rs
+++ b/crates/scheduler/src/call/crypto.rs
@@ -34,7 +34,7 @@ use wasefire_board_api::Api as Board;
 
 use crate::DispatchSchedulerCall;
 
-pub fn process<B: Board>(call: Api<DispatchSchedulerCall<B>>) {
+pub(super) fn process<B: Board>(call: Api<DispatchSchedulerCall<B>>) {
     match call {
         #[cfg(feature = "applet-api-crypto-cbc")]
         Api::Cbc(call) => cbc::process(call),

--- a/crates/scheduler/src/call/crypto/cbc.rs
+++ b/crates/scheduler/src/call/crypto/cbc.rs
@@ -25,7 +25,7 @@ use wasefire_board_api::{self as board, Support};
 use crate::Trap;
 use crate::{DispatchSchedulerCall, SchedulerCall};
 
-pub fn process<B: Board>(call: Api<DispatchSchedulerCall<B>>) {
+pub(super) fn process<B: Board>(call: Api<DispatchSchedulerCall<B>>) {
     match call {
         Api::IsSupported(call) => is_supported(call),
         Api::Encrypt(call) => or_fail!("board-api-crypto-aes256-cbc", encrypt(call)),

--- a/crates/scheduler/src/call/crypto/ccm.rs
+++ b/crates/scheduler/src/call/crypto/ccm.rs
@@ -25,7 +25,7 @@ use wasefire_board_api::{self as board, Support};
 use crate::Trap;
 use crate::{DispatchSchedulerCall, SchedulerCall};
 
-pub fn process<B: Board>(call: Api<DispatchSchedulerCall<B>>) {
+pub(super) fn process<B: Board>(call: Api<DispatchSchedulerCall<B>>) {
     match call {
         Api::IsSupported(call) => is_supported(call),
         Api::Encrypt(call) => or_fail!("board-api-crypto-aes128-ccm", encrypt(call)),

--- a/crates/scheduler/src/call/crypto/ec.rs
+++ b/crates/scheduler/src/call/crypto/ec.rs
@@ -25,7 +25,7 @@ use wasefire_board_api::{self as board, Support};
 
 use crate::{DispatchSchedulerCall, SchedulerCall, Trap};
 
-pub fn process<B: Board>(call: Api<DispatchSchedulerCall<B>>) {
+pub(super) fn process<B: Board>(call: Api<DispatchSchedulerCall<B>>) {
     match call {
         Api::IsSupported(call) => is_supported(call),
         Api::IsValidScalar(call) => {

--- a/crates/scheduler/src/call/crypto/ecdh.rs
+++ b/crates/scheduler/src/call/crypto/ecdh.rs
@@ -30,7 +30,7 @@ use wasefire_error::{Code, Error};
 use crate::applet::store::Memory;
 use crate::{DispatchSchedulerCall, Failure, SchedulerCall};
 
-pub fn process<B: Board>(call: Api<DispatchSchedulerCall<B>>) {
+pub(super) fn process<B: Board>(call: Api<DispatchSchedulerCall<B>>) {
     match call {
         Api::IsSupported(call) => is_supported(call),
         Api::GetLayout(call) => or_fail!("internal-board-api-crypto-ecdh", get_layout(call)),

--- a/crates/scheduler/src/call/crypto/ecdsa.rs
+++ b/crates/scheduler/src/call/crypto/ecdsa.rs
@@ -30,7 +30,7 @@ use wasefire_error::{Code, Error};
 use crate::applet::store::Memory;
 use crate::{DispatchSchedulerCall, Failure, SchedulerCall};
 
-pub fn process<B: Board>(call: Api<DispatchSchedulerCall<B>>) {
+pub(super) fn process<B: Board>(call: Api<DispatchSchedulerCall<B>>) {
     match call {
         Api::IsSupported(call) => is_supported(call),
         Api::GetLayout(call) => or_fail!("internal-board-api-crypto-ecdsa", get_layout(call)),

--- a/crates/scheduler/src/call/crypto/ed25519.rs
+++ b/crates/scheduler/src/call/crypto/ed25519.rs
@@ -31,7 +31,7 @@ use crate::Failure;
 use crate::applet::store::Memory;
 use crate::{DispatchSchedulerCall, SchedulerCall};
 
-pub fn process<B: Board>(call: Api<DispatchSchedulerCall<B>>) {
+pub(super) fn process<B: Board>(call: Api<DispatchSchedulerCall<B>>) {
     match call {
         Api::IsSupported(call) => is_supported(call),
         Api::GetLayout(call) => or_fail!("board-api-crypto-ed25519", get_layout(call)),

--- a/crates/scheduler/src/call/crypto/gcm.rs
+++ b/crates/scheduler/src/call/crypto/gcm.rs
@@ -25,7 +25,7 @@ use wasefire_board_api::{self as board, Support as _};
 use crate::Trap;
 use crate::{DispatchSchedulerCall, SchedulerCall};
 
-pub fn process<B: Board>(call: Api<DispatchSchedulerCall<B>>) {
+pub(super) fn process<B: Board>(call: Api<DispatchSchedulerCall<B>>) {
     match call {
         Api::Support(call) => support(call),
         Api::TagLength(call) => or_fail!("board-api-crypto-aes256-gcm", tag_length(call)),

--- a/crates/scheduler/src/call/crypto/hash.rs
+++ b/crates/scheduler/src/call/crypto/hash.rs
@@ -26,7 +26,7 @@ use crate::applet::HashContext;
 use crate::applet::store::StoreApi;
 use crate::{DispatchSchedulerCall, Failure, SchedulerCall, Trap};
 
-pub fn process<B: Board>(call: Api<DispatchSchedulerCall<B>>) {
+pub(super) fn process<B: Board>(call: Api<DispatchSchedulerCall<B>>) {
     match call {
         #[cfg(feature = "applet-api-crypto-hash")]
         Api::IsSupported(call) => is_supported(call),

--- a/crates/scheduler/src/call/debug.rs
+++ b/crates/scheduler/src/call/debug.rs
@@ -19,7 +19,7 @@ use wasefire_board_api::{self as board, Api as Board};
 
 use crate::{DispatchSchedulerCall, SchedulerCall, Trap};
 
-pub fn process<B: Board>(call: Api<DispatchSchedulerCall<B>>) {
+pub(super) fn process<B: Board>(call: Api<DispatchSchedulerCall<B>>) {
     match call {
         Api::Println(call) => println(call),
         Api::Time(call) => time(call),

--- a/crates/scheduler/src/call/fingerprint.rs
+++ b/crates/scheduler/src/call/fingerprint.rs
@@ -32,7 +32,7 @@ mod matcher;
 #[cfg(feature = "applet-api-fingerprint-sensor")]
 mod sensor;
 
-pub fn process<B: Board>(call: Api<DispatchSchedulerCall<B>>) {
+pub(super) fn process<B: Board>(call: Api<DispatchSchedulerCall<B>>) {
     match call {
         #[cfg(feature = "applet-api-fingerprint-matcher")]
         Api::Matcher(call) => matcher::process(call),

--- a/crates/scheduler/src/call/fingerprint/matcher.rs
+++ b/crates/scheduler/src/call/fingerprint/matcher.rs
@@ -26,7 +26,7 @@ use wasefire_board_api::{self as board, Support};
 use crate::event::{Handler, fingerprint::matcher::Key};
 use crate::{DispatchSchedulerCall, SchedulerCall};
 
-pub fn process<B: Board>(call: Api<DispatchSchedulerCall<B>>) {
+pub(super) fn process<B: Board>(call: Api<DispatchSchedulerCall<B>>) {
     match call {
         Api::IsSupported(call) => is_supported(call),
         Api::TemplateLength(call) => {

--- a/crates/scheduler/src/call/fingerprint/sensor.rs
+++ b/crates/scheduler/src/call/fingerprint/sensor.rs
@@ -24,7 +24,7 @@ use wasefire_board_api::{self as board, Support};
 use crate::event::{Handler, fingerprint::sensor::Key};
 use crate::{DispatchSchedulerCall, SchedulerCall};
 
-pub fn process<B: Board>(call: Api<DispatchSchedulerCall<B>>) {
+pub(super) fn process<B: Board>(call: Api<DispatchSchedulerCall<B>>) {
     match call {
         Api::IsSupported(call) => is_supported(call),
         Api::Capture(call) => or_fail!("board-api-fingerprint-sensor", capture(call)),

--- a/crates/scheduler/src/call/gpio.rs
+++ b/crates/scheduler/src/call/gpio.rs
@@ -25,7 +25,7 @@ use wasefire_error::{Code, Error};
 use crate::event::{Handler, gpio::Key};
 use crate::{DispatchSchedulerCall, SchedulerCall};
 
-pub fn process<B: Board>(call: Api<DispatchSchedulerCall<B>>) {
+pub(super) fn process<B: Board>(call: Api<DispatchSchedulerCall<B>>) {
     match call {
         Api::Count(call) => count(call),
         Api::Configure(call) => or_fail!("board-api-gpio", configure(call)),

--- a/crates/scheduler/src/call/led.rs
+++ b/crates/scheduler/src/call/led.rs
@@ -21,7 +21,7 @@ use wasefire_board_api::{self as board, Id, Support};
 
 use crate::{DispatchSchedulerCall, SchedulerCall};
 
-pub fn process<B: Board>(call: Api<DispatchSchedulerCall<B>>) {
+pub(super) fn process<B: Board>(call: Api<DispatchSchedulerCall<B>>) {
     match call {
         Api::Count(call) => count(call),
         Api::Get(call) => or_fail!("board-api-led", get(call)),

--- a/crates/scheduler/src/call/platform.rs
+++ b/crates/scheduler/src/call/platform.rs
@@ -34,7 +34,7 @@ mod protocol;
 #[cfg(feature = "applet-api-platform-update")]
 mod update;
 
-pub fn process<B: Board>(call: Api<DispatchSchedulerCall<B>>) {
+pub(super) fn process<B: Board>(call: Api<DispatchSchedulerCall<B>>) {
     match call {
         #[cfg(feature = "applet-api-platform-protocol")]
         Api::Protocol(call) => protocol::process(call),

--- a/crates/scheduler/src/call/platform/protocol.rs
+++ b/crates/scheduler/src/call/platform/protocol.rs
@@ -21,7 +21,7 @@ use crate::event::Handler;
 use crate::event::platform::protocol::Key;
 use crate::{DispatchSchedulerCall, SchedulerCall};
 
-pub fn process<B: Board>(call: Api<DispatchSchedulerCall<B>>) {
+pub(super) fn process<B: Board>(call: Api<DispatchSchedulerCall<B>>) {
     match call {
         Api::Read(call) => read(call),
         Api::Write(call) => write(call),

--- a/crates/scheduler/src/call/platform/update.rs
+++ b/crates/scheduler/src/call/platform/update.rs
@@ -19,7 +19,7 @@ use wasefire_board_api::{self as board, Api as Board};
 
 use crate::{DispatchSchedulerCall, SchedulerCall, Trap};
 
-pub fn process<B: Board>(call: Api<DispatchSchedulerCall<B>>) {
+pub(super) fn process<B: Board>(call: Api<DispatchSchedulerCall<B>>) {
     match call {
         Api::Initialize(call) => initialize(call),
         Api::Process(call) => process_(call),

--- a/crates/scheduler/src/call/rng.rs
+++ b/crates/scheduler/src/call/rng.rs
@@ -27,7 +27,7 @@ use crate::DispatchSchedulerCall;
 #[cfg(feature = "board-api-rng")]
 use crate::SchedulerCall;
 
-pub fn process<B: Board>(call: Api<DispatchSchedulerCall<B>>) {
+pub(super) fn process<B: Board>(call: Api<DispatchSchedulerCall<B>>) {
     match call {
         Api::FillBytes(call) => or_fail!("board-api-rng", fill_bytes(call)),
     }

--- a/crates/scheduler/src/call/scheduling.rs
+++ b/crates/scheduler/src/call/scheduling.rs
@@ -17,7 +17,7 @@ use wasefire_board_api::Api as Board;
 
 use crate::{DispatchSchedulerCall, SchedulerCall};
 
-pub fn process<B: Board>(call: Api<DispatchSchedulerCall<B>>) {
+pub(super) fn process<B: Board>(call: Api<DispatchSchedulerCall<B>>) {
     match call {
         Api::WaitForCallback(call) => wait_for_callback(call),
         Api::NumPendingCallbacks(call) => num_pending_callbacks(call),

--- a/crates/scheduler/src/call/store.rs
+++ b/crates/scheduler/src/call/store.rs
@@ -30,7 +30,7 @@ use crate::SchedulerCall;
 #[cfg(feature = "applet-api-store-fragment")]
 mod fragment;
 
-pub fn process<B: Board>(call: Api<DispatchSchedulerCall<B>>) {
+pub(super) fn process<B: Board>(call: Api<DispatchSchedulerCall<B>>) {
     match call {
         #[cfg(feature = "applet-api-store")]
         Api::MaxKey(call) => or_fail!("board-api-store", max_key(call)),

--- a/crates/scheduler/src/call/store/fragment.rs
+++ b/crates/scheduler/src/call/store/fragment.rs
@@ -27,7 +27,7 @@ use crate::DispatchSchedulerCall;
 #[cfg(feature = "board-api-store-fragment")]
 use crate::SchedulerCall;
 
-pub fn process<B: Board>(call: Api<DispatchSchedulerCall<B>>) {
+pub(super) fn process<B: Board>(call: Api<DispatchSchedulerCall<B>>) {
     match call {
         Api::Insert(call) => or_fail!("board-api-store-fragment", insert(call)),
         Api::Remove(call) => or_fail!("board-api-store-fragment", remove(call)),

--- a/crates/scheduler/src/call/timer.rs
+++ b/crates/scheduler/src/call/timer.rs
@@ -27,7 +27,7 @@ use crate::{DispatchSchedulerCall, SchedulerCall};
 #[cfg(feature = "board-api-timer")]
 use crate::{Scheduler, Timer};
 
-pub fn process<B: Board>(call: Api<DispatchSchedulerCall<B>>) {
+pub(super) fn process<B: Board>(call: Api<DispatchSchedulerCall<B>>) {
     match call {
         Api::Allocate(call) => allocate(call),
         Api::Start(call) => or_fail!("board-api-timer", start(call)),

--- a/crates/scheduler/src/call/uart.rs
+++ b/crates/scheduler/src/call/uart.rs
@@ -27,7 +27,7 @@ use crate::Failure;
 use crate::event::{Handler, uart::Key};
 use crate::{DispatchSchedulerCall, SchedulerCall};
 
-pub fn process<B: Board>(call: Api<DispatchSchedulerCall<B>>) {
+pub(super) fn process<B: Board>(call: Api<DispatchSchedulerCall<B>>) {
     match call {
         Api::Count(call) => count(call),
         Api::SetBaudrate(call) => or_fail!("board-api-uart", set_baudrate(call)),

--- a/crates/scheduler/src/call/usb.rs
+++ b/crates/scheduler/src/call/usb.rs
@@ -22,7 +22,7 @@ mod ctap;
 #[cfg(feature = "applet-api-usb-serial")]
 mod serial;
 
-pub fn process<B: Board>(call: Api<DispatchSchedulerCall<B>>) {
+pub(super) fn process<B: Board>(call: Api<DispatchSchedulerCall<B>>) {
     match call {
         #[cfg(feature = "applet-api-usb-ctap")]
         Api::Ctap(call) => ctap::process(call),

--- a/crates/scheduler/src/call/usb/ctap.rs
+++ b/crates/scheduler/src/call/usb/ctap.rs
@@ -29,7 +29,7 @@ use crate::event::{Handler, usb::ctap::Key};
 #[cfg(feature = "board-api-usb-ctap")]
 use crate::{SchedulerCall, Trap};
 
-pub fn process<B: Board>(call: Api<DispatchSchedulerCall<B>>) {
+pub(super) fn process<B: Board>(call: Api<DispatchSchedulerCall<B>>) {
     match call {
         Api::Read(call) => or_fail!("board-api-usb-ctap", read(call)),
         Api::Write(call) => or_fail!("board-api-usb-ctap", write(call)),

--- a/crates/scheduler/src/call/usb/serial.rs
+++ b/crates/scheduler/src/call/usb/serial.rs
@@ -29,7 +29,7 @@ use crate::event::{Handler, usb::serial::Key};
 #[cfg(feature = "board-api-usb-serial")]
 use crate::{SchedulerCall, Trap};
 
-pub fn process<B: Board>(call: Api<DispatchSchedulerCall<B>>) {
+pub(super) fn process<B: Board>(call: Api<DispatchSchedulerCall<B>>) {
     match call {
         Api::Read(call) => or_fail!("board-api-usb-serial", read(call)),
         Api::Write(call) => or_fail!("board-api-usb-serial", write(call)),

--- a/crates/scheduler/src/call/vendor.rs
+++ b/crates/scheduler/src/call/vendor.rs
@@ -25,7 +25,7 @@ use crate::SchedulerCall;
 #[cfg(feature = "board-api-vendor")]
 use crate::applet::store::StoreApi as _;
 
-pub fn process<B: Board>(call: Api<DispatchSchedulerCall<B>>) {
+pub(super) fn process<B: Board>(call: Api<DispatchSchedulerCall<B>>) {
     match call {
         Api::Syscall(call) => or_fail!("board-api-vendor", syscall(call)),
     }

--- a/crates/scheduler/src/event.rs
+++ b/crates/scheduler/src/event.rs
@@ -19,35 +19,35 @@ use derive_where::derive_where;
 use wasefire_board_api::{Api as Board, Event, Impossible};
 use wasefire_error::Error;
 #[cfg(feature = "wasm")]
-pub use wasefire_interpreter::InstId;
+pub(crate) use wasefire_interpreter::InstId;
 use wasefire_logger as log;
 
 use crate::Scheduler;
 
 #[cfg(feature = "board-api-button")]
-pub mod button;
+pub(crate) mod button;
 #[cfg(feature = "internal-board-api-fingerprint")]
-pub mod fingerprint;
+pub(crate) mod fingerprint;
 #[cfg(feature = "board-api-gpio")]
-pub mod gpio;
-pub mod platform;
+pub(crate) mod gpio;
+pub(crate) mod platform;
 #[cfg(feature = "board-api-timer")]
-pub mod timer;
+pub(crate) mod timer;
 #[cfg(feature = "board-api-uart")]
-pub mod uart;
+pub(crate) mod uart;
 #[cfg(feature = "internal-board-api-usb")]
-pub mod usb;
+pub(crate) mod usb;
 #[cfg(feature = "board-api-vendor")]
-pub mod vendor;
+pub(crate) mod vendor;
 
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg(any(feature = "native", feature = "pulley"))]
-pub struct InstId;
+pub(crate) struct InstId;
 
 // TODO: This could be encoded into a u32 for performance/footprint.
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive_where(Debug, Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub enum Key<B: Board> {
+pub(crate) enum Key<B: Board> {
     #[cfg(feature = "board-api-button")]
     Button(button::Key<B>),
     #[cfg(feature = "internal-board-api-fingerprint")]
@@ -125,7 +125,7 @@ impl<'a, B: Board> From<&'a Event<B>> for Key<B> {
 }
 
 impl<B: Board> Key<B> {
-    pub fn disable(self) -> Result<(), Error> {
+    pub(crate) fn disable(self) -> Result<(), Error> {
         match self {
             #[cfg(feature = "board-api-button")]
             Key::Button(x) => x.disable(),
@@ -148,7 +148,7 @@ impl<B: Board> Key<B> {
 }
 
 #[derive_where(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Handler<B: Board> {
+pub(crate) struct Handler<B: Board> {
     pub key: Key<B>,
     pub inst: InstId,
     pub func: u32,
@@ -162,7 +162,7 @@ impl<B: Board> Borrow<Key<B>> for Handler<B> {
 }
 
 #[cfg_attr(feature = "native", allow(clippy::needless_pass_by_ref_mut))]
-pub fn process<B: Board>(scheduler: &mut Scheduler<B>, event: Event<B>) {
+pub(crate) fn process<B: Board>(scheduler: &mut Scheduler<B>, event: Event<B>) {
     let applet = scheduler.applet.get().unwrap();
     let (inst, func, data) = match applet.get(Key::from(&event)) {
         Some(x) => (x.inst, x.func, x.data),

--- a/crates/scheduler/src/event/button.rs
+++ b/crates/scheduler/src/event/button.rs
@@ -21,7 +21,7 @@ use wasefire_error::Error;
 
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive_where(Debug, Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Key<B: Board> {
+pub(crate) struct Key<B: Board> {
     pub button: Id<board::Button<B>>,
 }
 
@@ -38,12 +38,12 @@ impl<'a, B: Board> From<&'a Event<B>> for Key<B> {
 }
 
 impl<B: Board> Key<B> {
-    pub fn disable(self) -> Result<(), Error> {
+    pub(crate) fn disable(self) -> Result<(), Error> {
         use wasefire_board_api::button::Api as _;
         board::Button::<B>::disable(self.button)
     }
 }
 
-pub fn process<B: Board>(event: Event<B>, params: &mut Vec<u32>) {
+pub(crate) fn process<B: Board>(event: Event<B>, params: &mut Vec<u32>) {
     params.push(event.pressed as u32);
 }

--- a/crates/scheduler/src/event/fingerprint.rs
+++ b/crates/scheduler/src/event/fingerprint.rs
@@ -21,13 +21,13 @@ use wasefire_error::Error;
 use crate::applet::Applet;
 
 #[cfg(feature = "board-api-fingerprint-matcher")]
-pub mod matcher;
+pub(crate) mod matcher;
 #[cfg(feature = "board-api-fingerprint-sensor")]
-pub mod sensor;
+pub(crate) mod sensor;
 
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub enum Key {
+pub(crate) enum Key {
     #[cfg(feature = "board-api-fingerprint-matcher")]
     Matcher(matcher::Key),
 
@@ -56,7 +56,7 @@ impl<'a> From<&'a Event> for Key {
 }
 
 impl Key {
-    pub fn disable<B: Board>(self) -> Result<(), Error> {
+    pub(crate) fn disable<B: Board>(self) -> Result<(), Error> {
         match self {
             #[cfg(feature = "board-api-fingerprint-matcher")]
             Key::Matcher(x) => x.disable::<B>(),
@@ -67,7 +67,7 @@ impl Key {
     }
 }
 
-pub fn process<B: Board>(event: Event, params: &mut Vec<u32>, applet: &mut Applet<B>) {
+pub(crate) fn process<B: Board>(event: Event, params: &mut Vec<u32>, applet: &mut Applet<B>) {
     match event {
         #[cfg(feature = "board-api-fingerprint-matcher")]
         Event::Matcher(event) => matcher::process(event, params, applet),

--- a/crates/scheduler/src/event/fingerprint/matcher.rs
+++ b/crates/scheduler/src/event/fingerprint/matcher.rs
@@ -23,7 +23,7 @@ use crate::applet::Applet;
 
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub enum Key {
+pub(crate) enum Key {
     Enroll,
     EnrollStep,
     Identify,
@@ -46,7 +46,7 @@ impl<'a> From<&'a Event> for Key {
 }
 
 impl Key {
-    pub fn disable<B: Board>(self) -> Result<(), Error> {
+    pub(crate) fn disable<B: Board>(self) -> Result<(), Error> {
         use wasefire_board_api::fingerprint::matcher::Api as _;
         match self {
             Key::Enroll => board::fingerprint::Matcher::<B>::abort_enroll(),
@@ -56,7 +56,7 @@ impl Key {
     }
 }
 
-pub fn process<B: Board>(event: Event, params: &mut Vec<u32>, applet: &mut Applet<B>) {
+pub(crate) fn process<B: Board>(event: Event, params: &mut Vec<u32>, applet: &mut Applet<B>) {
     match event {
         Event::EnrollStep { remaining } => params.push(remaining as u32),
         Event::EnrollDone => {

--- a/crates/scheduler/src/event/fingerprint/sensor.rs
+++ b/crates/scheduler/src/event/fingerprint/sensor.rs
@@ -23,7 +23,7 @@ use crate::applet::Applet;
 
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub enum Key {
+pub(crate) enum Key {
     Capture,
 }
 
@@ -42,7 +42,7 @@ impl<'a> From<&'a Event> for Key {
 }
 
 impl Key {
-    pub fn disable<B: Board>(self) -> Result<(), Error> {
+    pub(crate) fn disable<B: Board>(self) -> Result<(), Error> {
         use wasefire_board_api::fingerprint::sensor::Api as _;
         match self {
             Key::Capture => board::fingerprint::Sensor::<B>::abort_capture(),
@@ -50,7 +50,7 @@ impl Key {
     }
 }
 
-pub fn process<B: Board>(event: Event, params: &mut Vec<u32>, applet: &mut Applet<B>) {
+pub(crate) fn process<B: Board>(event: Event, params: &mut Vec<u32>, applet: &mut Applet<B>) {
     match event {
         Event::CaptureDone => {
             let width = board::fingerprint::Sensor::<B>::IMAGE_WIDTH as u32;

--- a/crates/scheduler/src/event/gpio.rs
+++ b/crates/scheduler/src/event/gpio.rs
@@ -19,7 +19,7 @@ use wasefire_error::Error;
 
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive_where(Debug, Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Key<B: Board> {
+pub(crate) struct Key<B: Board> {
     pub gpio: Id<board::Gpio<B>>,
 }
 
@@ -36,10 +36,10 @@ impl<'a, B: Board> From<&'a Event<B>> for Key<B> {
 }
 
 impl<B: Board> Key<B> {
-    pub fn disable(self) -> Result<(), Error> {
+    pub(crate) fn disable(self) -> Result<(), Error> {
         use wasefire_board_api::gpio::Api as _;
         board::Gpio::<B>::disable(self.gpio)
     }
 }
 
-pub fn process() {}
+pub(crate) fn process() {}

--- a/crates/scheduler/src/event/platform.rs
+++ b/crates/scheduler/src/event/platform.rs
@@ -16,11 +16,11 @@ use wasefire_board_api::Api as Board;
 use wasefire_board_api::platform::Event;
 use wasefire_error::Error;
 
-pub mod protocol;
+pub(crate) mod protocol;
 
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub enum Key {
+pub(crate) enum Key {
     Protocol(protocol::Key),
 }
 
@@ -39,14 +39,14 @@ impl<'a> From<&'a Event> for Key {
 }
 
 impl Key {
-    pub fn disable(self) -> Result<(), Error> {
+    pub(crate) fn disable(self) -> Result<(), Error> {
         match self {
             Key::Protocol(x) => x.disable(),
         }
     }
 }
 
-pub fn process(event: Event) {
+pub(crate) fn process(event: Event) {
     match event {
         Event::Protocol(_) => protocol::process(),
     }

--- a/crates/scheduler/src/event/platform/protocol.rs
+++ b/crates/scheduler/src/event/platform/protocol.rs
@@ -18,7 +18,7 @@ use wasefire_error::Error;
 
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub enum Key {
+pub(crate) enum Key {
     Request,
 }
 
@@ -37,10 +37,10 @@ impl<'a> From<&'a Event> for Key {
 }
 
 impl Key {
-    pub fn disable(self) -> Result<(), Error> {
+    pub(crate) fn disable(self) -> Result<(), Error> {
         // We need to process non-applet requests.
         Ok(())
     }
 }
 
-pub fn process() {}
+pub(crate) fn process() {}

--- a/crates/scheduler/src/event/timer.rs
+++ b/crates/scheduler/src/event/timer.rs
@@ -19,7 +19,7 @@ use wasefire_error::Error;
 
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive_where(Debug, Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Key<B: Board> {
+pub(crate) struct Key<B: Board> {
     pub timer: Id<board::Timer<B>>,
 }
 
@@ -36,10 +36,10 @@ impl<'a, B: Board> From<&'a Event<B>> for Key<B> {
 }
 
 impl<B: Board> Key<B> {
-    pub fn disable(self) -> Result<(), Error> {
+    pub(crate) fn disable(self) -> Result<(), Error> {
         use wasefire_board_api::timer::Api as _;
         board::Timer::<B>::disarm(self.timer)
     }
 }
 
-pub fn process() {}
+pub(crate) fn process() {}

--- a/crates/scheduler/src/event/uart.rs
+++ b/crates/scheduler/src/event/uart.rs
@@ -19,7 +19,7 @@ use wasefire_error::Error;
 
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive_where(Debug, Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Key<B: Board> {
+pub(crate) struct Key<B: Board> {
     pub uart: Id<board::Uart<B>>,
     pub direction: Direction,
 }
@@ -37,10 +37,10 @@ impl<'a, B: Board> From<&'a Event<B>> for Key<B> {
 }
 
 impl<B: Board> Key<B> {
-    pub fn disable(self) -> Result<(), Error> {
+    pub(crate) fn disable(self) -> Result<(), Error> {
         use wasefire_board_api::uart::Api as _;
         board::Uart::<B>::disable(self.uart, self.direction)
     }
 }
 
-pub fn process() {}
+pub(crate) fn process() {}

--- a/crates/scheduler/src/event/usb.rs
+++ b/crates/scheduler/src/event/usb.rs
@@ -17,13 +17,13 @@ use wasefire_board_api::usb::Event;
 use wasefire_error::Error;
 
 #[cfg(feature = "board-api-usb-ctap")]
-pub mod ctap;
+pub(crate) mod ctap;
 #[cfg(feature = "board-api-usb-serial")]
-pub mod serial;
+pub(crate) mod serial;
 
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub enum Key {
+pub(crate) enum Key {
     #[cfg(feature = "board-api-usb-ctap")]
     Ctap(ctap::Key),
 
@@ -49,7 +49,7 @@ impl<'a> From<&'a Event> for Key {
 }
 
 impl Key {
-    pub fn disable<B: Board>(self) -> Result<(), Error> {
+    pub(crate) fn disable<B: Board>(self) -> Result<(), Error> {
         match self {
             #[cfg(feature = "board-api-usb-ctap")]
             Key::Ctap(x) => x.disable::<B>(),
@@ -59,7 +59,7 @@ impl Key {
     }
 }
 
-pub fn process(event: Event) {
+pub(crate) fn process(event: Event) {
     match event {
         #[cfg(feature = "board-api-usb-ctap")]
         Event::Ctap(_) => ctap::process(),

--- a/crates/scheduler/src/event/usb/ctap.rs
+++ b/crates/scheduler/src/event/usb/ctap.rs
@@ -18,7 +18,7 @@ use wasefire_error::Error;
 
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub enum Key {
+pub(crate) enum Key {
     Read,
     Write,
 }
@@ -39,7 +39,7 @@ impl<'a> From<&'a Event> for Key {
 }
 
 impl Key {
-    pub fn disable<B: Board>(self) -> Result<(), Error> {
+    pub(crate) fn disable<B: Board>(self) -> Result<(), Error> {
         use wasefire_board_api::usb::ctap::Api as _;
         let event = match self {
             Key::Read => Event::Read,
@@ -49,4 +49,4 @@ impl Key {
     }
 }
 
-pub fn process() {}
+pub(crate) fn process() {}

--- a/crates/scheduler/src/event/usb/serial.rs
+++ b/crates/scheduler/src/event/usb/serial.rs
@@ -18,7 +18,7 @@ use wasefire_error::Error;
 
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub enum Key {
+pub(crate) enum Key {
     Read,
     Write,
 }
@@ -39,7 +39,7 @@ impl<'a> From<&'a Event> for Key {
 }
 
 impl Key {
-    pub fn disable<B: Board>(self) -> Result<(), Error> {
+    pub(crate) fn disable<B: Board>(self) -> Result<(), Error> {
         use wasefire_board_api::usb::serial::Api as _;
         let event = match self {
             Key::Read => Event::Read,
@@ -49,4 +49,4 @@ impl Key {
     }
 }
 
-pub fn process() {}
+pub(crate) fn process() {}

--- a/crates/scheduler/src/event/vendor.rs
+++ b/crates/scheduler/src/event/vendor.rs
@@ -24,7 +24,7 @@ use crate::applet::store::StoreApi as _;
 
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive_where(Debug, Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Key<B: Board> {
+pub(crate) struct Key<B: Board> {
     pub key: board::vendor::Key<B>,
 }
 
@@ -41,12 +41,12 @@ impl<'a, B: Board> From<&'a Event<B>> for Key<B> {
 }
 
 impl<B: Board> Key<B> {
-    pub fn disable(self) -> Result<(), Error> {
+    pub(crate) fn disable(self) -> Result<(), Error> {
         board::Vendor::<B>::disable(self.key)
     }
 }
 
-pub fn process<B: Board>(event: Event<B>, params: &mut Vec<u32>, applet: &mut Applet<B>) {
+pub(crate) fn process<B: Board>(event: Event<B>, params: &mut Vec<u32>, applet: &mut Applet<B>) {
     let memory = applet.store.memory();
     let handlers = applet.events.handlers(None);
     board::Vendor::<B>::callback(memory, handlers, event.0, params)

--- a/crates/scheduler/src/perf.rs
+++ b/crates/scheduler/src/perf.rs
@@ -19,7 +19,7 @@ use wasefire_applet_api::debug as api;
 use wasefire_board_api::debug::Api as _;
 use wasefire_board_api::{self as board, Api as Board};
 
-pub struct Perf<B: Board> {
+pub(crate) struct Perf<B: Board> {
     start: u64,
     value: api::Perf,
     board: PhantomData<B>,
@@ -32,7 +32,7 @@ impl<B: Board> Default for Perf<B> {
 }
 
 impl<B: Board> Perf<B> {
-    pub fn record(&mut self, slot: Slot) {
+    pub(crate) fn record(&mut self, slot: Slot) {
         let end = board::Debug::<B>::time();
         let start = core::mem::replace(&mut self.start, end);
         let value = match slot {
@@ -44,13 +44,13 @@ impl<B: Board> Perf<B> {
             if end < start { board::Debug::<B>::MAX_TIME - start + end + 1 } else { end - start };
     }
 
-    pub fn read(&mut self) -> api::Perf {
+    pub(crate) fn read(&mut self) -> api::Perf {
         self.value
     }
 }
 
 #[derive(Debug)]
-pub enum Slot {
+pub(crate) enum Slot {
     Platform,
     Applets,
     Waiting,

--- a/crates/scheduler/src/protocol.rs
+++ b/crates/scheduler/src/protocol.rs
@@ -32,19 +32,19 @@ use wasefire_protocol::{self as service, Api, ApiResult, Request, Service, VERSI
 use crate::Scheduler;
 
 #[derive(Debug, Default)]
-pub struct State(StateImpl);
+pub(crate) struct State(StateImpl);
 
-pub fn enable<B: Board>() {
+pub(crate) fn enable<B: Board>() {
     if let Err(error) = board::platform::Protocol::<B>::enable() {
         log::warn!("Failed to enable platform protocol: {}", error);
     }
 }
 
-pub fn should_process_event<B: Board>(event: &board::Event<B>) -> bool {
+pub(crate) fn should_process_event<B: Board>(event: &board::Event<B>) -> bool {
     *event == board::Event::from(board::platform::protocol::Event)
 }
 
-pub fn process_event<B: Board>(scheduler: &mut Scheduler<B>, event: board::Event<B>) {
+pub(crate) fn process_event<B: Board>(scheduler: &mut Scheduler<B>, event: board::Event<B>) {
     let request = match board::platform::Protocol::<B>::read() {
         Ok(Some(x)) => x,
         Ok(None) => return log::warn!("Expected platform protocol request, but found none."),
@@ -181,7 +181,7 @@ fn process_event_<B: Board>(
 }
 
 #[cfg(feature = "applet-api-platform-protocol")]
-pub fn put_response<B: Board>(
+pub(crate) fn put_response<B: Board>(
     call: &mut crate::SchedulerCall<B, applet_api::write::Sig>, response: Box<[u8]>,
 ) -> Result<(), Error> {
     match call.applet().put_response(response) {

--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -37,7 +37,7 @@ for dir in $(find crates examples/rust -name Cargo.toml -printf '%h\n' | sort); 
   esac
   # TODO: Enable for all crates.
   case $crate in
-    runner-*|scheduler|xtask|*/fuzz) ;;
+    runner-*|xtask|*/fuzz) ;;
     examples/rust/exercises/part-*) ;;
     *) add_lint $file warn rust.unreachable_pub ;;
   esac


### PR DESCRIPTION
## What

Enables the `rust.unreachable_pub` lint for the `wasefire-scheduler` crate:

- Removes `scheduler` from the `unreachable_pub` exclusion list in `scripts/sync.sh`.
- Adds `rust.unreachable_pub = "warn"` to `crates/scheduler/Cargo.toml` (matching the ordering `sync.sh` generates).
- Restricts crate-internal items to `pub(crate)` across the `call`, `event`, `applet`, `perf`, and `protocol` modules. The crate's public API (`lib.rs`) is unchanged.
- Adds a CHANGELOG entry.

## Why

Continues the incremental work of #565 ("Fix all lints currently disabled in scripts/sync.sh"), following #1139 which enabled the same lint for the interpreter.

## Verification

Ran the full feature/target matrix from `crates/scheduler/test.sh` on host:

- `cargo check --lib` for: host `wasm,std,log`; `i686-unknown-linux-gnu` `native,std(,log)`; `thumbv7em-none-eabi` `wasm`/`pulley`/`native`, each with and without `defmt` — **all report zero `unreachable_pub` warnings**.
- `cargo test --lib --features=_test,full-api,wasm,std` passes.
- `cargo clippy` and `cargo fmt --check` pass.

Note: the full Linux CI suite (`scripts/ci.sh`) was not run locally.